### PR TITLE
Fixes #962 Create Simulation Layout and workflow

### DIFF
--- a/src/MoBi.UI/Views/CreateSimulationConfigurationView.Designer.cs
+++ b/src/MoBi.UI/Views/CreateSimulationConfigurationView.Designer.cs
@@ -35,6 +35,9 @@
          this.layoutControlGroup1 = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutControlItem1 = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemName = new DevExpress.XtraLayout.LayoutControlItem();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlBase)).BeginInit();
+         this.layoutControlBase.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItemBase)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
          this.layoutControl.SuspendLayout();
@@ -45,6 +48,40 @@
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemName)).BeginInit();
          this.SuspendLayout();
          // 
+         // btnPrevious
+         // 
+         this.btnPrevious.Location = new System.Drawing.Point(567, 12);
+         this.btnPrevious.Size = new System.Drawing.Size(163, 22);
+         // 
+         // btnNext
+         // 
+         this.btnNext.Location = new System.Drawing.Point(734, 12);
+         this.btnNext.Size = new System.Drawing.Size(123, 22);
+         // 
+         // btnOk
+         // 
+         this.btnOk.Location = new System.Drawing.Point(861, 12);
+         this.btnOk.Size = new System.Drawing.Size(98, 22);
+         // 
+         // btnCancel
+         // 
+         this.btnCancel.Location = new System.Drawing.Point(963, 12);
+         this.btnCancel.Size = new System.Drawing.Size(223, 22);
+         // 
+         // layoutControlBase
+         // 
+         this.layoutControlBase.Location = new System.Drawing.Point(0, 722);
+         this.layoutControlBase.OptionsCustomizationForm.DesignTimeCustomizationFormPositionAndSize = new System.Drawing.Rectangle(574, 236, 650, 400);
+         this.layoutControlBase.Size = new System.Drawing.Size(1198, 46);
+         this.layoutControlBase.Controls.SetChildIndex(this.btnPrevious, 0);
+         this.layoutControlBase.Controls.SetChildIndex(this.btnNext, 0);
+         this.layoutControlBase.Controls.SetChildIndex(this.btnOk, 0);
+         this.layoutControlBase.Controls.SetChildIndex(this.btnCancel, 0);
+         // 
+         // emptySpaceItemBase
+         // 
+         this.emptySpaceItemBase.Size = new System.Drawing.Size(555, 26);
+         // 
          // layoutControl
          // 
          this.layoutControl.AllowCustomization = false;
@@ -54,7 +91,7 @@
          this.layoutControl.Location = new System.Drawing.Point(0, 0);
          this.layoutControl.Name = "layoutControl";
          this.layoutControl.Root = this.layoutControlGroup1;
-         this.layoutControl.Size = new System.Drawing.Size(606, 697);
+         this.layoutControl.Size = new System.Drawing.Size(1198, 722);
          this.layoutControl.TabIndex = 5;
          this.layoutControl.Text = "layoutControl1";
          // 
@@ -62,14 +99,14 @@
          // 
          this.tabWizard.Location = new System.Drawing.Point(12, 36);
          this.tabWizard.Name = "tabWizard";
-         this.tabWizard.Size = new System.Drawing.Size(582, 649);
+         this.tabWizard.Size = new System.Drawing.Size(1174, 674);
          this.tabWizard.TabIndex = 5;
          // 
          // tbName
          // 
-         this.tbName.Location = new System.Drawing.Point(94, 12);
+         this.tbName.Location = new System.Drawing.Point(103, 12);
          this.tbName.Name = "tbName";
-         this.tbName.Size = new System.Drawing.Size(500, 20);
+         this.tbName.Size = new System.Drawing.Size(1083, 20);
          this.tbName.StyleController = this.layoutControl;
          this.tbName.TabIndex = 4;
          // 
@@ -81,10 +118,8 @@
          this.layoutControlGroup1.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
             this.layoutControlItem1,
             this.layoutItemName});
