### PR TITLE
Fixes #816 View and Presenter for the Module Explorer

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -14,7 +14,7 @@ namespace MoBi.Assets
 {
    public static class AppConstants
    {
-      public static readonly int LayoutVersion = 24;
+      public static readonly int LayoutVersion = 25;
       public static readonly string NotMatch = "not tagged with";
       public static readonly string Match = "tagged with";
       public static readonly string MatchAll = "in all containers";
@@ -88,6 +88,7 @@ namespace MoBi.Assets
       public static class DefaultNames
       {
          public static readonly string MoleculeBuildingBlock = "Molecules";
+         public static readonly string Module1 = "Module1";
          public static readonly string ReactionBuildingBlock = "Reaction";
          public static readonly string SpatialStructure = "Organism";
          public static readonly string PassiveTransportBuildingBlock = "Passive Transports";
@@ -997,6 +998,7 @@ namespace MoBi.Assets
          public static readonly string ExportHistory = Captions.ExportHistory;
          public static readonly string StartPopulationSimulation = "Send Simulation to PK-Sim for Population Simulation...";
          public static readonly string BuildingBlockExplorer = "Building Blocks";
+         public static readonly string ModuleExplorer = "Modules";
          public static readonly string SimulationExplorer = "Simulations";
          public static readonly string New = "New";
          public static readonly string NewMolecule = AddNew(ObjectTypes.Molecule);

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -88,7 +88,7 @@ namespace MoBi.Assets
       public static class DefaultNames
       {
          public static readonly string MoleculeBuildingBlock = "Molecules";
-         public static readonly string Module1 = "Module1";
+         public static readonly string Module = "Module";
          public static readonly string ReactionBuildingBlock = "Reaction";
          public static readonly string SpatialStructure = "Organism";
          public static readonly string PassiveTransportBuildingBlock = "Passive Transports";

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.102" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.103" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/ToolTips.cs
+++ b/src/MoBi.Assets/ToolTips.cs
@@ -122,7 +122,7 @@ namespace MoBi.Assets
 
       public static class ViewRibbon
       {
-         public static readonly string ViewBBs = "Show or hide the building blocks explorer";
+         public static readonly string ViewModules = "Show or hide the module explorer";
          public static readonly string ViewSims = "Show or hide the simulations explorer";
          public static readonly string ViewsHistoryManager = "Show or hide the history";
          public static readonly string ViewSearch = "Show or hide the search window";

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.103" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />

--- a/src/MoBi.Core/Domain/Model/MoBiProject.cs
+++ b/src/MoBi.Core/Domain/Model/MoBiProject.cs
@@ -24,6 +24,7 @@ namespace MoBi.Core.Domain.Model
       IReadOnlyList<ExpressionProfileBuildingBlock> ExpressionProfileCollection { get; }
       IReadOnlyList<IndividualBuildingBlock> IndividualsCollection { get; }
       IReadOnlyList<ISimulationSettings> SimulationSettingsCollection { get; }
+      IReadOnlyList<Module> Modules { get; }
 
       ReactionDimensionMode ReactionDimensionMode { get; set; }
 
@@ -31,6 +32,7 @@ namespace MoBi.Core.Domain.Model
       void RemoveSimulation(IMoBiSimulation simulationToRemove);
       void AddChart(CurveChart chart);
       void RemoveChart(CurveChart chartToRemove);
+      void AddModule(Module module);
 
       //only for serialization
       IReadOnlyList<IBuildingBlock> AllBuildingBlocks();
@@ -80,6 +82,9 @@ namespace MoBi.Core.Domain.Model
       private readonly List<IBuildingBlock> _buildingBlocks;
       private readonly List<CurveChart> _charts;
       private readonly List<IMoBiSimulation> _allSimulations;
+      private readonly List<Module> _modules = new List<Module>();
+
+      public IReadOnlyList<Module> Modules => _modules;
 
       public string ChartSettings { get; set; }
 
@@ -111,6 +116,11 @@ namespace MoBi.Core.Domain.Model
       public IEnumerable<CurveChart> Charts => _charts;
 
       public bool IsEmpty => !_buildingBlocks.Any() && !_allSimulations.Any();
+
+      public void AddModule(Module module)
+      {
+         _modules.Add(module);
+      }
 
       public IReadOnlyList<IMoBiSimulation> Simulations => _allSimulations;
 

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -32,13 +32,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.103" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.103" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MenusAndBars/MenuBarItemIds.cs
+++ b/src/MoBi.Presentation/MenusAndBars/MenuBarItemIds.cs
@@ -16,7 +16,7 @@ namespace MoBi.Presentation.MenusAndBars
       public static MenuBarItemId CloseProject = createMenuBarItemId("CloseProject");
       public static MenuBarItemId About = createMenuBarItemId("About");
       public static MenuBarItemId HistoryView = createMenuBarItemId("HistoryView");
-      public static MenuBarItemId BuildingBlockExplorerView = createMenuBarItemId("BuildingBlockExplorerView");
+      public static MenuBarItemId ModuleExplorerView = createMenuBarItemId("ModuleExplorerView");
       public static MenuBarItemId Options = createMenuBarItemId("Options");
       public static MenuBarItemId GarbageCollection = createMenuBarItemId("GarbageCollection");
       public static MenuBarItemId Exit = createMenuBarItemId("Exit");

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.102" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.103" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/PresentationRegister.cs
+++ b/src/MoBi.Presentation/PresentationRegister.cs
@@ -161,8 +161,9 @@ namespace MoBi.Presentation
       {
          if (_registerMainViewPresenter)
             container.Register<IMainViewPresenter, IChangePropagator, MoBiMainViewPresenter>(LifeStyle.Singleton);
-
+         
          container.Register<IBuildingBlockExplorerPresenter, IMainViewItemPresenter, BuildingBlockExplorerPresenter>(LifeStyle.Singleton);
+         container.Register<IModuleExplorerPresenter, IMainViewItemPresenter, ModuleExplorerPresenter>(LifeStyle.Singleton);
          container.Register<IHistoryPresenter, IMainViewItemPresenter, HistoryPresenter>(LifeStyle.Singleton);
          container.Register<IJournalDiagramMainPresenter, IMainViewItemPresenter, JournalDiagramMainPresenter>(LifeStyle.Singleton);
          container.Register<IJournalPresenter, IMainViewItemPresenter, JournalPresenter>(LifeStyle.Singleton);

--- a/src/MoBi.Presentation/Presenter/Main/MenuAndToolBarPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/MenuAndToolBarPresenter.cs
@@ -173,7 +173,7 @@ namespace MoBi.Presentation.Presenter.Main
          _menuBarItemRepository[MenuBarItemIds.NotificationView].Enabled = true;
          _menuBarItemRepository[MenuBarItemIds.ComparisonView].Enabled = true;
          _menuBarItemRepository[MenuBarItemIds.OpenSimulation].Enabled = true;
-         _menuBarItemRepository[MenuBarItemIds.BuildingBlockExplorerView].Enabled = true;
+         _menuBarItemRepository[MenuBarItemIds.ModuleExplorerView].Enabled = true;
          _menuBarItemRepository[MenuBarItemIds.SimulationExplorerView].Enabled = true;
          _menuBarItemRepository[MenuBarItemIds.GarbageCollection].Enabled = true;
          _menuBarItemRepository[MenuBarItemIds.Exit].Enabled = true;

--- a/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Nodes;
+using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.Nodes;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Presenters.Classifications;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Presentation.Presenters.Nodes;
+using OSPSuite.Presentation.Presenters.ObservedData;
+using OSPSuite.Presentation.Regions;
+using OSPSuite.Presentation.Services;
+using OSPSuite.Presentation.Views;
+using OSPSuite.Utility.Extensions;
+using ITreeNodeFactory = MoBi.Presentation.Nodes.ITreeNodeFactory;
+
+namespace MoBi.Presentation.Presenter.Main
+{
+   public interface IModuleExplorerPresenter : IExplorerPresenter, IPresenter<IModuleExplorerView>
+   {
+      bool ShouldSort(ITreeNode node);
+   }
+
+   public class ModuleExplorerPresenter : ExplorerPresenter<IModuleExplorerView, IModuleExplorerPresenter>, IModuleExplorerPresenter
+   {
+      private readonly IObservedDataInExplorerPresenter _observedDataInExplorerPresenter;
+      private readonly IEditBuildingBlockStarter _editBuildingBlockStarter;
+
+      public ModuleExplorerPresenter(IModuleExplorerView view, IRegionResolver regionResolver, ITreeNodeFactory treeNodeFactory,
+         IViewItemContextMenuFactory viewItemContextMenuFactory, IMoBiContext context, IClassificationPresenter classificationPresenter,
+         IToolTipPartCreator toolTipPartCreator, IObservedDataInExplorerPresenter observedDataInExplorerPresenter,
+         IMultipleTreeNodeContextMenuFactory multipleTreeNodeContextMenuFactory, IProjectRetriever projectRetriever, IEditBuildingBlockStarter editBuildingBlockStarter) :
+         base(view, regionResolver, treeNodeFactory, viewItemContextMenuFactory, context, RegionNames.ModuleExplorer,
+            classificationPresenter, toolTipPartCreator, multipleTreeNodeContextMenuFactory, projectRetriever)
+      {
+         _observedDataInExplorerPresenter = observedDataInExplorerPresenter;
+         _observedDataInExplorerPresenter.InitializeWith(this, classificationPresenter, RootNodeTypes.ObservedDataFolder);
+         _editBuildingBlockStarter = editBuildingBlockStarter;
+      }
+
+      protected override IContextMenu ContextMenuFor(ITreeNode treeNode)
+      {
+         if (treeNode.TagAsObject is IBuildingBlock buildingBlock)
+            return ContextMenuFor(new BuildingBlockViewItem(buildingBlock));
+
+         if (treeNode.TagAsObject is ClassifiableObservedData observedData)
+            return ContextMenuFor(new ObservedDataViewItem(observedData.Repository));
+
+         return base.ContextMenuFor(treeNode);
+      }
+
+      public override void NodeDoubleClicked(ITreeNode node)
+      {
+         var moleculeBuilder = node.TagAsObject as IMoleculeBuilder;
+         if (moleculeBuilder == null)
+         {
+            base.NodeDoubleClicked(node);
+            return;
+         }
+
+         var moleculeBuildingBlock = node.ParentNode.TagAsObject.DowncastTo<IMoleculeBuildingBlock>();
+         _editBuildingBlockStarter.EditMolecule(moleculeBuildingBlock, moleculeBuilder);
+      }
+
+      public bool ShouldSort(ITreeNode node)
+      {
+         if (node.ParentNode == null)
+            return false;
+
+         // Do not sort if this is content of a module.
+         // Child nodes are created in the same order as the older Building Block Explorer
+         return !node.ParentNode.TagAsObject.IsAnImplementationOf<Module>();
+      }
+
+      public override bool CanDrag(ITreeNode node)
+      {
+         if (node == null)
+            return false;
+
+         if (node.IsAnImplementationOf<ClassificationNode>())
+            return true;
+
+         return _observedDataInExplorerPresenter.CanDrag(node);
+      }
+
+      public override IEnumerable<ClassificationTemplate> AvailableClassificationCategories(ITreeNode<IClassification> parentClassificationNode)
+      {
+         return _observedDataInExplorerPresenter.AvailableObservedDataCategoriesIn(parentClassificationNode);
+      }
+
+      public override void AddToClassificationTree(ITreeNode<IClassification> parentNode, string category)
+      {
+         _observedDataInExplorerPresenter.GroupObservedDataByCategory(parentNode, category);
+      }
+
+      public override bool RemoveDataUnderClassification(ITreeNode<IClassification> classificationNode)
+      {
+         return _observedDataInExplorerPresenter.RemoveObservedDataUnder(classificationNode);
+      }
+
+      private void addBuildingBlockToTree<TBuildingBlock>(TBuildingBlock buildingBlock, RootNodeType buildingBlockFolderType) where TBuildingBlock : IBuildingBlock
+      {
+         var buildingBockFolderNode = _view.NodeByType(buildingBlockFolderType);
+
+         addBuildingBlockUnderNode(buildingBlock, buildingBockFolderNode);
+      }
+
+      private void addBuildingBlockUnderNode<TBuildingBlock>(TBuildingBlock buildingBlock, ITreeNode folderNode) where TBuildingBlock : IBuildingBlock
+      {
+         if (buildingBlock == null)
+            return;
+
+         _view.AddNode(_treeNodeFactory.CreateFor(buildingBlock)
+            .Under(folderNode));
+      }
+
+      protected override void AddProjectToTree(IMoBiProject project)
+      {
+         using (new BatchUpdate(_view))
+         {
+            _view.DestroyNodes();
+
+            project.Modules.Each(addModule);
+
+            _view.AddNode(_treeNodeFactory.CreateFor(MoBiRootNodeTypes.ExpressionProfilesFolder));
+            _view.AddNode(_treeNodeFactory.CreateFor(MoBiRootNodeTypes.IndividualsFolder));
+            _view.AddNode(_treeNodeFactory.CreateFor(RootNodeTypes.ObservedDataFolder));
+
+            project.ExpressionProfileCollection.Each(bb => addBuildingBlockToTree(bb, MoBiRootNodeTypes.ExpressionProfilesFolder));
+            project.IndividualsCollection.Each(bb => addBuildingBlockToTree(bb, MoBiRootNodeTypes.IndividualsFolder));
+
+            _observedDataInExplorerPresenter.AddObservedDataToTree(project);
+         }
+      }
+
+      private void addModule(Module module)
+      {
+         var moduleNode = _view.AddNode(_treeNodeFactory.CreateFor(module).WithIcon(ApplicationIcons.Folder));
+
+         addBuildingBlockUnderNode(module.SpatialStructure, moduleNode);
+         addBuildingBlockUnderNode(module.Molecule, moduleNode);
+         addBuildingBlockUnderNode(module.Reaction, moduleNode);
+         addBuildingBlockUnderNode(module.PassiveTransport, moduleNode);
+         addBuildingBlockUnderNode(module.Observer, moduleNode);
+         addBuildingBlockUnderNode(module.EventGroup, moduleNode);
+
+         var moleculeStartValuesCollectionNode = collectionNodeFor(module.MoleculeStartValuesCollection, MoBiRootNodeTypes.MoleculeStartValuesFolder, moduleNode);
+         var parameterStartValuesCollectionNode = collectionNodeFor(module.ParameterStartValuesCollection, MoBiRootNodeTypes.ParameterStartValuesFolder, moduleNode);
+
+         module.MoleculeStartValuesCollection.Each(bb => addBuildingBlockUnderNode(bb, moleculeStartValuesCollectionNode));
+         module.ParameterStartValuesCollection.Each(bb => addBuildingBlockUnderNode(bb, parameterStartValuesCollectionNode));
+      }
+
+      private ITreeNode collectionNodeFor<T>(IReadOnlyList<IStartValuesBuildingBlock<T>> startValueBlockCollection, RootNodeType rootNodeType, ITreeNode moduleNode) where T : class, IStartValue
+      {
+         return startValueBlockCollection.Count > 1 ? _view.AddNode(_treeNodeFactory.CreateFor(rootNodeType).Under(moduleNode)) : moduleNode;
+      }
+   }
+
+   public interface IModuleExplorerView : IExplorerView, IView<IModuleExplorerPresenter>
+   {
+   }
+}

--- a/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using MoBi.Core.Domain.Model;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Nodes;
+using MoBi.Presentation.Views;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
@@ -160,9 +161,5 @@ namespace MoBi.Presentation.Presenter.Main
       {
          return startValueBlockCollection.Count > 1 ? _view.AddNode(_treeNodeFactory.CreateFor(rootNodeType).Under(moduleNode)) : moduleNode;
       }
-   }
-
-   public interface IModuleExplorerView : IExplorerView, IView<IModuleExplorerPresenter>
-   {
    }
 }

--- a/src/MoBi.Presentation/RegionNames.cs
+++ b/src/MoBi.Presentation/RegionNames.cs
@@ -11,6 +11,7 @@ namespace MoBi.Presentation
       private static readonly IList<RegionName> _allRegions = new List<RegionName>();
 
       public static RegionName BuildingBlockExplorer = createRegionName("BuildingBlockExplorer", AppConstants.MenuNames.BuildingBlockExplorer, ApplicationIcons.BuildingBlockExplorer);
+      public static RegionName ModuleExplorer = createRegionName("ModuleExplorer", AppConstants.MenuNames.ModuleExplorer, ApplicationIcons.ModuleExplorer);
       public static RegionName SimulationExplorer = createRegionName("ProjectExplorer", AppConstants.MenuNames.SimulationExplorer, ApplicationIcons.SimulationExplorer);
       public static RegionName History = createRegionName("History", AppConstants.BarNames.History, ApplicationIcons.History);
       public static RegionName Search = createRegionName("Search", AppConstants.Captions.Search, ApplicationIcons.Search);

--- a/src/MoBi.Presentation/Repositories/ButtonGroupRepository.cs
+++ b/src/MoBi.Presentation/Repositories/ButtonGroupRepository.cs
@@ -189,7 +189,7 @@ namespace MoBi.Presentation.Repositories
          .WithId(ButtonGroupIds.Tools);
 
       private IButtonGroup viewButtonGroup => CreateButtonGroup.WithCaption(AppConstants.BarNames.Views)
-         .WithButton(CreateRibbonButton.From(_menuBarItemRepository.Find(MenuBarItemIds.BuildingBlockExplorerView)))
+         .WithButton(CreateRibbonButton.From(_menuBarItemRepository.Find(MenuBarItemIds.ModuleExplorerView)))
          .WithButton(CreateRibbonButton.From(_menuBarItemRepository.Find(MenuBarItemIds.SimulationExplorerView)))
          .WithButton(CreateRibbonButton.From(_menuBarItemRepository.Find(MenuBarItemIds.HistoryView)))
          .WithButton(CreateRibbonButton.From(_menuBarItemRepository.Find(MenuBarItemIds.ComparisonView)))

--- a/src/MoBi.Presentation/Repositories/MenuBarItemRepository.cs
+++ b/src/MoBi.Presentation/Repositories/MenuBarItemRepository.cs
@@ -188,12 +188,12 @@ namespace MoBi.Presentation.Repositories
            .WithIcon(ApplicationIcons.PKMLLoad)
            .WithCommand<LoadDataRepositoryUICommand>();
 
-         yield return CreateMenuButton.WithCaption(AppConstants.MenuNames.BuildingBlockExplorer)
-            .WithId(MenuBarItemIds.BuildingBlockExplorerView)
-            .WithIcon(ApplicationIcons.BuildingBlockExplorer)
-            .WithDescription(ToolTips.ViewRibbon.ViewBBs)
-            .WithCommand<ShowBuildingBlockExplorerCommand>()
-            .WithShortcut(Keys.Control | Keys.Shift | Keys.B);
+         yield return CreateMenuButton.WithCaption(AppConstants.MenuNames.ModuleExplorer)
+            .WithId(MenuBarItemIds.ModuleExplorerView)
+            .WithIcon(ApplicationIcons.ModuleExplorer)
+            .WithDescription(ToolTips.ViewRibbon.ViewModules)
+            .WithCommand<ShowModuleExplorerCommand>()
+            .WithShortcut(Keys.Control | Keys.Shift | Keys.M);
 
          yield return CreateMenuButton.WithCaption(AppConstants.MenuNames.SimulationExplorer)
             .WithId(MenuBarItemIds.SimulationExplorerView)

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -291,7 +291,7 @@ namespace MoBi.Presentation.Tasks
          module.PassiveTransport = addDefault<IPassiveTransportBuildingBlock>(AppConstants.DefaultNames.PassiveTransportBuildingBlock);
          module.EventGroup = addDefault<IEventGroupBuildingBlock>(AppConstants.DefaultNames.EventBuildingBlock);
          module.Observer = addDefault<IObserverBuildingBlock>(AppConstants.DefaultNames.ObserverBuildingBlock);
-         module.WithName(AppConstants.DefaultNames.Module1).WithIcon(ApplicationIcons.Folder.IconName);
+         module.WithName(AppConstants.DefaultNames.Module).WithIcon(ApplicationIcons.Folder.IconName);
 
          addModule(module);
 

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -5,6 +5,7 @@ using MoBi.Core.Domain.Builder;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Exceptions;
 using MoBi.Core.Services;
+using OSPSuite.Assets;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
@@ -275,33 +276,47 @@ namespace MoBi.Presentation.Tasks
             return false;
 
          _mruProvider.Add(fileName);
-
+         
          notifyProjectLoaded();
+
          return true;
       }
 
       private void generateDefaultsInCurrentProject()
       {
-         addDefault<IMoleculeBuildingBlock>(AppConstants.DefaultNames.MoleculeBuildingBlock);
-         addDefault(AppConstants.DefaultNames.ReactionBuildingBlock, () => _reactionBuildingBlockFactory.Create());
-         addDefault(AppConstants.DefaultNames.SpatialStructure, () => _spatialStructureFactory.CreateDefault(AppConstants.DefaultNames.SpatialStructure));
-         addDefault<IPassiveTransportBuildingBlock>(AppConstants.DefaultNames.PassiveTransportBuildingBlock);
-         addDefault<IEventGroupBuildingBlock>(AppConstants.DefaultNames.EventBuildingBlock);
-         addDefault<IObserverBuildingBlock>(AppConstants.DefaultNames.ObserverBuildingBlock);
+         var module = _context.Create<Module>();
+         module.Molecule = addDefault<IMoleculeBuildingBlock>(AppConstants.DefaultNames.MoleculeBuildingBlock);
+         module.Reaction = addDefault(AppConstants.DefaultNames.ReactionBuildingBlock, () => _reactionBuildingBlockFactory.Create());
+         module.SpatialStructure = addDefault(AppConstants.DefaultNames.SpatialStructure, () => _spatialStructureFactory.CreateDefault(AppConstants.DefaultNames.SpatialStructure));
+         module.PassiveTransport = addDefault<IPassiveTransportBuildingBlock>(AppConstants.DefaultNames.PassiveTransportBuildingBlock);
+         module.EventGroup = addDefault<IEventGroupBuildingBlock>(AppConstants.DefaultNames.EventBuildingBlock);
+         module.Observer = addDefault<IObserverBuildingBlock>(AppConstants.DefaultNames.ObserverBuildingBlock);
+         module.WithName(AppConstants.DefaultNames.Module1).WithIcon(ApplicationIcons.Folder.IconName);
+
+         addModule(module);
+
          addDefault(AppConstants.DefaultNames.SimulationSettings, _simulationSettingsFactory.CreateDefault);
       }
 
-      private void addDefault<T>(string defaultName) where T : class, IBuildingBlock
+      private void addModule(Module module)
       {
-         addDefault(defaultName, _context.Create<T>);
+         var project = _context.CurrentProject;
+         project.AddModule(module);
+         _context.Register(module);
       }
 
-      private void addDefault<T>(string defaultName, Func<T> buildingBlockCreator) where T : IBuildingBlock
+      private T addDefault<T>(string defaultName) where T : class, IBuildingBlock
+      {
+         return addDefault(defaultName, _context.Create<T>);
+      }
+
+      private T addDefault<T>(string defaultName, Func<T> buildingBlockCreator) where T : IBuildingBlock
       {
          var project = _context.CurrentProject;
          var buildingBlock = buildingBlockCreator().WithName(defaultName);
          project.AddBuildingBlock(buildingBlock);
          _context.Register(buildingBlock);
+         return buildingBlock;
       }
    }
 }

--- a/src/MoBi.Presentation/UICommand/ShowModuleExplorerCommand.cs
+++ b/src/MoBi.Presentation/UICommand/ShowModuleExplorerCommand.cs
@@ -3,17 +3,20 @@ using MoBi.Presentation.Presenter.Main;
 
 namespace MoBi.Presentation.UICommand
 {
-    internal class ShowBuildingBlockExplorerCommand : IUICommand
+    internal class ShowModuleExplorerCommand : IUICommand
    {
       private readonly IBuildingBlockExplorerPresenter _buildingBlockExplorerPresenter;
+      private readonly IModuleExplorerPresenter _moduleExplorerPresenter;
 
-      public ShowBuildingBlockExplorerCommand(IBuildingBlockExplorerPresenter buildingBlockExplorerPresenter)
+      public ShowModuleExplorerCommand(IBuildingBlockExplorerPresenter buildingBlockExplorerPresenter, IModuleExplorerPresenter moduleExplorerPresenter)
       {
          _buildingBlockExplorerPresenter = buildingBlockExplorerPresenter;
+         _moduleExplorerPresenter = moduleExplorerPresenter;
       }
 
       public void Execute()
       {
+         _moduleExplorerPresenter.ToggleVisibility();
          _buildingBlockExplorerPresenter.ToggleVisibility();
       }
    }

--- a/src/MoBi.Presentation/Views/IModuleExplorerView.cs
+++ b/src/MoBi.Presentation/Views/IModuleExplorerView.cs
@@ -1,0 +1,9 @@
+﻿using MoBi.Presentation.Presenter.Main;
+using OSPSuite.Presentation.Views;
+
+namespace MoBi.Presentation.Views
+{
+   public interface IModuleExplorerView : IExplorerView, IView<IModuleExplorerPresenter>
+   {
+   }
+}

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.103" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">
@@ -56,6 +56,9 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Views\ModuleExplorerView.cs">
+      <SubType>UserControl</SubType>
     </Compile>
   </ItemGroup>
 

--- a/src/MoBi.UI/Views/MoBiMainView.Designer.cs
+++ b/src/MoBi.UI/Views/MoBiMainView.Designer.cs
@@ -18,7 +18,7 @@ namespace MoBi.UI.Views
       {
          if (disposing && (components != null))
          {
-               components.Dispose();
+            components.Dispose();
          }
          base.Dispose(disposing);
       }
@@ -35,13 +35,15 @@ namespace MoBi.UI.Views
          System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MoBiMainView));
          this.dockManager = new DevExpress.XtraBars.Docking.DockManager(this.components);
          this.panelContainer3 = new DevExpress.XtraBars.Docking.DockPanel();
