### PR TITLE
Fixes #981 Remove distinction of Extension vs. PK-Sim modules

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -825,7 +825,7 @@ namespace MoBi.Assets
       {
          public static readonly string ObservedData = "Observed Data";
          public static readonly string Individual = Captions.Individual;
-         public static readonly string NewExtensionModule = "Extension Module";
+         public static readonly string NewModule = "Module";
          public static readonly string Simulation = MenuNames.Simulation;
          public static readonly string Molecules = "Molecules";
          public static readonly string Reactions = "Reactions";
@@ -1643,8 +1643,7 @@ namespace MoBi.Assets
          public static readonly string Individuals = "Individuals";
          public static readonly string OriginData = "Origin Data";
          public static readonly string PKSimVersion = "PK-Sim Version";
-         public static readonly string PKSimModules = "PK-Sim Modules";
-         public static readonly string ExtensionModulesFolder = "Extension Modules";
+         public static readonly string ModulesFolder = "Modules";
          public static readonly string Module = "Module";
          public static readonly string CreateBuildingBlocks = "Create Building Blocks";
          public static readonly string AddSelectedBuildingBlocks = "Add Selected Building Blocks";

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.170" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.173" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/ToolTips.cs
+++ b/src/MoBi.Assets/ToolTips.cs
@@ -69,7 +69,7 @@ namespace MoBi.Assets
       public static class ModelingRibbon
       {
          public static readonly string CreateIndividual = "Create a new Individual";
-         public static readonly string CreateExtensionModule = "Create a new Extension Module";
+         public static readonly string CreateModule = "Create a new Module";
          public static readonly string CreateExpressionProfile = "Create a new Expression Profile";
       }
 

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.170" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.173" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -33,13 +33,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.170" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.173" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.170" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.173" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuFactoryForBuildBlocks.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuFactoryForBuildBlocks.cs
@@ -73,7 +73,7 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
 
    public class RootContextMenuFactoryForExtensionModule : RootNodeContextMenuFactoryFor<Module>
    {
-      public RootContextMenuFactoryForExtensionModule() : base(MoBiRootNodeTypes.ExtensionModulesFolder)
+      public RootContextMenuFactoryForExtensionModule() : base(MoBiRootNodeTypes.ModulesFolder)
       {
       }
    }

--- a/src/MoBi.Presentation/MenusAndBars/MenuBarItemIds.cs
+++ b/src/MoBi.Presentation/MenusAndBars/MenuBarItemIds.cs
@@ -24,7 +24,7 @@ namespace MoBi.Presentation.MenusAndBars
       public static MenuBarItemId NewIndividual = createMenuBarItemId("NewIndividual");
       public static MenuBarItemId NewMetabolizingEnzyme = createMenuBarItemId("NewMetabolizingEnzyme");
       public static MenuBarItemId NewExpressionProfile = createMenuBarItemId("NewExpressionProfile");
-      public static MenuBarItemId NewExtensionModule = createMenuBarItemId("NewExtensionModule");
+      public static MenuBarItemId NewModule = createMenuBarItemId("NewModule");
       public static MenuBarItemId NewTransportProtein = createMenuBarItemId("NewTransportProtein");
       public static MenuBarItemId NewSpecificBindingPartner = createMenuBarItemId("NewSpecificBindingPartner");
       public static MenuBarItemId Run = createMenuBarItemId("Run");

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.170" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.173" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Nodes/RootNodeType.cs
+++ b/src/MoBi.Presentation/Nodes/RootNodeType.cs
@@ -16,7 +16,6 @@ namespace MoBi.Presentation.Nodes
       public static readonly RootNodeType ParameterStartValuesFolder = new RootNodeType(AppConstants.Captions.ParameterStartValues, ApplicationIcons.ParameterStartValuesFolder);
       public static readonly RootNodeType ExpressionProfilesFolder = new RootNodeType(AppConstants.Captions.ExpressionProfiles, ApplicationIcons.ExpressionProfileFolder);
       public static readonly RootNodeType IndividualsFolder = new RootNodeType(AppConstants.Captions.Individuals, ApplicationIcons.IndividualFolder);
-      public static readonly RootNodeType PKSimModuleFolder = new RootNodeType(AppConstants.Captions.PKSimModules, ApplicationIcons.PKSimModulesFolder);
-      public static readonly RootNodeType ExtensionModulesFolder = new RootNodeType(AppConstants.Captions.ExtensionModulesFolder, ApplicationIcons.ExtensionModulesFolder);
+      public static readonly RootNodeType ModulesFolder = new RootNodeType(AppConstants.Captions.ModulesFolder, ApplicationIcons.ModulesFolder);
    }
 }