-         this.layoutControlGroup1.Location = new System.Drawing.Point(0, 0);
          this.layoutControlGroup1.Name = "layoutControlGroup1";
-         this.layoutControlGroup1.Size = new System.Drawing.Size(606, 697);
-         this.layoutControlGroup1.Text = "layoutControlGroup1";
+         this.layoutControlGroup1.Size = new System.Drawing.Size(1198, 722);
          this.layoutControlGroup1.TextVisible = false;
          // 
          // layoutControlItem1
@@ -93,10 +128,8 @@
          this.layoutControlItem1.CustomizationFormText = "layoutControlItem1";
          this.layoutControlItem1.Location = new System.Drawing.Point(0, 24);
          this.layoutControlItem1.Name = "layoutControlItem1";
-         this.layoutControlItem1.Size = new System.Drawing.Size(586, 653);
-         this.layoutControlItem1.Text = "layoutControlItem1";
+         this.layoutControlItem1.Size = new System.Drawing.Size(1178, 678);
          this.layoutControlItem1.TextSize = new System.Drawing.Size(0, 0);
-         this.layoutControlItem1.TextToControlDistance = 0;
          this.layoutControlItem1.TextVisible = false;
          // 
          // layoutItemName
@@ -105,20 +138,23 @@
          this.layoutItemName.CustomizationFormText = "layoutItemName";
          this.layoutItemName.Location = new System.Drawing.Point(0, 0);
          this.layoutItemName.Name = "layoutItemName";
-         this.layoutItemName.Size = new System.Drawing.Size(586, 24);
-         this.layoutItemName.Text = "layoutItemName";
+         this.layoutItemName.Size = new System.Drawing.Size(1178, 24);
          this.layoutItemName.TextSize = new System.Drawing.Size(79, 13);
          // 
-         // CreateSimulationView
+         // CreateSimulationConfigurationView
          // 
          this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
          this.Caption = "CreateSimulationView";
-         this.ClientSize = new System.Drawing.Size(606, 743);
+         this.ClientSize = new System.Drawing.Size(1198, 768);
          this.Controls.Add(this.layoutControl);
          this.Name = "CreateSimulationConfigurationView";
          this.Text = "CreateSimulationView";
+         this.Controls.SetChildIndex(this.layoutControlBase, 0);
          this.Controls.SetChildIndex(this.layoutControl, 0);
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlBase)).EndInit();
+         this.layoutControlBase.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItemBase)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
          this.layoutControl.ResumeLayout(false);
@@ -128,6 +164,7 @@
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemName)).EndInit();
          this.ResumeLayout(false);
+         this.PerformLayout();
 
       }
 

--- a/src/MoBi.UI/Views/EditIndividualAndExpressionConfigurationsView.Designer.cs
+++ b/src/MoBi.UI/Views/EditIndividualAndExpressionConfigurationsView.Designer.cs
@@ -77,14 +77,14 @@
          this.uxLayoutControl1.Name = "uxLayoutControl1";
          this.uxLayoutControl1.OptionsCustomizationForm.DesignTimeCustomizationFormPositionAndSize = new System.Drawing.Rectangle(1087, 142, 650, 400);
          this.uxLayoutControl1.Root = this.Root;
-         this.uxLayoutControl1.Size = new System.Drawing.Size(623, 434);
+         this.uxLayoutControl1.Size = new System.Drawing.Size(1100, 650);
          this.uxLayoutControl1.TabIndex = 0;
          this.uxLayoutControl1.Text = "uxLayoutControl1";
          // 
          // simulationExpressionsTree
          // 
          this.simulationExpressionsTree.IsLatched = false;
-         this.simulationExpressionsTree.Location = new System.Drawing.Point(352, 114);
+         this.simulationExpressionsTree.Location = new System.Drawing.Point(603, 116);
          this.simulationExpressionsTree.Name = "simulationExpressionsTree";
          this.simulationExpressionsTree.OptionsBehavior.Editable = false;
          this.simulationExpressionsTree.OptionsMenu.ShowExpandCollapseItems = false;