-         this._panelJournal = new OSPSuite.UI.Controls.UxDockPanel();
-         this.controlContainer7 = new DevExpress.XtraBars.Docking.ControlContainer();
          this._panelSearch = new OSPSuite.UI.Controls.UxDockPanel();
          this.controlContainer3 = new DevExpress.XtraBars.Docking.ControlContainer();
+         this._panelJournal = new OSPSuite.UI.Controls.UxDockPanel();
+         this.controlContainer7 = new DevExpress.XtraBars.Docking.ControlContainer();
          this.panelContainer1 = new DevExpress.XtraBars.Docking.DockPanel();
          this._panelBuildingBlockExplorer = new OSPSuite.UI.Controls.UxDockPanel();
          this.dockPanel1_Container = new DevExpress.XtraBars.Docking.ControlContainer();
+         this._panelModuleExplorer = new OSPSuite.UI.Controls.UxDockPanel();
+         this.controlContainer8 = new DevExpress.XtraBars.Docking.ControlContainer();
          this._panelSimulationExplorer = new OSPSuite.UI.Controls.UxDockPanel();
          this.controlContainer1 = new DevExpress.XtraBars.Docking.ControlContainer();
          this.panelContainer2 = new DevExpress.XtraBars.Docking.DockPanel();
@@ -63,10 +65,11 @@ namespace MoBi.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.xtraTabbedMdiManager)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.dockManager)).BeginInit();
          this.panelContainer3.SuspendLayout();