--- a/src/MoBi.Presentation/Presenter/Main/MenuAndToolBarPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/MenuAndToolBarPresenter.cs
@@ -222,7 +222,7 @@ namespace MoBi.Presentation.Presenter.Main
             _menuBarItemRepository[MenuBarItemIds.NewSimulation].Enabled = enabled;
             _menuBarItemRepository[MenuBarItemIds.NewIndividual].Enabled = enabled;
             _menuBarItemRepository[MenuBarItemIds.NewExpressionProfile].Enabled = enabled;
-            _menuBarItemRepository[MenuBarItemIds.NewExtensionModule].Enabled = enabled;
+            _menuBarItemRepository[MenuBarItemIds.NewModule].Enabled = enabled;
             _menuBarItemRepository[MenuBarItemIds.NewMetabolizingEnzyme].Enabled = enabled;
             _menuBarItemRepository[MenuBarItemIds.NewTransportProtein].Enabled = enabled;
             _menuBarItemRepository[MenuBarItemIds.NewSpecificBindingPartner].Enabled = enabled;

--- a/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
@@ -125,7 +125,7 @@ namespace MoBi.Presentation.Presenter.Main
 
       private int rootNodeTypeComparison(ITreeNode<IWithName> node1, ITreeNode<IWithName> node2)
       {
-         if (node1.Tag.Equals(MoBiRootNodeTypes.ExtensionModulesFolder))
+         if (node1.Tag.Equals(MoBiRootNodeTypes.ModulesFolder))
             return 1;
 
          return -1;
@@ -146,8 +146,7 @@ namespace MoBi.Presentation.Presenter.Main
 
       private static bool nodeTagIsModuleRootNode(ITreeNode<IWithName> node)
       {
-         var rootNodeList = new List<IWithName> { MoBiRootNodeTypes.ExtensionModulesFolder, MoBiRootNodeTypes.PKSimModuleFolder };
-         return rootNodeList.Contains(node?.Tag);
+         return Equals(node?.Tag, MoBiRootNodeTypes.ModulesFolder);
       }
 
       public override IEnumerable<ClassificationTemplate> AvailableClassificationCategories(ITreeNode<IClassification> parentClassificationNode) => _observedDataInExplorerPresenter.AvailableObservedDataCategoriesIn(parentClassificationNode);
@@ -182,8 +181,7 @@ namespace MoBi.Presentation.Presenter.Main
          {
             _view.DestroyNodes();
 
-            _view.AddNode(_treeNodeFactory.CreateFor(MoBiRootNodeTypes.PKSimModuleFolder));
-            _view.AddNode(_treeNodeFactory.CreateFor(MoBiRootNodeTypes.ExtensionModulesFolder));
+            _view.AddNode(_treeNodeFactory.CreateFor(MoBiRootNodeTypes.ModulesFolder));
             _view.AddNode(_treeNodeFactory.CreateFor(MoBiRootNodeTypes.ExpressionProfilesFolder));
             _view.AddNode(_treeNodeFactory.CreateFor(MoBiRootNodeTypes.IndividualsFolder));
             _view.AddNode(_treeNodeFactory.CreateFor(RootNodeTypes.ObservedDataFolder));
@@ -206,7 +204,7 @@ namespace MoBi.Presentation.Presenter.Main
 
       private void addModule(Module module)
       {
-         _view.AddNode(_treeNodeFactory.CreateFor(module).Under(_view.NodeByType(MoBiRootNodeTypes.ExtensionModulesFolder)));
+         _view.AddNode(_treeNodeFactory.CreateFor(module).Under(_view.NodeByType(MoBiRootNodeTypes.ModulesFolder)));
       }
 
       public void Handle(AddedEvent eventToHandle)

--- a/src/MoBi.Presentation/Repositories/ButtonGroupRepository.cs
+++ b/src/MoBi.Presentation/Repositories/ButtonGroupRepository.cs
@@ -175,7 +175,7 @@ namespace MoBi.Presentation.Repositories
          .WithId(ButtonGroupIds.Export);
 
       private IButtonGroup buildingBlocksButtonGroup => CreateButtonGroup.WithCaption(AppConstants.BarNames.BuildingBlocks)
-         .WithButton(CreateRibbonButton.From(_menuBarItemRepository.Find(MenuBarItemIds.NewExtensionModule)).WithCaption(AppConstants.RibbonButtonNames.NewExtensionModule))
+         .WithButton(CreateRibbonButton.From(_menuBarItemRepository.Find(MenuBarItemIds.NewModule)).WithCaption(AppConstants.RibbonButtonNames.NewModule))
          .WithButton(CreateRibbonButton.From(_menuBarItemRepository.Find(MenuBarItemIds.NewExpressionProfile))
             .WithSubItem(_menuBarItemRepository.Find(MenuBarItemIds.NewMetabolizingEnzyme))
             .WithSubItem(_menuBarItemRepository.Find(MenuBarItemIds.NewTransportProtein))

--- a/src/MoBi.Presentation/Repositories/MenuBarItemRepository.cs
+++ b/src/MoBi.Presentation/Repositories/MenuBarItemRepository.cs
@@ -235,9 +235,9 @@ namespace MoBi.Presentation.Repositories
             .WithIcon(ApplicationIcons.Individual);
 
          yield return CreateMenuButton.WithCaption(AppConstants.Captions.Module)
-            .WithId(MenuBarItemIds.NewExtensionModule)
+            .WithId(MenuBarItemIds.NewModule)
             .WithCommand<NewModuleWithBuildingBlocksUICommand>(_container)
-            .WithDescription(ToolTips.ModelingRibbon.CreateExtensionModule)
+            .WithDescription(ToolTips.ModelingRibbon.CreateModule)
             .WithIcon(ApplicationIcons.Module);
 
          yield return CreateMenuButton.WithCaption(AppConstants.Captions.ExpressionProfile)

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.170" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.173" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.170" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.173" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.170" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.173" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.170" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.173" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/ModuleExplorerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ModuleExplorerPresenterSpecs.cs
@@ -185,17 +185,14 @@ namespace MoBi.Presentation
       private ITreeNode<SpatialStructure> _spatialStructureA;
       private ITreeNode<RootNodeType> _spatialStructureRootNode;
       private ITreeNode<RootNodeType> _moduleNode;
-      private ITreeNode<RootNodeType> _pkSimModuleNode;
-      private ITreeNode<RootNodeType> _extensionModuleNode;
 
       protected override void Context()
       {
          base.Context();
-         _moduleNode = _treeNodeFactory.CreateFor(MoBiRootNodeTypes.PKSimModuleFolder);
+         
          _spatialStructureA = _treeNodeFactory.CreateFor<SpatialStructure>(new SpatialStructure().WithName("A"));
          _spatialStructureRootNode = _treeNodeFactory.CreateFor(MoBiRootNodeTypes.SpatialStructureFolder);
-         _pkSimModuleNode = _treeNodeFactory.CreateFor(MoBiRootNodeTypes.PKSimModuleFolder);
-         _extensionModuleNode = _treeNodeFactory.CreateFor(MoBiRootNodeTypes.ExtensionModulesFolder);
+         _moduleNode = _treeNodeFactory.CreateFor(MoBiRootNodeTypes.ModulesFolder);
       }
 
       [Observation]
@@ -203,13 +200,6 @@ namespace MoBi.Presentation
       {
          sut.OrderingComparisonFor(_moduleNode, _spatialStructureRootNode).ShouldBeEqualTo(-1);
          sut.OrderingComparisonFor(_moduleNode, _spatialStructureA).ShouldBeEqualTo(-1);
-      }
-
-      [Observation]
-      public void should_order_pksim_module_first()
-      {
-         sut.OrderingComparisonFor(_pkSimModuleNode, _extensionModuleNode).ShouldBeEqualTo(-1);
-         sut.OrderingComparisonFor((_extensionModuleNode), _pkSimModuleNode).ShouldBeEqualTo(1);
       }
    }
 
@@ -361,7 +351,7 @@ namespace MoBi.Presentation
          _allNodesAdded.Count(x => x.TagAsObject.Equals(_module1.MoleculeStartValuesCollection.ElementAt(0))).ShouldBeEqualTo(1);
 
          // Make sure nodes have not been added for null items
-         _allNodesAdded.Count.ShouldBeEqualTo(11);
+         _allNodesAdded.Count.ShouldBeEqualTo(10);
       }
    }
 

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.170" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.170" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.173" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.173" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Removing the references to 'Extension' from some spots in the UI.

Module Explorer gets one folder instead of two
New ribbon buttons just get a text change.