@@ -92,29 +92,29 @@
          this.simulationExpressionsTree.OptionsView.ShowHorzLines = false;
          this.simulationExpressionsTree.OptionsView.ShowIndicator = false;
          this.simulationExpressionsTree.OptionsView.ShowVertLines = false;
-         this.simulationExpressionsTree.Size = new System.Drawing.Size(247, 296);
+         this.simulationExpressionsTree.Size = new System.Drawing.Size(471, 508);
          this.simulationExpressionsTree.TabIndex = 8;
          this.simulationExpressionsTree.ToolTipForNode = null;
          this.simulationExpressionsTree.UseLazyLoading = false;
          // 
          // btnAdd
          // 
-         this.btnAdd.Location = new System.Drawing.Point(261, 251);
+         this.btnAdd.Location = new System.Drawing.Point(501, 350);
          this.btnAdd.Manager = null;
          this.btnAdd.Name = "btnAdd";
          this.btnAdd.Shortcut = System.Windows.Forms.Keys.None;
-         this.btnAdd.Size = new System.Drawing.Size(87, 22);
+         this.btnAdd.Size = new System.Drawing.Size(96, 22);
          this.btnAdd.StyleController = this.uxLayoutControl1;
          this.btnAdd.TabIndex = 7;
          this.btnAdd.Text = "btnAdd";
          // 
          // btnRemove
          // 
-         this.btnRemove.Location = new System.Drawing.Point(261, 277);
+         this.btnRemove.Location = new System.Drawing.Point(501, 376);
          this.btnRemove.Manager = null;
          this.btnRemove.Name = "btnRemove";
          this.btnRemove.Shortcut = System.Windows.Forms.Keys.None;
-         this.btnRemove.Size = new System.Drawing.Size(87, 22);
+         this.btnRemove.Size = new System.Drawing.Size(96, 22);
          this.btnRemove.StyleController = this.uxLayoutControl1;
          this.btnRemove.TabIndex = 6;
          this.btnRemove.Text = "btnRemove";
@@ -124,7 +124,7 @@
          this.projectExpressionsTree.Location = new System.Drawing.Point(24, 114);
          this.projectExpressionsTree.Name = "projectExpressionsTree";
          this.projectExpressionsTree.ShowDescendantNode = true;
-         this.projectExpressionsTree.Size = new System.Drawing.Size(233, 296);
+         this.projectExpressionsTree.Size = new System.Drawing.Size(473, 512);
          this.projectExpressionsTree.TabIndex = 5;
          // 
          // cbIndividualSelection
@@ -134,7 +134,7 @@
          this.cbIndividualSelection.Properties.AllowMouseWheel = false;
          this.cbIndividualSelection.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbIndividualSelection.Size = new System.Drawing.Size(575, 20);
+         this.cbIndividualSelection.Size = new System.Drawing.Size(1052, 20);
          this.cbIndividualSelection.StyleController = this.uxLayoutControl1;
          this.cbIndividualSelection.TabIndex = 4;
          // 
@@ -146,7 +146,7 @@
             this.layoutGroupIndividual,
             this.layoutGroupExpression});
          this.Root.Name = "Root";
-         this.Root.Size = new System.Drawing.Size(623, 434);
+         this.Root.Size = new System.Drawing.Size(1100, 650);
          this.Root.TextVisible = false;
          // 
          // layoutGroupIndividual
@@ -155,15 +155,14 @@
             this.layoutControlItem1});
          this.layoutGroupIndividual.Location = new System.Drawing.Point(0, 0);
          this.layoutGroupIndividual.Name = "layoutGroupIndividual";