-         this._panelJournal.SuspendLayout();
          this._panelSearch.SuspendLayout();
+         this._panelJournal.SuspendLayout();
          this.panelContainer1.SuspendLayout();
          this._panelBuildingBlockExplorer.SuspendLayout();
+         this._panelModuleExplorer.SuspendLayout();
          this._panelSimulationExplorer.SuspendLayout();
          this.panelContainer2.SuspendLayout();
          this._panelJournalDiagram.SuspendLayout();
@@ -96,46 +99,27 @@ namespace MoBi.UI.Views
          // 
          // panelContainer3
          // 
-         this.panelContainer3.ActiveChild = this._panelJournal;
+         this.panelContainer3.ActiveChild = this._panelSearch;
          this.panelContainer3.Controls.Add(this._panelJournal);
          this.panelContainer3.Controls.Add(this._panelSearch);
          this.panelContainer3.Dock = DevExpress.XtraBars.Docking.DockingStyle.Right;
          this.panelContainer3.ID = new System.Guid("bc71e420-92ce-49f2-82a9-a99eea92af7f");
-         this.panelContainer3.Location = new System.Drawing.Point(955, 49);
+         this.panelContainer3.Location = new System.Drawing.Point(955, 58);
          this.panelContainer3.Name = "panelContainer3";
          this.panelContainer3.OriginalSize = new System.Drawing.Size(272, 200);
