### PR TITLE
only shows duplicated in compartment warning when there is in fact a problem

### DIFF
--- a/src/MoBi.Engine/Sbml/MoleculeInformation.cs
+++ b/src/MoBi.Engine/Sbml/MoleculeInformation.cs
@@ -21,7 +21,7 @@ namespace MoBi.Engine.Sbml
         /// </summary>
         public bool IsMultipleTimesInOneCompartment()
         {
-            return _container.Any(container=> _container.Any(con => container != con && container.Name == con.Name));
+            return _container.Any(target => _container.Any(duplicate => target != duplicate && target.Name == duplicate.Name));
         }
 
         public MoleculeInformation(Species species)

--- a/src/MoBi.Engine/Sbml/MoleculeInformation.cs
+++ b/src/MoBi.Engine/Sbml/MoleculeInformation.cs
@@ -21,7 +21,7 @@ namespace MoBi.Engine.Sbml
         /// </summary>
         public bool IsMultipleTimesInOneCompartment()
         {
-            return _container.Select(container => container.Name).Any(name => _container.Any(con => name == con.Name));
+            return _container.Any(container=> _container.Any(con => container != con && container.Name == con.Name));
         }
 
         public MoleculeInformation(Species species)

--- a/tests/MoBi.Tests/Core/SBML/MoleculeInformationSpecs.cs
+++ b/tests/MoBi.Tests/Core/SBML/MoleculeInformationSpecs.cs
@@ -57,5 +57,11 @@ namespace MoBi.Core.SBML
          molinfo.GetAllSpecies().ShouldNotBeNull();
          molinfo.GetAllSpecies().Count.ShouldBeEqualTo(2);
       }
+
+      [Observation]
+      public void IsMultipleTimesInOneCompartmentTest()
+      {
+         _moleculeInformation.Any(info => info.IsMultipleTimesInOneCompartment()).ShouldBeFalse();
+      }
    }
 }


### PR DESCRIPTION
Fixes #610 (only shows duplicated in compartment warning when there is in fact a problem)