-         this.layoutGroupIndividual.Size = new System.Drawing.Size(603, 69);
-         this.layoutGroupIndividual.Text = "layoutGroupIndividual";
+         this.layoutGroupIndividual.Size = new System.Drawing.Size(1080, 69);
          // 
          // layoutControlItem1
          // 
          this.layoutControlItem1.Control = this.cbIndividualSelection;
          this.layoutControlItem1.Location = new System.Drawing.Point(0, 0);
          this.layoutControlItem1.Name = "layoutControlItem1";
-         this.layoutControlItem1.Size = new System.Drawing.Size(579, 24);
+         this.layoutControlItem1.Size = new System.Drawing.Size(1056, 24);
          this.layoutControlItem1.Text = "layoutItemIndividualSelect";
          this.layoutControlItem1.TextSize = new System.Drawing.Size(0, 0);
          this.layoutControlItem1.TextVisible = false;
@@ -179,58 +178,58 @@
             this.layoutItemSimulationExpressions});
          this.layoutGroupExpression.Location = new System.Drawing.Point(0, 69);
          this.layoutGroupExpression.Name = "layoutGroupExpression";
-         this.layoutGroupExpression.Size = new System.Drawing.Size(603, 345);
-         this.layoutGroupExpression.Text = "layoutGroupExpression";
+         this.layoutGroupExpression.Size = new System.Drawing.Size(1080, 561);
          // 
          // layoutItemProjectExpressions
          // 
          this.layoutItemProjectExpressions.Control = this.projectExpressionsTree;
          this.layoutItemProjectExpressions.Location = new System.Drawing.Point(0, 0);
          this.layoutItemProjectExpressions.Name = "layoutItemProjectExpressions";
-         this.layoutItemProjectExpressions.Size = new System.Drawing.Size(237, 300);
+         this.layoutItemProjectExpressions.Size = new System.Drawing.Size(477, 516);
          this.layoutItemProjectExpressions.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemProjectExpressions.TextVisible = false;
          // 
          // emptySpaceItem1
          // 
          this.emptySpaceItem1.AllowHotTrack = false;
-         this.emptySpaceItem1.Location = new System.Drawing.Point(237, 0);
+         this.emptySpaceItem1.Location = new System.Drawing.Point(477, 0);
          this.emptySpaceItem1.Name = "emptySpaceItem1";
-         this.emptySpaceItem1.Size = new System.Drawing.Size(91, 137);
+         this.emptySpaceItem1.Size = new System.Drawing.Size(100, 236);
          this.emptySpaceItem1.TextSize = new System.Drawing.Size(0, 0);
          // 
          // layoutItemAddButton
          // 
          this.layoutItemAddButton.Control = this.btnAdd;
-         this.layoutItemAddButton.Location = new System.Drawing.Point(237, 137);
+         this.layoutItemAddButton.Location = new System.Drawing.Point(477, 236);
          this.layoutItemAddButton.Name = "layoutItemAddButton";
-         this.layoutItemAddButton.Size = new System.Drawing.Size(91, 26);
+         this.layoutItemAddButton.Size = new System.Drawing.Size(100, 26);
          this.layoutItemAddButton.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemAddButton.TextVisible = false;
          // 
          // layoutItemRemoveButton
          // 
          this.layoutItemRemoveButton.Control = this.btnRemove;
-         this.layoutItemRemoveButton.Location = new System.Drawing.Point(237, 163);
+         this.layoutItemRemoveButton.Location = new System.Drawing.Point(477, 262);
          this.layoutItemRemoveButton.Name = "layoutItemRemoveButton";
-         this.layoutItemRemoveButton.Size = new System.Drawing.Size(91, 26);
+         this.layoutItemRemoveButton.Size = new System.Drawing.Size(100, 26);
          this.layoutItemRemoveButton.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemRemoveButton.TextVisible = false;
          // 
          // emptySpaceItem2
          // 
          this.emptySpaceItem2.AllowHotTrack = false;
-         this.emptySpaceItem2.Location = new System.Drawing.Point(237, 189);
+         this.emptySpaceItem2.Location = new System.Drawing.Point(477, 288);
          this.emptySpaceItem2.Name = "emptySpaceItem2";