-         this.panelContainer3.Size = new System.Drawing.Size(272, 753);
+         this.panelContainer3.Size = new System.Drawing.Size(272, 751);
          this.panelContainer3.Tabbed = true;
          this.panelContainer3.Text = "panelContainer3";
-         // 
-         // _panelJournal
-         // 
-         this._panelJournal.Controls.Add(this.controlContainer7);
-         this._panelJournal.Dock = DevExpress.XtraBars.Docking.DockingStyle.Fill;
-         this._panelJournal.ID = new System.Guid("ddba7258-95af-4806-86de-7b6330f476ac");
-         this._panelJournal.Location = new System.Drawing.Point(4, 23);
-         this._panelJournal.Name = "_panelJournal";
-         this._panelJournal.OriginalSize = new System.Drawing.Size(200, 200);
-         this._panelJournal.Size = new System.Drawing.Size(264, 699);
-         this._panelJournal.Text = "_panelJournal";
-         // 
-         // controlContainer7
-         // 
-         this.defaultToolTipController.SetAllowHtmlText(this.controlContainer7, DevExpress.Utils.DefaultBoolean.Default);
-         this.controlContainer7.Location = new System.Drawing.Point(0, 0);
-         this.controlContainer7.Name = "controlContainer7";
-         this.controlContainer7.Size = new System.Drawing.Size(264, 699);
-         this.controlContainer7.TabIndex = 0;
          // 
          // _panelSearch
          // 
          this._panelSearch.Controls.Add(this.controlContainer3);
          this._panelSearch.Dock = DevExpress.XtraBars.Docking.DockingStyle.Fill;
          this._panelSearch.ID = new System.Guid("e6d3b85b-98f4-46b5-94f7-b1e106c56515");
-         this._panelSearch.Location = new System.Drawing.Point(4, 23);
+         this._panelSearch.Location = new System.Drawing.Point(4, 26);
          this._panelSearch.Name = "_panelSearch";
-         this._panelSearch.OriginalSize = new System.Drawing.Size(200, 200);
-         this._panelSearch.Size = new System.Drawing.Size(264, 699);
+         this._panelSearch.OriginalSize = new System.Drawing.Size(264, 699);
+         this._panelSearch.Size = new System.Drawing.Size(265, 696);
          this._panelSearch.Text = "_panelSearch";
          // 
          // controlContainer3
@@ -143,21 +127,41 @@ namespace MoBi.UI.Views
          this.defaultToolTipController.SetAllowHtmlText(this.controlContainer3, DevExpress.Utils.DefaultBoolean.Default);
          this.controlContainer3.Location = new System.Drawing.Point(0, 0);
          this.controlContainer3.Name = "controlContainer3";
-         this.controlContainer3.Size = new System.Drawing.Size(264, 699);
+         this.controlContainer3.Size = new System.Drawing.Size(265, 696);
          this.controlContainer3.TabIndex = 0;
+         // 
+         // _panelJournal
+         // 
+         this._panelJournal.Controls.Add(this.controlContainer7);
+         this._panelJournal.Dock = DevExpress.XtraBars.Docking.DockingStyle.Fill;
+         this._panelJournal.ID = new System.Guid("ddba7258-95af-4806-86de-7b6330f476ac");
+         this._panelJournal.Location = new System.Drawing.Point(4, 26);
+         this._panelJournal.Name = "_panelJournal";
+         this._panelJournal.OriginalSize = new System.Drawing.Size(264, 699);
+         this._panelJournal.Size = new System.Drawing.Size(265, 696);
+         this._panelJournal.Text = "_panelJournal";
+         // 
+         // controlContainer7
+         // 
+         this.defaultToolTipController.SetAllowHtmlText(this.controlContainer7, DevExpress.Utils.DefaultBoolean.Default);
+         this.controlContainer7.Location = new System.Drawing.Point(0, 0);
+         this.controlContainer7.Name = "controlContainer7";
+         this.controlContainer7.Size = new System.Drawing.Size(265, 696);
+         this.controlContainer7.TabIndex = 0;
          // 
          // panelContainer1
          // 
          this.panelContainer1.Appearance.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(235)))), ((int)(((byte)(236)))), ((int)(((byte)(239)))));
          this.panelContainer1.Appearance.Options.UseBackColor = true;
          this.panelContainer1.Controls.Add(this._panelBuildingBlockExplorer);
+         this.panelContainer1.Controls.Add(this._panelModuleExplorer);
          this.panelContainer1.Controls.Add(this._panelSimulationExplorer);
          this.panelContainer1.Dock = DevExpress.XtraBars.Docking.DockingStyle.Left;
          this.panelContainer1.ID = new System.Guid("38102c06-df38-46bd-96b7-ca9a31525bba");
-         this.panelContainer1.Location = new System.Drawing.Point(0, 49);
+         this.panelContainer1.Location = new System.Drawing.Point(0, 58);
          this.panelContainer1.Name = "panelContainer1";
          this.panelContainer1.OriginalSize = new System.Drawing.Size(200, 200);
-         this.panelContainer1.Size = new System.Drawing.Size(200, 753);
+         this.panelContainer1.Size = new System.Drawing.Size(200, 751);
          this.panelContainer1.Text = "panelContainer1";
          // 
          // _panelBuildingBlockExplorer
@@ -169,17 +173,38 @@ namespace MoBi.UI.Views
          this._panelBuildingBlockExplorer.ID = new System.Guid("ab131c6d-2069-408e-9bba-7124cb69aac3");
          this._panelBuildingBlockExplorer.Location = new System.Drawing.Point(0, 0);
          this._panelBuildingBlockExplorer.Name = "_panelBuildingBlockExplorer";
-         this._panelBuildingBlockExplorer.OriginalSize = new System.Drawing.Size(200, 264);
-         this._panelBuildingBlockExplorer.Size = new System.Drawing.Size(200, 376);
+         this._panelBuildingBlockExplorer.OriginalSize = new System.Drawing.Size(200, 376);
+         this._panelBuildingBlockExplorer.Size = new System.Drawing.Size(200, 250);
          this._panelBuildingBlockExplorer.Text = "_panelBuildingBlockExplorer";
          // 
          // dockPanel1_Container
          // 
          this.defaultToolTipController.SetAllowHtmlText(this.dockPanel1_Container, DevExpress.Utils.DefaultBoolean.Default);
-         this.dockPanel1_Container.Location = new System.Drawing.Point(4, 23);
+         this.dockPanel1_Container.Location = new System.Drawing.Point(3, 26);
          this.dockPanel1_Container.Name = "dockPanel1_Container";
-         this.dockPanel1_Container.Size = new System.Drawing.Size(192, 349);
+         this.dockPanel1_Container.Size = new System.Drawing.Size(193, 220);
          this.dockPanel1_Container.TabIndex = 0;
+         // 
+         // _panelModuleExplorer
+         // 
+         this._panelModuleExplorer.Appearance.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(235)))), ((int)(((byte)(236)))), ((int)(((byte)(239)))));
+         this._panelModuleExplorer.Appearance.Options.UseBackColor = true;
+         this._panelModuleExplorer.Controls.Add(this.controlContainer8);
+         this._panelModuleExplorer.Dock = DevExpress.XtraBars.Docking.DockingStyle.Fill;
+         this._panelModuleExplorer.ID = new System.Guid("a18c4d16-e6c8-46db-bcf9-e4a27c56f346");
+         this._panelModuleExplorer.Location = new System.Drawing.Point(0, 250);
+         this._panelModuleExplorer.Name = "_panelModuleExplorer";
+         this._panelModuleExplorer.OriginalSize = new System.Drawing.Size(200, 200);
+         this._panelModuleExplorer.Size = new System.Drawing.Size(200, 250);
+         this._panelModuleExplorer.Text = "_panelModuleExplorer";
+         // 
+         // controlContainer8
+         // 
+         this.defaultToolTipController.SetAllowHtmlText(this.controlContainer8, DevExpress.Utils.DefaultBoolean.Default);
+         this.controlContainer8.Location = new System.Drawing.Point(3, 26);
+         this.controlContainer8.Name = "controlContainer8";
+         this.controlContainer8.Size = new System.Drawing.Size(193, 220);
+         this.controlContainer8.TabIndex = 0;
          // 
          // _panelSimulationExplorer
          // 
@@ -188,18 +213,18 @@ namespace MoBi.UI.Views
          this._panelSimulationExplorer.Controls.Add(this.controlContainer1);
          this._panelSimulationExplorer.Dock = DevExpress.XtraBars.Docking.DockingStyle.Fill;
          this._panelSimulationExplorer.ID = new System.Guid("82f18ed9-e0cb-4b39-9b61-baa05d838a8c");
-         this._panelSimulationExplorer.Location = new System.Drawing.Point(0, 376);
+         this._panelSimulationExplorer.Location = new System.Drawing.Point(0, 500);
          this._panelSimulationExplorer.Name = "_panelSimulationExplorer";
-         this._panelSimulationExplorer.OriginalSize = new System.Drawing.Size(200, 264);
-         this._panelSimulationExplorer.Size = new System.Drawing.Size(200, 377);
+         this._panelSimulationExplorer.OriginalSize = new System.Drawing.Size(200, 377);
+         this._panelSimulationExplorer.Size = new System.Drawing.Size(200, 251);
          this._panelSimulationExplorer.Text = "_panelSimulationExplorer";
          // 
          // controlContainer1
          // 
          this.defaultToolTipController.SetAllowHtmlText(this.controlContainer1, DevExpress.Utils.DefaultBoolean.Default);
-         this.controlContainer1.Location = new System.Drawing.Point(4, 23);
+         this.controlContainer1.Location = new System.Drawing.Point(3, 26);
          this.controlContainer1.Name = "controlContainer1";
-         this.controlContainer1.Size = new System.Drawing.Size(192, 350);
+         this.controlContainer1.Size = new System.Drawing.Size(193, 222);
          this.controlContainer1.TabIndex = 0;
          // 
          // panelContainer2
@@ -212,7 +237,7 @@ namespace MoBi.UI.Views
          this.panelContainer2.Dock = DevExpress.XtraBars.Docking.DockingStyle.Bottom;
          this.panelContainer2.FloatVertical = true;
          this.panelContainer2.ID = new System.Guid("6dced7fd-e36c-4393-b426-bcaf8926773c");
-         this.panelContainer2.Location = new System.Drawing.Point(200, 602);
+         this.panelContainer2.Location = new System.Drawing.Point(200, 609);
          this.panelContainer2.Name = "panelContainer2";
          this.panelContainer2.OriginalSize = new System.Drawing.Size(200, 200);
          this.panelContainer2.Size = new System.Drawing.Size(755, 200);
@@ -225,10 +250,10 @@ namespace MoBi.UI.Views
          this._panelJournalDiagram.Dock = DevExpress.XtraBars.Docking.DockingStyle.Fill;
          this._panelJournalDiagram.FloatVertical = true;
          this._panelJournalDiagram.ID = new System.Guid("d848fbb3-7f05-4dff-bf90-562918f8d25d");
-         this._panelJournalDiagram.Location = new System.Drawing.Point(4, 23);
+         this._panelJournalDiagram.Location = new System.Drawing.Point(3, 27);
          this._panelJournalDiagram.Name = "_panelJournalDiagram";
-         this._panelJournalDiagram.OriginalSize = new System.Drawing.Size(200, 200);
-         this._panelJournalDiagram.Size = new System.Drawing.Size(747, 146);
+         this._panelJournalDiagram.OriginalSize = new System.Drawing.Size(747, 146);
+         this._panelJournalDiagram.Size = new System.Drawing.Size(749, 144);
          this._panelJournalDiagram.Text = "_panelJournalDiagram";
          // 
          // controlContainer6
@@ -236,7 +261,7 @@ namespace MoBi.UI.Views
          this.defaultToolTipController.SetAllowHtmlText(this.controlContainer6, DevExpress.Utils.DefaultBoolean.Default);
          this.controlContainer6.Location = new System.Drawing.Point(0, 0);
          this.controlContainer6.Name = "controlContainer6";
-         this.controlContainer6.Size = new System.Drawing.Size(747, 146);
+         this.controlContainer6.Size = new System.Drawing.Size(749, 144);
          this.controlContainer6.TabIndex = 0;
          // 
          // _panelHistoryBrowser
@@ -247,10 +272,10 @@ namespace MoBi.UI.Views
          this._panelHistoryBrowser.Dock = DevExpress.XtraBars.Docking.DockingStyle.Fill;
          this._panelHistoryBrowser.FloatVertical = true;
          this._panelHistoryBrowser.ID = new System.Guid("7d442645-69c2-404d-aefc-4b4c044c3a48");
-         this._panelHistoryBrowser.Location = new System.Drawing.Point(4, 23);
+         this._panelHistoryBrowser.Location = new System.Drawing.Point(3, 27);
          this._panelHistoryBrowser.Name = "_panelHistoryBrowser";
-         this._panelHistoryBrowser.OriginalSize = new System.Drawing.Size(1019, 146);
-         this._panelHistoryBrowser.Size = new System.Drawing.Size(747, 146);
+         this._panelHistoryBrowser.OriginalSize = new System.Drawing.Size(747, 146);
+         this._panelHistoryBrowser.Size = new System.Drawing.Size(749, 144);
          this._panelHistoryBrowser.Text = "_panelHistoryBrowser";
          // 
          // controlContainer2
@@ -258,7 +283,7 @@ namespace MoBi.UI.Views
          this.defaultToolTipController.SetAllowHtmlText(this.controlContainer2, DevExpress.Utils.DefaultBoolean.Default);
          this.controlContainer2.Location = new System.Drawing.Point(0, 0);
          this.controlContainer2.Name = "controlContainer2";
-         this.controlContainer2.Size = new System.Drawing.Size(747, 146);
+         this.controlContainer2.Size = new System.Drawing.Size(749, 144);
          this.controlContainer2.TabIndex = 0;
          // 
          // _panelWarningList
@@ -266,10 +291,10 @@ namespace MoBi.UI.Views
          this._panelWarningList.Controls.Add(this.controlContainer4);
          this._panelWarningList.Dock = DevExpress.XtraBars.Docking.DockingStyle.Fill;
          this._panelWarningList.ID = new System.Guid("1f0ce5a0-aede-4240-b15c-7191ac1dc039");
-         this._panelWarningList.Location = new System.Drawing.Point(4, 23);
+         this._panelWarningList.Location = new System.Drawing.Point(3, 27);
          this._panelWarningList.Name = "_panelWarningList";
-         this._panelWarningList.OriginalSize = new System.Drawing.Size(1019, 146);
-         this._panelWarningList.Size = new System.Drawing.Size(747, 146);
+         this._panelWarningList.OriginalSize = new System.Drawing.Size(747, 146);
+         this._panelWarningList.Size = new System.Drawing.Size(749, 144);
          this._panelWarningList.Text = "_panelWarningList";
          // 
          // controlContainer4
@@ -277,7 +302,7 @@ namespace MoBi.UI.Views
          this.defaultToolTipController.SetAllowHtmlText(this.controlContainer4, DevExpress.Utils.DefaultBoolean.Default);
          this.controlContainer4.Location = new System.Drawing.Point(0, 0);
          this.controlContainer4.Name = "controlContainer4";
-         this.controlContainer4.Size = new System.Drawing.Size(747, 146);
+         this.controlContainer4.Size = new System.Drawing.Size(749, 144);
          this.controlContainer4.TabIndex = 0;
          // 
          // _panelComparison
@@ -286,10 +311,10 @@ namespace MoBi.UI.Views
          this._panelComparison.Dock = DevExpress.XtraBars.Docking.DockingStyle.Fill;
          this._panelComparison.FloatVertical = true;
          this._panelComparison.ID = new System.Guid("4885d682-375e-43bc-befc-dda4c7d6dd87");
-         this._panelComparison.Location = new System.Drawing.Point(4, 23);
+         this._panelComparison.Location = new System.Drawing.Point(3, 27);
          this._panelComparison.Name = "_panelComparison";
-         this._panelComparison.OriginalSize = new System.Drawing.Size(1019, 146);
-         this._panelComparison.Size = new System.Drawing.Size(747, 146);
+         this._panelComparison.OriginalSize = new System.Drawing.Size(747, 146);
+         this._panelComparison.Size = new System.Drawing.Size(749, 144);
          this._panelComparison.Text = "_panelComparison";
          // 
          // controlContainer5
@@ -297,32 +322,32 @@ namespace MoBi.UI.Views
          this.defaultToolTipController.SetAllowHtmlText(this.controlContainer5, DevExpress.Utils.DefaultBoolean.Default);
          this.controlContainer5.Location = new System.Drawing.Point(0, 0);
          this.controlContainer5.Name = "controlContainer5";
-         this.controlContainer5.Size = new System.Drawing.Size(747, 146);
+         this.controlContainer5.Size = new System.Drawing.Size(749, 144);
          this.controlContainer5.TabIndex = 0;
          // 
          // ribbonStatusBar1
          // 
-         this.ribbonStatusBar1.Location = new System.Drawing.Point(0, 802);
+         this.ribbonStatusBar1.Location = new System.Drawing.Point(0, 809);
          this.ribbonStatusBar1.Name = "ribbonStatusBar1";
          this.ribbonStatusBar1.Ribbon = this.ribbonControl;
-         this.ribbonStatusBar1.Size = new System.Drawing.Size(1227, 31);
+         this.ribbonStatusBar1.Size = new System.Drawing.Size(1227, 24);
          // 
          // ribbonControl
          // 
          this.ribbonControl.AllowTrimPageText = false;
          this.ribbonControl.ApplicationButtonDropDownControl = this.applicationMenu;
+         this.ribbonControl.ApplicationButtonImageOptions.Image = ((System.Drawing.Image)(resources.GetObject("ribbonControl.ApplicationButtonImageOptions.Image")));
          this.ribbonControl.ApplicationButtonText = null;
-         this.ribbonControl.ApplicationIcon = ((System.Drawing.Bitmap)(resources.GetObject("ribbonControl.ApplicationIcon")));
          this.ribbonControl.AutoSizeItems = true;
-         this.ribbonControl.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
          this.ribbonControl.ExpandCollapseItem.Id = 0;
          this.ribbonControl.Items.AddRange(new DevExpress.XtraBars.BarItem[] {
+            this.ribbonControl.SearchEditItem,
             this.ribbonControl.ExpandCollapseItem});
          this.ribbonControl.Location = new System.Drawing.Point(0, 0);
          this.ribbonControl.MaxItemId = 1;
          this.ribbonControl.Name = "ribbonControl";
          this.ribbonControl.RibbonStyle = DevExpress.XtraBars.Ribbon.RibbonControlStyle.Office2010;
-         this.ribbonControl.Size = new System.Drawing.Size(1227, 49);
+         this.ribbonControl.Size = new System.Drawing.Size(1227, 58);
          this.ribbonControl.StatusBar = this.ribbonStatusBar1;
          // 
          // applicationMenu
@@ -362,6 +387,7 @@ namespace MoBi.UI.Views
          // labelControl1
          // 
          this.labelControl1.Appearance.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
+         this.labelControl1.Appearance.Options.UseFont = true;
          this.labelControl1.AutoSizeMode = DevExpress.XtraEditors.LabelAutoSizeMode.None;
          this.labelControl1.Dock = System.Windows.Forms.DockStyle.Top;
          this.labelControl1.LineLocation = DevExpress.XtraEditors.LineLocation.Bottom;