-         this.emptySpaceItem2.Size = new System.Drawing.Size(91, 111);
+         this.emptySpaceItem2.Size = new System.Drawing.Size(100, 228);
          this.emptySpaceItem2.TextSize = new System.Drawing.Size(0, 0);
          // 
          // layoutItemSimulationExpressions
          // 
          this.layoutItemSimulationExpressions.Control = this.simulationExpressionsTree;
-         this.layoutItemSimulationExpressions.Location = new System.Drawing.Point(328, 0);
+         this.layoutItemSimulationExpressions.Location = new System.Drawing.Point(577, 0);
          this.layoutItemSimulationExpressions.Name = "layoutItemSimulationExpressions";
-         this.layoutItemSimulationExpressions.Size = new System.Drawing.Size(251, 300);
+         this.layoutItemSimulationExpressions.Padding = new DevExpress.XtraLayout.Utils.Padding(4, 4, 4, 4);
+         this.layoutItemSimulationExpressions.Size = new System.Drawing.Size(479, 516);
          this.layoutItemSimulationExpressions.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemSimulationExpressions.TextVisible = false;
          // 
@@ -240,7 +239,7 @@
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
          this.Controls.Add(this.uxLayoutControl1);
          this.Name = "EditIndividualAndExpressionConfigurationsView";
-         this.Size = new System.Drawing.Size(623, 434);
+         this.Size = new System.Drawing.Size(1100, 650);
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.uxLayoutControl1)).EndInit();
          this.uxLayoutControl1.ResumeLayout(false);

--- a/src/MoBi.UI/Views/EditModuleConfigurationsView.Designer.cs
+++ b/src/MoBi.UI/Views/EditModuleConfigurationsView.Designer.cs
@@ -75,7 +75,7 @@
          this.moduleSelectionTreeView.Location = new System.Drawing.Point(24, 45);
          this.moduleSelectionTreeView.Name = "moduleSelectionTreeView";
          this.moduleSelectionTreeView.ShowDescendantNode = true;
-         this.moduleSelectionTreeView.Size = new System.Drawing.Size(474, 699);
+         this.moduleSelectionTreeView.Size = new System.Drawing.Size(463, 699);
          this.moduleSelectionTreeView.TabIndex = 0;
          // 
          // uxLayoutControl1
@@ -90,38 +90,38 @@
          this.uxLayoutControl1.Dock = System.Windows.Forms.DockStyle.Fill;
          this.uxLayoutControl1.Location = new System.Drawing.Point(0, 0);
          this.uxLayoutControl1.Name = "uxLayoutControl1";
-         this.uxLayoutControl1.OptionsCustomizationForm.DesignTimeCustomizationFormPositionAndSize = new System.Drawing.Rectangle(666, 549, 650, 400);
+         this.uxLayoutControl1.OptionsCustomizationForm.DesignTimeCustomizationFormPositionAndSize = new System.Drawing.Rectangle(1674, 938, 650, 864);
          this.uxLayoutControl1.Root = this.Root;
-         this.uxLayoutControl1.Size = new System.Drawing.Size(1166, 768);
+         this.uxLayoutControl1.Size = new System.Drawing.Size(1100, 768);
          this.uxLayoutControl1.TabIndex = 2;
          this.uxLayoutControl1.Text = "uxLayoutControl1";
          // 
          // cbParameterValuesSelection
          // 
-         this.cbParameterValuesSelection.Location = new System.Drawing.Point(660, 700);
+         this.cbParameterValuesSelection.Location = new System.Drawing.Point(649, 700);
          this.cbParameterValuesSelection.Name = "cbParameterValuesSelection";
          this.cbParameterValuesSelection.Properties.AllowMouseWheel = false;
          this.cbParameterValuesSelection.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbParameterValuesSelection.Size = new System.Drawing.Size(482, 20);