@@ -395,7 +421,7 @@ namespace MoBi.UI.Views
          this.Controls.Add(this.panelContainer3);
          this.Controls.Add(this.ribbonStatusBar1);
          this.Controls.Add(this.ribbonControl);
-         this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+         this.IconOptions.Icon = ((System.Drawing.Icon)(resources.GetObject("MoBiMainView.IconOptions.Icon")));
          this.Name = "MoBiMainView";
          this.Ribbon = this.ribbonControl;
          this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
@@ -410,10 +436,11 @@ namespace MoBi.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.xtraTabbedMdiManager)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.dockManager)).EndInit();
          this.panelContainer3.ResumeLayout(false);
-         this._panelJournal.ResumeLayout(false);
          this._panelSearch.ResumeLayout(false);
+         this._panelJournal.ResumeLayout(false);
          this.panelContainer1.ResumeLayout(false);
          this._panelBuildingBlockExplorer.ResumeLayout(false);
+         this._panelModuleExplorer.ResumeLayout(false);
          this._panelSimulationExplorer.ResumeLayout(false);
          this.panelContainer2.ResumeLayout(false);
          this._panelJournalDiagram.ResumeLayout(false);
@@ -460,5 +487,7 @@ namespace MoBi.UI.Views
       private DevExpress.XtraBars.Docking.DockPanel panelContainer3;
       private OSPSuite.UI.Controls.UxDockPanel _panelJournal;
       private DevExpress.XtraBars.Docking.ControlContainer controlContainer7;
+      private OSPSuite.UI.Controls.UxDockPanel _panelModuleExplorer;
+      private DevExpress.XtraBars.Docking.ControlContainer controlContainer8;
    }
 }

--- a/src/MoBi.UI/Views/MoBiMainView.cs
+++ b/src/MoBi.UI/Views/MoBiMainView.cs
@@ -65,6 +65,7 @@ namespace MoBi.UI.Views
       {
          base.RegisterRegions();
          RegisterRegion(_panelBuildingBlockExplorer, RegionNames.BuildingBlockExplorer);
+         RegisterRegion(_panelModuleExplorer, RegionNames.ModuleExplorer);
          RegisterRegion(_panelSimulationExplorer, RegionNames.SimulationExplorer);
          RegisterRegion(_panelHistoryBrowser, RegionNames.History);
          RegisterRegion(_panelSearch, RegionNames.Search);

--- a/src/MoBi.UI/Views/MoBiMainView.resx
+++ b/src/MoBi.UI/Views/MoBiMainView.resx
@@ -121,42 +121,42 @@
     <value>17, 17</value>
   </metadata>
   <metadata name="defaultToolTipController.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 56</value>
+    <value>200, 17</value>
   </metadata>
   <metadata name="defaultLookAndFeel.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 95</value>
+    <value>385, 17</value>
   </metadata>
   <metadata name="alertControl.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 134</value>
+    <value>545, 17</value>
   </metadata>
   <metadata name="dockManager.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 212</value>
+    <value>804, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>63</value>
   </metadata>
   <metadata name="applicationMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 173</value>
+    <value>661, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="ribbonControl.ApplicationIcon" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="ribbonControl.ApplicationButtonImageOptions.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
-        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADrwAAA68AZW8ckkAAAKZSURBVDhPpZPfS1NhHMYPRZddldtxGpsmLut69QcEXUT4
-        CymLIn/EMpcWpcaIutAMrHRLa5nOaWz4I0NjmiWYGqvlNnecHrco8cdwm267CdMWdfH0vq9E22V04Mvz
-        nsN5Pu/zPvByu8p6sFNtwQ61+Z+GeqiXowu/MI7Qo9NMVU1rUDWG4Axvos61ylSlC5Eh3/XrUD0Mszmi
-        DzMIR2nU/CWHY5pR60Rmg5OZd98QUEtUUePAvis2pJQMQlbQhuF3nxD9BaYMwBLo85gqW3zIavWynanZ
-        vvYN6XU+yLUepFZOIqV0gJnpQ5UBVE0hVAwswxaMIcvgxSHj9tB1zWgQ7rUY5DdFpF59D1nZK7wcExH9
-        GZeAAtK0DlSNhCCEYzhoEIlZxIFmEZn3RVy3BjAd/M4A06sbuNxqJ32EWZnbAFKQvNqO9Hofqt8EIazH
-        oNTNQflARMZdEWm351HevQT7ygYqn81AdqqTFZkIICUpyI/773hRNRyAJ/KDrLfNCq0AR2ALleZ5JJe8
-        QPJJYyKga3YWnV4ljIILCnLW9FtzKOvzwzrhZUVRrbD4wKutkBb1gi94isPxAGouGefQJqbCvryFj/5N
-        TC5uIEKKog9V2cUh8MX9kJw1Q5pnSAT8SdAx44asfBQpmjE2tG1qpiotfg7JOTOSCjsgyWkmgMhfAKXR
-        WPz5bvCl/eAvDEAIbEJjcpHIfShvn4LL/xV7Co1IyjdAevxeIkBFXpJPNJIkHpi8mWgXnNC0TUFK4krO
-        dJFdTdC02mBbiML6YQnXepcx4liJB4QhO1qPoYVsFL3lMPj5GPj8J5DSyX0MSW4L9mbrcEn3GhrLIjiu
-        gUEYgF4IejEopNPjZhCTx8WOlTgRNvEJ2GX6v+vcg9/hnJuwZit++QAAAABJRU5ErkJggg==
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        vAAADrwBlbxySQAAAplJREFUOE+lk99LU2Ecxg9Fl12V23EamyYu63r1BwRdRPgLKYsif8Qylxalxoi6
+        0AysdEtrmc5pbPgjQ2OaJZgaq+U2d5wetyjxx3CbbrsJ0xZ18fS+r0TbZXTgy/Oew3k+7/M+8HK7ynqw
+        U23BDrX5n4Z6qJejC78wjtCj00xVTWtQNYbgDG+izrXKVKULkSHf9etQPQyzOaIPMwhHadT8JYdjmlHr
+        RGaDk5l33xBQS1RR48C+KzaklAxCVtCG4XefEP0FpgzAEujzmCpbfMhq9bKdqdm+9g3pdT7ItR6kVk4i
+        pXSAmelDlQFUTSFUDCzDFowhy+DFIeP20HXNaBDutRjkN0WkXn0PWdkrvBwTEf0Zl4AC0rQOVI2EIIRj
+        OGgQiVnEgWYRmfdFXLcGMB38zgDTqxu43GonfYRZmdsAUpC82o70eh+q3wQhrMeg1M1B+UBExl0Rabfn
+        Ud69BPvKBiqfzUB2qpMVmQggJSnIj/vveFE1HIAn8oOst80KrQBHYAuV5nkkl7xA8kljIqBrdhadXiWM
+        ggsKctb0W3Mo6/PDOuFlRVGtsPjAq62QFvWCL3iKw/EAai4Z59AmpsK+vIWP/k1MLm4gQoqiD1XZxSHw
+        xf2QnDVDmmdIBPxJ0DHjhqx8FCmaMTa0bWqmKi1+Dsk5M5IKOyDJaSaAyF8ApdFY/Plu8KX94C8MQAhs
+        QmNykch9KG+fgsv/FXsKjUjKN0B6/F4iQEVekk80kiQemLyZaBec0LRNQUriSs50kV1N0LTaYFuIwvph
+        Cdd6lzHiWIkHhCE7Wo+hhWwUveUw+PkY+PwnkNLJfQxJbgv2ZutwSfcaGssiOK6BQRiAXgh6MSik0+Nm
+        EJPHxY6VOBE28QnYZfq/69yD3+Gcm7BmK375AAAAAElFTkSuQmCC
 </value>
   </data>
-  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="MoBiMainView.IconOptions.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAcAEBAAAAEAGABoAwAAdgAAACAgAAABABgAqAwAAN4DAAAwMAAAAQAYAKgcAACGEAAAEBAAAAEA
         IABoBAAALi0AACAgAAABACAAqBAAAJYxAAAwMAAAAQAgAKglAAA+QgAAgIAAAAEAIAAoCAEA5mcAACgA

--- a/src/MoBi.UI/Views/ModuleExplorerView.Designer.cs
+++ b/src/MoBi.UI/Views/ModuleExplorerView.Designer.cs
@@ -1,0 +1,37 @@
+﻿namespace MoBi.UI.Views
+{
+   partial class ModuleExplorerView
+   {
+      /// <summary> 
+      /// Required designer variable.
+      /// </summary>
+      private System.ComponentModel.IContainer components = null;
+
+      /// <summary> 
+      /// Clean up any resources being used.
+      /// </summary>
+      /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+      protected override void Dispose(bool disposing)
+      {
+         if (disposing && (components != null))
+         {
+            components.Dispose();
+         }
+         base.Dispose(disposing);
+      }
+
+      #region Component Designer generated code
+
+      /// <summary> 
+      /// Required method for Designer support - do not modify 
+      /// the contents of this method with the code editor.
+      /// </summary>
+      private void InitializeComponent()
+      {
+         components = new System.ComponentModel.Container();
+         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      }
+
+      #endregion
+   }
+}

--- a/src/MoBi.UI/Views/ModuleExplorerView.cs
+++ b/src/MoBi.UI/Views/ModuleExplorerView.cs
@@ -1,0 +1,37 @@
+﻿using DevExpress.XtraTreeList;
+using MoBi.Presentation.Presenter.Main;
+using OSPSuite.Presentation.Nodes;
+using OSPSuite.UI.Services;
+using OSPSuite.UI.Views;
+
+namespace MoBi.UI.Views
+{
+   public partial class ModuleExplorerView : BaseExplorerView, IModuleExplorerView
+   {
+      private IModuleExplorerPresenter _moduleExplorerPresenter;
+
+      public ModuleExplorerView(IImageListRetriever imageListRetriever) : base(imageListRetriever)
+      {
+         InitializeComponent();
+         treeView.CompareNodeValues += compareNodeValues;
+      }
+
+      public void AttachPresenter(IModuleExplorerPresenter presenter)
+      {
+         _moduleExplorerPresenter = presenter;
+         base.AttachPresenter(presenter);
+      }
+
+      private void compareNodeValues(object sender, CompareNodeValuesEventArgs e)
+      {
+         //we only want to sort for the top nodes (level 0)
+         if (e.Node1 == null)
+            return;
+
+         //we do not want to sort the root nodes or if the presenter indicates no sort
+         if (e.Node1.Level == 0 || !_moduleExplorerPresenter.ShouldSort(e.Node1.Tag as ITreeNode))
+            e.Result = 0;
+
+      }
+   }
+}

--- a/src/MoBi.UI/Views/ModuleExplorerView.cs
+++ b/src/MoBi.UI/Views/ModuleExplorerView.cs
@@ -1,5 +1,6 @@
 ﻿using DevExpress.XtraTreeList;
 using MoBi.Presentation.Presenter.Main;
+using MoBi.Presentation.Views;
 using OSPSuite.Presentation.Nodes;
 using OSPSuite.UI.Services;
 using OSPSuite.UI.Views;
@@ -31,7 +32,6 @@ namespace MoBi.UI.Views
          //we do not want to sort the root nodes or if the presenter indicates no sort
          if (e.Node1.Level == 0 || !_moduleExplorerPresenter.ShouldSort(e.Node1.Tag as ITreeNode))
             e.Result = 0;
-
       }
    }
 }

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.103" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.102" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.103" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.103" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/BuildingBlockExplorerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/BuildingBlockExplorerPresenterSpecs.cs
@@ -3,7 +3,6 @@ using System.Drawing;
 using OSPSuite.BDDHelper;
 using OSPSuite.Presentation.Nodes;
 using FakeItEasy;