+         this.cbParameterValuesSelection.Size = new System.Drawing.Size(427, 20);
          this.cbParameterValuesSelection.StyleController = this.uxLayoutControl1;
          this.cbParameterValuesSelection.TabIndex = 8;
          // 
          // cbInitialConditionsSelection
          // 
-         this.cbInitialConditionsSelection.Location = new System.Drawing.Point(660, 724);
+         this.cbInitialConditionsSelection.Location = new System.Drawing.Point(649, 724);
          this.cbInitialConditionsSelection.Name = "cbInitialConditionsSelection";
          this.cbInitialConditionsSelection.Properties.AllowMouseWheel = false;
          this.cbInitialConditionsSelection.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
             new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
-         this.cbInitialConditionsSelection.Size = new System.Drawing.Size(482, 20);
+         this.cbInitialConditionsSelection.Size = new System.Drawing.Size(427, 20);
          this.cbInitialConditionsSelection.StyleController = this.uxLayoutControl1;
          this.cbInitialConditionsSelection.TabIndex = 7;
          // 
          // selectedModuleTreeView
          // 
          this.selectedModuleTreeView.IsLatched = false;
-         this.selectedModuleTreeView.Location = new System.Drawing.Point(654, 45);
+         this.selectedModuleTreeView.Location = new System.Drawing.Point(617, 47);
          this.selectedModuleTreeView.Name = "selectedModuleTreeView";
          this.selectedModuleTreeView.OptionsBehavior.Editable = false;
          this.selectedModuleTreeView.OptionsMenu.ShowExpandCollapseItems = false;
@@ -129,25 +129,25 @@
          this.selectedModuleTreeView.OptionsView.ShowHorzLines = false;
          this.selectedModuleTreeView.OptionsView.ShowIndicator = false;
          this.selectedModuleTreeView.OptionsView.ShowVertLines = false;
-         this.selectedModuleTreeView.Size = new System.Drawing.Size(488, 606);
+         this.selectedModuleTreeView.Size = new System.Drawing.Size(457, 602);
          this.selectedModuleTreeView.TabIndex = 6;
          this.selectedModuleTreeView.ToolTipForNode = null;
          this.selectedModuleTreeView.UseLazyLoading = false;
          // 
          // btnAdd
          // 
-         this.btnAdd.Location = new System.Drawing.Point(523, 176);
+         this.btnAdd.Location = new System.Drawing.Point(503, 176);
          this.btnAdd.Name = "btnAdd";
-         this.btnAdd.Size = new System.Drawing.Size(106, 22);
+         this.btnAdd.Size = new System.Drawing.Size(96, 22);
          this.btnAdd.StyleController = this.uxLayoutControl1;
          this.btnAdd.TabIndex = 5;
          this.btnAdd.Text = "btnAdd";
          // 
          // btnRemove
          // 
-         this.btnRemove.Location = new System.Drawing.Point(523, 202);
+         this.btnRemove.Location = new System.Drawing.Point(503, 202);
          this.btnRemove.Name = "btnRemove";
-         this.btnRemove.Size = new System.Drawing.Size(106, 22);
+         this.btnRemove.Size = new System.Drawing.Size(96, 22);
          this.btnRemove.StyleController = this.uxLayoutControl1;
          this.btnRemove.TabIndex = 4;
          this.btnRemove.Text = "btnRemove";
@@ -165,43 +165,41 @@
             this.layoutGroupModuleSelection,
             this.layoutGroupSelectedModules});
          this.Root.Name = "Root";
-         this.Root.Size = new System.Drawing.Size(1166, 768);
+         this.Root.Size = new System.Drawing.Size(1100, 768);
          this.Root.TextVisible = false;
          // 
          // layoutItemBtnRemove
          // 
          this.layoutItemBtnRemove.Control = this.btnRemove;