-using MoBi.Assets;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
 using MoBi.Presentation.Nodes;
@@ -24,7 +23,6 @@ using OSPSuite.Presentation.Regions;
 using OSPSuite.Presentation.Services;
 using OSPSuite.Presentation.Views;
 using ITreeNodeFactory = MoBi.Presentation.Nodes.ITreeNodeFactory;
-using System;
 
 namespace MoBi.Presentation
 {

--- a/tests/MoBi.Tests/Presentation/ModuleExplorerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ModuleExplorerPresenterSpecs.cs
@@ -1,0 +1,282 @@
+﻿using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OSPSuite.BDDHelper;
+using OSPSuite.Presentation.Nodes;
+using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.Nodes;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Presenter.Main;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Events;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.Presenters.Classifications;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Presentation.Presenters.Nodes;
+using OSPSuite.Presentation.Presenters.ObservedData;
+using OSPSuite.Presentation.Regions;
+using OSPSuite.Presentation.Services;
+using OSPSuite.Presentation.Views;
+using OSPSuite.Core.Domain.Repositories;
+
+namespace MoBi.Presentation
+{
+   public abstract class concern_for_ModuleExplorerPresenter : ContextSpecification<ModuleExplorerPresenter>
+   {
+      protected IModuleExplorerView _view;
+      protected IMoBiContext _context;
+      protected IViewItemContextMenuFactory _viewItemContextMenuFactory;
+      private IRegionResolver _regionResolver;
+      protected Nodes.TreeNodeFactory _treeNodeFactory;
+      private IClassificationPresenter _classificationPresenter;
+      private IToolTipPartCreator _toolTipPartCreator;
+      protected IObservedDataInExplorerPresenter _observedDataInExplorerPresenter;
+      private IMultipleTreeNodeContextMenuFactory _multipleTreeNodeContextMenuFactory;
+      private IProjectRetriever _projectRetriever;
+      protected IEditBuildingBlockStarter _editBuildingBlockStarter;
+
+      protected ITreeNode<RootNodeType> _nodeObservedDataFolder;
+      private IObservedDataRepository _observedDataRepository;
+
+      protected override void Context()
+      {
+         _projectRetriever = A.Fake<IProjectRetriever>();
+         _view = A.Fake<IModuleExplorerView>();
+         A.CallTo(() => _view.TreeView).Returns(A.Fake<IUxTreeView>());
+         _context = A.Fake<IMoBiContext>();
+         _regionResolver = A.Fake<IRegionResolver>();
+         _observedDataRepository = A.Fake<IObservedDataRepository>();
+
+         _viewItemContextMenuFactory = A.Fake<IViewItemContextMenuFactory>();
+         _classificationPresenter = A.Fake<IClassificationPresenter>();
+         _toolTipPartCreator = A.Fake<IToolTipPartCreator>();
+         _observedDataInExplorerPresenter = A.Fake<IObservedDataInExplorerPresenter>();
+         _multipleTreeNodeContextMenuFactory = A.Fake<IMultipleTreeNodeContextMenuFactory>();
+         _editBuildingBlockStarter = A.Fake<IEditBuildingBlockStarter>();
+         _treeNodeFactory = new Nodes.TreeNodeFactory(_observedDataRepository, _toolTipPartCreator);
+         
+         sut = new ModuleExplorerPresenter(_view, _regionResolver, _treeNodeFactory, _viewItemContextMenuFactory, _context,
+            _classificationPresenter, _toolTipPartCreator, _observedDataInExplorerPresenter, _multipleTreeNodeContextMenuFactory, _projectRetriever, _editBuildingBlockStarter);
+      }
+   }
+
+   public class When_the_module_explorer_presenter_is_notified_that_the_project_is_being_closed : concern_for_ModuleExplorerPresenter
+   {
+      private readonly ProjectClosedEvent _closeProjectEvent = new ProjectClosedEvent();
+
+      protected override void Because()
+      {
+         sut.Handle(_closeProjectEvent);
+      }
+
+      [Observation]
+      public void should_tell_view_to_clear()
+      {
+         A.CallTo(() => _view.TreeView.DestroyAllNodes()).MustHaveHappened();
+      }
+   }
+
+   public class When_the_module_explorer_presenter_is_told_to_show_a_context_menu : concern_for_ModuleExplorerPresenter
+   {
+      private IViewItem _viewItem;
+      private Point _point;
+      private IContextMenu _menu;
+
+      protected override void Because()
+      {
+         sut.ShowContextMenu(_viewItem, _point);
+      }
+
+      protected override void Context()
+      {
+         base.Context();
+         _viewItem = A.Fake<IViewItem>();
+         _point = new Point(1, 2);
+         _menu = A.Fake<IContextMenu>();
+         A.CallTo(() => _viewItemContextMenuFactory.CreateFor(_viewItem, sut)).Returns(_menu);
+      }
+
+      [Observation]
+      public void should_ask_context_menu_factory_for_the_right_context_menu()
+      {
+         A.CallTo(() => _viewItemContextMenuFactory.CreateFor(_viewItem, sut)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_tell_view_to_show_the_menu_at_point()
+      {
+         A.CallTo(() => _menu.Show(_view, _point)).MustHaveHappened();
+      }
+   }
+
+   public class When_double_clicking_on_a_node_that_is_not_a_molecule_builder_node_in_module_explorer : concern_for_ModuleExplorerPresenter
+   {
+      private ITreeNode _node;
+      private IViewItem _viewItem;
+      private IContextMenu _contextMenu;
+
+      protected override void Context()
+      {
+         base.Context();
+         _node = A.Fake<ITreeNode>();
+         _viewItem = A.Fake<IViewItem>();
+         _contextMenu = A.Fake<IContextMenu>();
+         A.CallTo(() => _node.TagAsObject).Returns(_viewItem);
+         A.CallTo(() => _viewItemContextMenuFactory.CreateFor(_viewItem, sut)).Returns(_contextMenu);
+      }
+
+      protected override void Because()
+      {
+         sut.NodeDoubleClicked(_node);
+      }
+
+      [Observation]
+      public void should_invoke_the_first_element_of_the_context_menu()
+      {
+         A.CallTo(() => _contextMenu.ActivateFirstMenu()).MustHaveHappened();
+      }
+   }
+
+   public class When_double_clicking_on_a_node_that_is_a_molecule_builder_node_in_module_explorer : concern_for_ModuleExplorerPresenter
+   {
+      private ITreeNode _node;
+      private IMoleculeBuilder _moleculeBuilder;
+      private IMoleculeBuildingBlock _moleculeBuildingBlock;
+
+      protected override void Context()
+      {
+         base.Context();
+         _moleculeBuilder = A.Fake<IMoleculeBuilder>();
+         _moleculeBuildingBlock = A.Fake<IMoleculeBuildingBlock>();
+         var moleculeBuildingBlockNode = A.Fake<ITreeNode>();
+         A.CallTo(() => moleculeBuildingBlockNode.TagAsObject).Returns(_moleculeBuildingBlock);
+         _node = A.Fake<ITreeNode>();
+         _node.ParentNode = moleculeBuildingBlockNode;
+         A.CallTo(() => _node.TagAsObject).Returns(_moleculeBuilder);
+      }
+
+      protected override void Because()
+      {
+         sut.NodeDoubleClicked(_node);
+      }
+
+      [Observation]
+      public void should_invoke_the_first_element_of_the_context_menu()
+      {
+         A.CallTo(() => _editBuildingBlockStarter.EditMolecule(_moleculeBuildingBlock, _moleculeBuilder)).MustHaveHappened();
+      }
+   }
+
+   public class When_the_module_explorer_presenter_is_asked_whether_to_sort : concern_for_ModuleExplorerPresenter
+   {
+      private ITreeNode _spatialStructureNode;
+
+      protected override void Context()
+      {
+         base.Context();
+         var moduleNode = _treeNodeFactory.CreateFor(new Module());
+         _spatialStructureNode = _treeNodeFactory.CreateFor(new SpatialStructure());
+         moduleNode.AddChild(_spatialStructureNode);
+      }
+
+      [Observation]
+      public void should_return_true()
+      {
+         sut.ShouldSort(_spatialStructureNode).ShouldBeFalse();
+      }
+   }
+
+   public class When_the_module_explorer_presenter_is_adding_the_project_to_the_tree : concern_for_ModuleExplorerPresenter
+   {
+      private List<ITreeNode> _allNodesAdded;
+      private IMoBiProject _project;
+      private ObserverBuildingBlock _observerBuildingBlock;
+      private SimulationSettings _simulationSettingsBuildingBlock;
+      private Module _module1;
+
+      protected override void Context()
+      {
+         base.Context();
+         _project = new MoBiProject();
+         _observerBuildingBlock = new ObserverBuildingBlock().WithName("OBSERVERS");
+         _simulationSettingsBuildingBlock = new SimulationSettings().WithName("SIMULATION_SETTINGS");
+         _module1 = new Module
+         {
+            SpatialStructure = new MoBiSpatialStructure()
+         };
+
+         _module1.AddParameterStartValueBlock(new ParameterStartValuesBuildingBlock());
+         _module1.AddParameterStartValueBlock(new ParameterStartValuesBuildingBlock());
+         
+         _module1.AddMoleculeStartValueBlock(new MoleculeStartValuesBuildingBlock());
+
+         _allNodesAdded = new List<ITreeNode>();
+         A.CallTo(() => _view.AddNode(A<ITreeNode>._)).Invokes(x =>
+         {
+            _allNodesAdded.Add(x.GetArgument<ITreeNode>(0));
+         });
+
+         _project.AddBuildingBlock(_observerBuildingBlock);
+         _project.AddBuildingBlock(_simulationSettingsBuildingBlock);
+         _project.AddModule(_module1);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new ProjectCreatedEvent(_project));
+      }
+
+      [Observation]
+      public void should_add_a_folder_node_for_all_building_block_types()
+      {
+         _allNodesAdded.Count(x => x.TagAsObject.Equals(MoBiRootNodeTypes.ExpressionProfilesFolder)).ShouldBeEqualTo(1);
+         _allNodesAdded.Count(x => x.TagAsObject.Equals(MoBiRootNodeTypes.IndividualsFolder)).ShouldBeEqualTo(1);
+
+         // We have a module with two parameter start values building blocks so a root node should be created
+         _allNodesAdded.Count(x => x.TagAsObject.Equals(MoBiRootNodeTypes.ParameterStartValuesFolder)).ShouldBeEqualTo(1);
+
+         // There is only one molecule start values building block so a root node should not be created
+         _allNodesAdded.Count(x => x.TagAsObject.Equals(MoBiRootNodeTypes.MoleculeStartValuesFolder)).ShouldBeEqualTo(0);
+
+         _allNodesAdded.Count(x => x.TagAsObject.Equals(RootNodeTypes.ObservedDataFolder)).ShouldBeEqualTo(1);
+         _allNodesAdded.Count(x => x.TagAsObject.Equals(_module1)).ShouldBeEqualTo(1);
+         _allNodesAdded.Count(x => x.TagAsObject.Equals(_module1.SpatialStructure)).ShouldBeEqualTo(1);
+         _allNodesAdded.Count(x => x.TagAsObject.Equals(_module1.ParameterStartValuesCollection.ElementAt(0))).ShouldBeEqualTo(1);
+         _allNodesAdded.Count(x => x.TagAsObject.Equals(_module1.ParameterStartValuesCollection.ElementAt(1))).ShouldBeEqualTo(1);
+         _allNodesAdded.Count(x => x.TagAsObject.Equals(_module1.MoleculeStartValuesCollection.ElementAt(0))).ShouldBeEqualTo(1);
+         
+         // Make sure nodes have not been added for null items
+         _allNodesAdded.Count.ShouldBeEqualTo(9);
+      }
+   }
+
+   public class When_the_module_explorer_presenter_is_asked_if_a_node_can_be_dragged : concern_for_ModuleExplorerPresenter
+   {
+      [Observation]
+      public void should_return_false_if_the_node_is_null()
+      {
+         sut.CanDrag(null).ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_return_true_if_the_node_is_a_classification_node()
+      {
+         sut.CanDrag(new ClassificationNode(A.Fake<IClassification>())).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_delegate_to_the_observed_data_presenter_otherwise()
+      {
+         var node = A.Fake<ITreeNode>();
+         A.CallTo(() => _observedDataInExplorerPresenter.CanDrag(node)).Returns(true);
+         sut.CanDrag(node).ShouldBeTrue();
+
+         A.CallTo(() => _observedDataInExplorerPresenter.CanDrag(node)).Returns(false);
+         sut.CanDrag(node).ShouldBeFalse();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/ModuleExplorerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ModuleExplorerPresenterSpecs.cs
@@ -8,6 +8,7 @@ using MoBi.Core.Domain.Model;
 using MoBi.Presentation.Nodes;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Presenter.Main;
+using MoBi.Presentation.Views;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;

--- a/tests/MoBi.Tests/Presentation/ProjectTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ProjectTaskSpecs.cs
@@ -213,11 +213,13 @@ namespace MoBi.Presentation
       private IObserverBuildingBlock _observerBuildingBlock;
       private IEventGroupBuildingBlock _eventGroupBuildingBlock;
       private ISimulationSettings _simulationSettings;
+      private Module _module;
 
       protected override void Context()
       {
          base.Context();
          _project = A.Fake<IMoBiProject>();
+         _module = new Module();
          _objectBaseRepository = A.Fake<IWithIdRepository>();
          _spatialStructure = A.Fake<IMoBiSpatialStructure>();
          _simulationSettings = A.Fake<ISimulationSettings>();
@@ -225,7 +227,7 @@ namespace MoBi.Presentation
          _moleculeBuildingBlock = A.Fake<IMoleculeBuildingBlock>();
          A.CallTo(() => _context.CurrentProject).Returns(_project);
          A.CallTo(() => _context.Create<IMoleculeBuildingBlock>()).Returns(_moleculeBuildingBlock);
-         A.CallTo(() => _context.Create<IMoBiReactionBuildingBlock>()).Returns(_moBiReactionBuildingBlock);
+         A.CallTo(() => _reactionBuildingBlockFactory.Create()).Returns(_moBiReactionBuildingBlock);
          A.CallTo(() => _spatialStructureFactory.CreateDefault(AppConstants.DefaultNames.SpatialStructure)).Returns(_spatialStructure);
          A.CallTo(() => _simulationSettingsFactory.CreateDefault()).Returns(_simulationSettings);
          _topContainer = A.Fake<IContainer>();
@@ -237,6 +239,7 @@ namespace MoBi.Presentation
          _eventGroupBuildingBlock = A.Fake<IEventGroupBuildingBlock>();
          A.CallTo(() => _context.Create<IEventGroupBuildingBlock>()).Returns(_eventGroupBuildingBlock);
          A.CallTo(() => _context.ObjectRepository).Returns(_objectBaseRepository);
+         A.CallTo(() => _context.Create<Module>()).Returns(_module);
       }
 
       protected override void Because()
@@ -251,6 +254,19 @@ namespace MoBi.Presentation
       }
 
       [Observation]
+      public void the_default_module_contains_appropriate_building_blocks()
+      {
+         _module.SpatialStructure.ShouldBeEqualTo(_spatialStructure);
+         _module.PassiveTransport.ShouldBeEqualTo(_passiveTransportBuildingBlock);
+         _module.EventGroup.ShouldBeEqualTo(_eventGroupBuildingBlock);
+         _module.Molecule.ShouldBeEqualTo(_moleculeBuildingBlock);
+         _module.Observer.ShouldBeEqualTo(_observerBuildingBlock);
+         _module.Reaction.ShouldBeEqualTo(_moBiReactionBuildingBlock);
+         _module.MoleculeStartValuesCollection.ShouldBeEmpty();
+         _module.ParameterStartValuesCollection.ShouldBeEmpty();
+      }
+
+      [Observation]
       public void should_have_created_default_project_entries()
       {
          A.CallTo(() => _context.Create<IMoleculeBuildingBlock>()).MustHaveHappened();
@@ -260,6 +276,7 @@ namespace MoBi.Presentation
          A.CallTo(() => _context.Create<IEventGroupBuildingBlock>()).MustHaveHappened();
          A.CallTo(() => _spatialStructureFactory.CreateDefault(AppConstants.DefaultNames.SpatialStructure)).MustHaveHappened();
          A.CallTo(() => _simulationSettingsFactory.CreateDefault()).MustHaveHappened();
+         A.CallTo(() => _context.Create<Module>()).MustHaveHappened();
       }
 
       [Observation]
@@ -272,6 +289,7 @@ namespace MoBi.Presentation
          A.CallTo(() => _context.Register(_observerBuildingBlock)).MustHaveHappened();
          A.CallTo(() => _context.Register(_eventGroupBuildingBlock)).MustHaveHappened();
          A.CallTo(() => _context.Register(_simulationSettings)).MustHaveHappened();
+         A.CallTo(() => _context.Register(_module)).MustHaveHappened();
       }
 
       [Observation]

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.102" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.103" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.103" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
I implemented this default module feature similar to how new building blocks are added to blank projects. In this screenshot I was adding 2 PSV and 1 MSV just to get the folder logic correct.

![image](https://user-images.githubusercontent.com/261477/217235426-bcf6eec9-1a6a-4352-b19c-31b501a30e4e.png)

We get the context menus, but some entries will have to be changed around. I'm going to take that task on next with #823 .

![image](https://user-images.githubusercontent.com/261477/217236222-cb669810-ce82-4b00-8b52-f7425d61163d.png)