-         this.layoutItemBtnRemove.Location = new System.Drawing.Point(502, 190);
+         this.layoutItemBtnRemove.Location = new System.Drawing.Point(491, 190);
          this.layoutItemBtnRemove.Name = "layoutItemBtnRemove";
-         this.layoutItemBtnRemove.Size = new System.Drawing.Size(128, 26);
-         this.layoutItemBtnRemove.Spacing = new DevExpress.XtraLayout.Utils.Padding(9, 9, 0, 0);
+         this.layoutItemBtnRemove.Size = new System.Drawing.Size(100, 26);
          this.layoutItemBtnRemove.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemBtnRemove.TextVisible = false;
          // 
          // layoutItemBtnAdd
          // 
          this.layoutItemBtnAdd.Control = this.btnAdd;
-         this.layoutItemBtnAdd.Location = new System.Drawing.Point(502, 164);
+         this.layoutItemBtnAdd.Location = new System.Drawing.Point(491, 164);
          this.layoutItemBtnAdd.Name = "layoutItemBtnAdd";
-         this.layoutItemBtnAdd.Size = new System.Drawing.Size(128, 26);
-         this.layoutItemBtnAdd.Spacing = new DevExpress.XtraLayout.Utils.Padding(9, 9, 0, 0);
+         this.layoutItemBtnAdd.Size = new System.Drawing.Size(100, 26);
          this.layoutItemBtnAdd.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemBtnAdd.TextVisible = false;
          // 
          // emptySpaceItem1
          // 
          this.emptySpaceItem1.AllowHotTrack = false;
-         this.emptySpaceItem1.Location = new System.Drawing.Point(502, 0);
+         this.emptySpaceItem1.Location = new System.Drawing.Point(491, 0);
          this.emptySpaceItem1.Name = "emptySpaceItem1";
-         this.emptySpaceItem1.Size = new System.Drawing.Size(128, 164);
+         this.emptySpaceItem1.Size = new System.Drawing.Size(100, 164);
          this.emptySpaceItem1.TextSize = new System.Drawing.Size(0, 0);
          // 
          // emptySpaceItem2
          // 
          this.emptySpaceItem2.AllowHotTrack = false;
-         this.emptySpaceItem2.Location = new System.Drawing.Point(502, 216);
+         this.emptySpaceItem2.Location = new System.Drawing.Point(491, 216);
          this.emptySpaceItem2.Name = "emptySpaceItem2";
-         this.emptySpaceItem2.Size = new System.Drawing.Size(128, 439);
+         this.emptySpaceItem2.Size = new System.Drawing.Size(100, 439);
          this.emptySpaceItem2.TextSize = new System.Drawing.Size(0, 0);
          // 
          // startValuesSelectionGroup
@@ -209,9 +207,9 @@
          this.startValuesSelectionGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
             this.layoutItemPSVSelection,
             this.layoutItemMSVSelection});
-         this.startValuesSelectionGroup.Location = new System.Drawing.Point(502, 655);
+         this.startValuesSelectionGroup.Location = new System.Drawing.Point(491, 655);
          this.startValuesSelectionGroup.Name = "startValuesSelectionGroup";
-         this.startValuesSelectionGroup.Size = new System.Drawing.Size(644, 93);
+         this.startValuesSelectionGroup.Size = new System.Drawing.Size(589, 93);
          this.startValuesSelectionGroup.Spacing = new DevExpress.XtraLayout.Utils.Padding(9, 2, 2, 2);
          // 
          // layoutItemPSVSelection
@@ -219,7 +217,7 @@
          this.layoutItemPSVSelection.Control = this.cbParameterValuesSelection;
          this.layoutItemPSVSelection.Location = new System.Drawing.Point(0, 0);
          this.layoutItemPSVSelection.Name = "layoutItemPSVSelection";
-         this.layoutItemPSVSelection.Size = new System.Drawing.Size(613, 24);
+         this.layoutItemPSVSelection.Size = new System.Drawing.Size(558, 24);
          this.layoutItemPSVSelection.TextSize = new System.Drawing.Size(115, 13);
          // 
          // layoutItemMSVSelection
@@ -227,7 +225,7 @@
          this.layoutItemMSVSelection.Control = this.cbInitialConditionsSelection;
          this.layoutItemMSVSelection.Location = new System.Drawing.Point(0, 24);
          this.layoutItemMSVSelection.Name = "layoutItemMSVSelection";
-         this.layoutItemMSVSelection.Size = new System.Drawing.Size(613, 24);
+         this.layoutItemMSVSelection.Size = new System.Drawing.Size(558, 24);
          this.layoutItemMSVSelection.TextSize = new System.Drawing.Size(115, 13);
          // 
          // layoutGroupModuleSelection
@@ -236,14 +234,14 @@
             this.layoutItemModuleSelection});
          this.layoutGroupModuleSelection.Location = new System.Drawing.Point(0, 0);
          this.layoutGroupModuleSelection.Name = "layoutGroupModuleSelection";
-         this.layoutGroupModuleSelection.Size = new System.Drawing.Size(502, 748);
+         this.layoutGroupModuleSelection.Size = new System.Drawing.Size(491, 748);
          // 
          // layoutItemModuleSelection
          // 
          this.layoutItemModuleSelection.Control = this.moduleSelectionTreeView;
          this.layoutItemModuleSelection.Location = new System.Drawing.Point(0, 0);
          this.layoutItemModuleSelection.Name = "layoutItemModuleSelection";
-         this.layoutItemModuleSelection.Size = new System.Drawing.Size(478, 703);
+         this.layoutItemModuleSelection.Size = new System.Drawing.Size(467, 703);
          this.layoutItemModuleSelection.TextLocation = DevExpress.Utils.Locations.Top;
          this.layoutItemModuleSelection.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemModuleSelection.TextVisible = false;
@@ -252,16 +250,17 @@
          // 
          this.layoutGroupSelectedModules.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
             this.layoutItemSelectedModules});
-         this.layoutGroupSelectedModules.Location = new System.Drawing.Point(630, 0);
+         this.layoutGroupSelectedModules.Location = new System.Drawing.Point(591, 0);
          this.layoutGroupSelectedModules.Name = "layoutGroupSelectedModules";
-         this.layoutGroupSelectedModules.Size = new System.Drawing.Size(516, 655);
+         this.layoutGroupSelectedModules.Size = new System.Drawing.Size(489, 655);
          // 
          // layoutItemSelectedModules
          // 
          this.layoutItemSelectedModules.Control = this.selectedModuleTreeView;
          this.layoutItemSelectedModules.Location = new System.Drawing.Point(0, 0);
          this.layoutItemSelectedModules.Name = "layoutItemSelectedModules";
-         this.layoutItemSelectedModules.Size = new System.Drawing.Size(492, 610);
+         this.layoutItemSelectedModules.Padding = new DevExpress.XtraLayout.Utils.Padding(4, 4, 4, 4);
+         this.layoutItemSelectedModules.Size = new System.Drawing.Size(465, 610);
          this.layoutItemSelectedModules.TextLocation = DevExpress.Utils.Locations.Top;
          this.layoutItemSelectedModules.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemSelectedModules.TextVisible = false;
@@ -272,7 +271,7 @@
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
          this.Controls.Add(this.uxLayoutControl1);
          this.Name = "EditModuleConfigurationsView";
-         this.Size = new System.Drawing.Size(1166, 768);
+         this.Size = new System.Drawing.Size(1100, 768);
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.uxLayoutControl1)).EndInit();
          this.uxLayoutControl1.ResumeLayout(false);


### PR DESCRIPTION

![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/0983f6ed-6cf7-4a39-8908-d34a5e40bdb5)

![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/f766ccaf-38da-4537-94ec-bfa2c8d47588)

Somewhere along the line the auto-select individual was already fixed.

This is just designer changes to make the default view size look more symmetrical