### PR TITLE
Add context menu "new building block" to IC and PV BBs #1015

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.194" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.195" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.194" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.195" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -33,13 +33,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.194" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.195" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.194" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.195" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/DTO/AddBuildingBlocksToModuleDTO.cs
+++ b/src/MoBi.Presentation/DTO/AddBuildingBlocksToModuleDTO.cs
@@ -12,6 +12,8 @@ namespace MoBi.Presentation.DTO
    {
       private readonly List<string> _existingParameterValuesNames;
       private readonly List<string> _existingInitialConditionsNames;
+      private bool _allowOnlyInitialConditions;
+      private bool _allowOnlyParameterValues;
 
       public AddBuildingBlocksToModuleDTO(Module module)
       {
@@ -70,6 +72,28 @@ namespace MoBi.Presentation.DTO
       public bool CreatePassiveTransport => WithPassiveTransport && CanSelectPassiveTransport;
       public bool CreateEventGroup => WithEventGroup && CanSelectEventGroup;
       public bool CreateObserver => WithObserver && CanSelectObserver;
+
+      public bool AllowOnlyParameterValues
+      {
+         get => _allowOnlyParameterValues;
+         set
+         {
+            _allowOnlyParameterValues = value;
+            if (value)
+               WithParameterValues = true;
+         }
+      }
+      
+      public bool AllowOnlyInitialConditions
+      {
+         get => _allowOnlyInitialConditions;
+         set
+         {
+            _allowOnlyInitialConditions = value;
+            if (value)
+               WithInitialConditions = true;
+         }
+      }
 
       public void AddUsedInitialConditionsNames(IReadOnlyList<string> allNames)
       {

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForInitialConditionsFolder.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForInitialConditionsFolder.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using MoBi.Assets;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.UICommand;
+using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.MenuAndBars;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Utility.Extensions;
+using IContainer = OSPSuite.Utility.Container.IContainer;
+
+namespace MoBi.Presentation.MenusAndBars.ContextMenus
+{
+   internal class ContextMenuForInitialConditionsFolder : ContextMenuForModuleBuildingBlockCollection
+   {
+      private readonly IContainer _container;
+
+      public ContextMenuForInitialConditionsFolder(IContainer container)
+      {
+         _container = container;
+         _allMenuItems = new List<IMenuBarItem>();
+      }
+
+      protected override IMenuBarItem AddNewBuildingBlock(Module module)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddNew(ObjectTypes.InitialConditionsBuildingBlock))
+            .WithIcon(ApplicationIcons.LoadIconFor(nameof(InitialConditionsBuildingBlock)))
+            .WithCommandFor<AddNewInitialConditionsBuildingBlockUICommand, Module>(module, _container);
+      }
+   }
+
+   public class ContextMenuSpecificationFactoryForModuleInitialConditionsCollection : IContextMenuSpecificationFactory<IViewItem>
+   {
+      private readonly IContainer _container;
+
+      public ContextMenuSpecificationFactoryForModuleInitialConditionsCollection(IContainer container)
+      {
+         _container = container;
+      }
+
+      public IContextMenu CreateFor(IViewItem viewItem, IPresenterWithContextMenu<IViewItem> presenter)
+      {
+         var contextMenu = new ContextMenuForInitialConditionsFolder(_container);
+         return contextMenu.InitializeWith(viewItem.DowncastTo<ModuleViewItem>(), presenter);
+      }
+
+      public bool IsSatisfiedBy(IViewItem viewItem, IPresenterWithContextMenu<IViewItem> presenter)
+      {
+         if (!(viewItem is ModuleViewItem moduleViewItem))
+            return false;
+
+         return moduleViewItem.TargetAsObject.IsAnImplementationOf<IEnumerable<InitialConditionsBuildingBlock>>();
+      }
+   }
+}

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForModuleBuildingBlockCollection.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForModuleBuildingBlockCollection.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using MoBi.Presentation.DTO;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.MenuAndBars;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Utility.Extensions;
+
+namespace MoBi.Presentation.MenusAndBars.ContextMenus
+{
+   internal abstract class ContextMenuForModuleBuildingBlockCollection : ContextMenuBase, IContextMenuFor<ModuleViewItem>
+   {
+      protected List<IMenuBarItem> _allMenuItems;
+
+      public override IEnumerable<IMenuBarItem> AllMenuItems()
+      {
+         return _allMenuItems;
+      }
+      
+      public virtual IContextMenu InitializeWith(ObjectBaseDTO dto, IPresenter presenter)
+      {
+         _allMenuItems.Add(AddNewBuildingBlock(ModuleFor(dto)));
+         return this;
+      }
+
+      protected static Module ModuleFor(ObjectBaseDTO dto)
+      {
+         var collectionViewItem = dto.DowncastTo<ModuleViewItem>();
+         var module = collectionViewItem.Module;
+         return module;
+      }
+
+      protected abstract IMenuBarItem AddNewBuildingBlock(Module module);
+   }
+}

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForParameterValuesFolder.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForParameterValuesFolder.cs
@@ -14,10 +14,9 @@ using IContainer = OSPSuite.Utility.Container.IContainer;
 
 namespace MoBi.Presentation.MenusAndBars.ContextMenus
 {
-   internal class ContextMenuForParameterValuesFolder : ContextMenuBase, IContextMenuFor<ModuleViewItem>
+   internal class ContextMenuForParameterValuesFolder : ContextMenuForModuleBuildingBlockCollection
    {
       private readonly IContainer _container;
-      private readonly List<IMenuBarItem> _allMenuItems;
 
       public ContextMenuForParameterValuesFolder(IContainer container)
       {
@@ -25,22 +24,23 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          _allMenuItems = new List<IMenuBarItem>();
       }
 
-      public override IEnumerable<IMenuBarItem> AllMenuItems()
+      public override IContextMenu InitializeWith(ObjectBaseDTO dto, IPresenter presenter)
       {
-         return _allMenuItems;
+         base.InitializeWith(dto, presenter);
+         _allMenuItems.Add(createAddExpressionAsParameterValueBuildingBlock(ModuleFor(dto)));
+         return this;
       }
 
-      public IContextMenu InitializeWith(ObjectBaseDTO dto, IPresenter presenter)
+      protected override IMenuBarItem AddNewBuildingBlock(Module module)
       {
-         var psvCollectionViewItem = dto.DowncastTo<ModuleViewItem>();
-         var module = psvCollectionViewItem.Module;
-         _allMenuItems.Add(createAddExpressionAsParameterValueBuildingBlock(module));
-         return this;
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddNew(ObjectTypes.ParameterValuesBuildingBlock))
+            .WithIcon(ApplicationIcons.LoadIconFor(nameof(ParameterValuesBuildingBlock)))
+            .WithCommandFor<AddNewParameterValuesBuildingBlockUICommand, Module>(module, _container);
       }
 
       private IMenuBarItem createAddExpressionAsParameterValueBuildingBlock(Module module)
       {
-         return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddExisting(ObjectTypes.ExpressionProfileBuildingBlock)).AsGroupStarter()
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddExisting(ObjectTypes.ExpressionProfileBuildingBlock))
             .WithIcon(ApplicationIcons.LoadIconFor(nameof(ExpressionProfileBuildingBlock)))
             .WithCommandFor<AddExpressionAsParameterValuesCommand, Module>(module, _container);
       }

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.194" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.195" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Nodes/InitialConditionsFolderNode.cs
+++ b/src/MoBi.Presentation/Nodes/InitialConditionsFolderNode.cs
@@ -1,4 +1,5 @@
 ﻿using MoBi.Assets;
+using MoBi.Presentation.DTO;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Presentation.Nodes;
@@ -6,9 +7,9 @@ using OSPSuite.Utility;
 
 namespace MoBi.Presentation.Nodes
 {
-   public class InitialConditionsFolderNode : AbstractNode<Classification>
+   public class InitialConditionsFolderNode : AbstractNode<ModuleViewItem>
    {
-      public InitialConditionsFolderNode() : base(new Classification())
+      public InitialConditionsFolderNode(Module module) : base(new ModuleViewItem(module).WithTarget(module.InitialConditionsCollection))
       {
          Id = ShortGuid.NewGuid();
          Text = AppConstants.Captions.InitialConditions;

--- a/src/MoBi.Presentation/Nodes/TreeNodeFactory.cs
+++ b/src/MoBi.Presentation/Nodes/TreeNodeFactory.cs
@@ -84,7 +84,7 @@ namespace MoBi.Presentation.Nodes
          var parameterValuesFolderNode = new ParameterValuesFolderNode(module).Under(moduleNode);
          module.ParameterValuesCollection.Each(psv => { createAndAddNodeUnder(parameterValuesFolderNode, psv); });
 
-         var initialConditionsFolderNode = new InitialConditionsFolderNode().Under(moduleNode);
+         var initialConditionsFolderNode = new InitialConditionsFolderNode(module).Under(moduleNode);
          module.InitialConditionsCollection.Each(msv => createAndAddNodeUnder(initialConditionsFolderNode, msv));
       }
 

--- a/src/MoBi.Presentation/Presenter/AddBuildingBlocksToModulePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/AddBuildingBlocksToModulePresenter.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using MoBi.Assets;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;
@@ -13,6 +13,8 @@ namespace MoBi.Presentation.Presenter
    public interface IAddBuildingBlocksToModulePresenter : IDisposablePresenter
    {
       IReadOnlyList<IBuildingBlock> AddBuildingBlocksToModule(Module module);
+      IReadOnlyList<IBuildingBlock> AddInitialConditionsToModule(Module module);
+      IReadOnlyList<IBuildingBlock> AddParameterValuesToModule(Module module);
    }
 
    public class AddBuildingBlocksToModulePresenter : AbstractDisposablePresenter<IAddBuildingBlocksToModuleView, IAddBuildingBlocksToModulePresenter>,
@@ -31,9 +33,15 @@ namespace MoBi.Presentation.Presenter
 
       public IReadOnlyList<IBuildingBlock> AddBuildingBlocksToModule(Module module)
       {
+         return addBuildingBlocksToModule(module);
+      }
+
+      private IReadOnlyList<IBuildingBlock> addBuildingBlocksToModule(Module module, Action<AddBuildingBlocksToModuleDTO> configureDTOAction = null)
+      {
          _view.Caption = AppConstants.Captions.AddBuildingBlocksToModule(module.Name);
 
          var addBuildingBlocksToModuleDTO = _moduleToAddBuildingBlocksToModuleDTOMapper.MapFrom(module);
+         configureDTOAction?.Invoke(addBuildingBlocksToModuleDTO);
 
          _view.BindTo(addBuildingBlocksToModuleDTO);
          _view.Display();
@@ -42,6 +50,16 @@ namespace MoBi.Presentation.Presenter
             return new List<IBuildingBlock>();
 
          return _addBuildingBlocksToModuleDTOToBuildingBlocksListMapper.MapFrom(addBuildingBlocksToModuleDTO);
+      }
+
+      public IReadOnlyList<IBuildingBlock> AddParameterValuesToModule(Module module)
+      {
+         return addBuildingBlocksToModule(module, dto => dto.AllowOnlyParameterValues = true);
+      }
+
+      public IReadOnlyList<IBuildingBlock> AddInitialConditionsToModule(Module module)
+      {
+         return addBuildingBlocksToModule(module, dto => dto.AllowOnlyInitialConditions = true);
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/Main/ExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/ExplorerPresenter.cs
@@ -72,7 +72,7 @@ namespace MoBi.Presentation.Presenter.Main
 
       public override void NodeDoubleClicked(ITreeNode node)
       {
-         if (IsFolderNode(node) || IsModuleNode(node))
+         if (IsExpandable(node))
          {
             base.NodeDoubleClicked(node);
             return;

--- a/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
@@ -67,6 +67,11 @@ namespace MoBi.Presentation.Presenter.Main
          return base.ContextMenuFor(treeNode);
       }
 
+      protected override bool IsExpandable(ITreeNode node)
+      {
+         return base.IsExpandable(node) || node.IsAnImplementationOf<ParameterValuesFolderNode>() || node.IsAnImplementationOf<InitialConditionsFolderNode>();
+      }
+
       public override void NodeDoubleClicked(ITreeNode node)
       {
          var moleculeBuilder = node.TagAsObject as MoleculeBuilder;

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForModule.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForModule.cs
@@ -23,6 +23,8 @@ namespace MoBi.Presentation.Tasks.Interaction
       void LoadBuildingBlocksFromTemplateToModule(Module module);
       void RemoveModule(Module module);
       void AddCloneToProject(Module moduleToClone);
+      void AddNewInitialConditionsBuildingBlock(Module module);
+      void AddNewParameterValuesBuildingBlock(Module module);
    }
 
    public class InteractionTasksForModule : InteractionTasksForChildren<MoBiProject, Module>, IInteractionTasksForModule
@@ -72,9 +74,14 @@ namespace MoBi.Presentation.Tasks.Interaction
 
       public void AddBuildingBlocksToModule(Module module)
       {
+         addBuildingBlocksToModule(module, presenter => presenter.AddBuildingBlocksToModule(module));
+      }
+
+      private void addBuildingBlocksToModule(Module module, Func<IAddBuildingBlocksToModulePresenter, IReadOnlyList<IBuildingBlock>> buildingBlockCreator)
+      {
          using (var presenter = _interactionTaskContext.ApplicationController.Start<IAddBuildingBlocksToModulePresenter>())
          {
-            var listOfNewBuildingBlocks = presenter.AddBuildingBlocksToModule(module);
+            var listOfNewBuildingBlocks = buildingBlockCreator(presenter);
 
             if (!listOfNewBuildingBlocks.Any())
                return;
@@ -82,6 +89,16 @@ namespace MoBi.Presentation.Tasks.Interaction
             context.AddToHistory(GetAddBuildingBlocksToModuleCommand(module, listOfNewBuildingBlocks)
                .Run(context));
          }
+      }
+
+      public void AddNewParameterValuesBuildingBlock(Module module)
+      {
+         addBuildingBlocksToModule(module, presenter => presenter.AddParameterValuesToModule(module));
+      }
+
+      public void AddNewInitialConditionsBuildingBlock(Module module)
+      {
+         addBuildingBlocksToModule(module, presenter => presenter.AddInitialConditionsToModule(module));
       }
 
       public void LoadBuildingBlocksToModule(Module module)

--- a/src/MoBi.Presentation/UICommand/AddNewInitialConditionsBuildingBlockUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/AddNewInitialConditionsBuildingBlockUICommand.cs
@@ -1,0 +1,20 @@
+﻿using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   internal class AddNewInitialConditionsBuildingBlockUICommand : ObjectUICommand<Module>
+   {
+      private readonly IInteractionTasksForModule _interactionTasks;
+
+      public AddNewInitialConditionsBuildingBlockUICommand(IInteractionTasksForModule interactionTasks)
+      {
+         _interactionTasks = interactionTasks;
+      }
+      protected override void PerformExecute()
+      {
+         _interactionTasks.AddNewInitialConditionsBuildingBlock(Subject);
+      }
+   }
+}

--- a/src/MoBi.Presentation/UICommand/AddNewParameterValuesBuildingBlockUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/AddNewParameterValuesBuildingBlockUICommand.cs
@@ -1,0 +1,21 @@
+﻿using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   internal class AddNewParameterValuesBuildingBlockUICommand : ObjectUICommand<Module>
+   {
+      private readonly IInteractionTasksForModule _interactionTasks;
+
+      public AddNewParameterValuesBuildingBlockUICommand(IInteractionTasksForModule interactionTasks)
+      {
+         _interactionTasks = interactionTasks;
+      }
+
+      protected override void PerformExecute()
+      {
+         _interactionTasks.AddNewParameterValuesBuildingBlock(Subject);
+      }
+   }
+}

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.194" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.195" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/Views/AddBuildingBlocksToModuleView.cs
+++ b/src/MoBi.UI/Views/AddBuildingBlocksToModuleView.cs
@@ -1,10 +1,13 @@
-﻿using DevExpress.XtraLayout;
+﻿using System.Collections.Generic;
+using System.Drawing;
+using DevExpress.XtraLayout;
 using DevExpress.XtraLayout.Utils;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Views;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
+using OSPSuite.Utility.Extensions;
 
 namespace MoBi.UI.Views
 {
@@ -24,6 +27,15 @@ namespace MoBi.UI.Views
          _screenBinder.Bind(x => x.InitialConditionsName).To(tbInitialConditionsName);
       }
 
+      public override void BindTo(AddBuildingBlocksToModuleDTO moduleContentDTO)
+      {
+         base.BindTo(moduleContentDTO);
+         if (moduleContentDTO.AllowOnlyInitialConditions)
+            adjustViewForOnlyInitialConditions();
+         if (moduleContentDTO.AllowOnlyParameterValues)
+            adjustViewForOnlyParameterValues();
+      }
+
       protected override void StartValueCheckChanged(bool enabled, LayoutControlItem namingLayoutControlItem)
       {
          namingLayoutControlItem.Visibility = LayoutVisibilityConvertor.FromBoolean(enabled);
@@ -32,13 +44,46 @@ namespace MoBi.UI.Views
       public void AttachPresenter(IAddBuildingBlocksToModulePresenter presenter)
       {
       }
+
+      public void adjustViewForOnlyParameterValues()
+      {
+         ShowStartValueNameControls();
+         cbParameterValues.Checked = true;
+         cbParameterValues.Enabled = false;
+
+         hideAllItemsExcept(new List<BaseLayoutItem> { parameterValuesNameItem, parameterValuesItem });
+      }
+
+      public void adjustViewForOnlyInitialConditions()
+      {
+         ShowStartValueNameControls();
+         cbInitialConditions.Checked = true;
+         cbInitialConditions.Enabled = false;
+
+         hideAllItemsExcept(new List<BaseLayoutItem> { initialConditionsNameItem, initialConditionsItem });
+      }
+
+      private void adjustHeight(int heightAdjustment)
+      {
+         Size = new Size(Width, Height + heightAdjustment);
+      }
+
+      private void hideAllItemsExcept(List<BaseLayoutItem> itemsToShow)
+      {
+         var initialGroupHeight = createBuildingBlocksGroup.Size.Height;
+         createBuildingBlocksGroup.Items.Each(item =>
+         {
+            if (!itemsToShow.Contains(item))
+               item.Visibility = LayoutVisibility.Never;
+         });
+         adjustHeight(createBuildingBlocksGroup.Size.Height - initialGroupHeight);
+      }
    }
 
    public class CreateModuleView : BaseModuleContentView<ModuleContentDTO>, ICreateModuleView
    {
       public void AttachPresenter(ICreateModulePresenter presenter)
       {
-
       }
    }
 
@@ -47,7 +92,6 @@ namespace MoBi.UI.Views
    {
       public void AttachPresenter(ICloneBuildingBlocksToModulePresenter presenter)
       {
-         
       }
    }
 }

--- a/src/MoBi.UI/Views/AddBuildingBlocksToModuleView.cs
+++ b/src/MoBi.UI/Views/AddBuildingBlocksToModuleView.cs
@@ -76,6 +76,9 @@ namespace MoBi.UI.Views
             if (!itemsToShow.Contains(item))
                item.Visibility = LayoutVisibility.Never;
          });
+
+         // Adjust the height of the dialog box by the amount of height lost by hiding
+         // all the items except the ones we want to show.
          adjustHeight(createBuildingBlocksGroup.Size.Height - initialGroupHeight);
       }
    }

--- a/src/MoBi.UI/Views/BaseModuleContentView.Designer.cs
+++ b/src/MoBi.UI/Views/BaseModuleContentView.Designer.cs
@@ -455,17 +455,17 @@
       protected DevExpress.XtraLayout.LayoutControlItem passiveTransportsItem;
       protected DevExpress.XtraLayout.LayoutControlItem observersItem;
       protected DevExpress.XtraLayout.LayoutControlItem eventGroupItem;
-      private DevExpress.XtraLayout.LayoutControlGroup createBuildingBlocksGroup;
+      protected DevExpress.XtraLayout.LayoutControlGroup createBuildingBlocksGroup;
       protected DevExpress.XtraLayout.LayoutControlItem spatialStructureItem;
       protected DevExpress.XtraEditors.CheckEdit cbMolecules;
       protected DevExpress.XtraLayout.LayoutControlItem moleculesItem;
-      private DevExpress.XtraEditors.CheckEdit cbParameterValues;
-      private DevExpress.XtraEditors.CheckEdit cbInitialConditions;
-      private DevExpress.XtraLayout.LayoutControlItem initialConditionsItem;
-      private DevExpress.XtraLayout.LayoutControlItem parameterValuesItem;
+      protected DevExpress.XtraEditors.CheckEdit cbParameterValues;
+      protected DevExpress.XtraEditors.CheckEdit cbInitialConditions;
+      protected DevExpress.XtraLayout.LayoutControlItem initialConditionsItem;
+      protected DevExpress.XtraLayout.LayoutControlItem parameterValuesItem;
       protected DevExpress.XtraEditors.TextEdit tbInitialConditionsName;
       protected DevExpress.XtraEditors.TextEdit tbParameterValuesName;
-      private DevExpress.XtraLayout.LayoutControlItem parameterValuesNameItem;
+      protected DevExpress.XtraLayout.LayoutControlItem parameterValuesNameItem;
       protected DevExpress.XtraLayout.LayoutControlItem initialConditionsNameItem;
    }
 }

--- a/src/MoBi.UI/Views/BaseModuleContentView.cs
+++ b/src/MoBi.UI/Views/BaseModuleContentView.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using DevExpress.XtraLayout;
+﻿using DevExpress.XtraLayout;
 using DevExpress.XtraLayout.Utils;
 using MoBi.Assets;
 using MoBi.Presentation.DTO;

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.194" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.195" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.194" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.195" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.194" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.195" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/ModuleExplorerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ModuleExplorerPresenterSpecs.cs
@@ -192,8 +192,9 @@ namespace MoBi.Presentation
          
          _spatialStructureA = _treeNodeFactory.CreateFor<SpatialStructure>(new SpatialStructure().WithName("A"));
          _moduleNode = _treeNodeFactory.CreateFor(MoBiRootNodeTypes.ModulesFolder);
-         _parameterValuesFolderNode = new ParameterValuesFolderNode(new Module());
-         _initialConditionsFolderNode = new InitialConditionsFolderNode();
+         var module = new Module();
+         _parameterValuesFolderNode = new ParameterValuesFolderNode(module);
+         _initialConditionsFolderNode = new InitialConditionsFolderNode(module);
       }
 
       [Observation]

--- a/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForModuleSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForModuleSpecs.cs
@@ -158,6 +158,90 @@ namespace MoBi.Presentation.Tasks
       }
    }
 
+   public class When_adding_new_building_blocks : concern_for_InteractionTasksForModule
+   {
+      private Module _module;
+      private IAddBuildingBlocksToModulePresenter _addBuildingBlocksToModulePresenter;
+      private IReadOnlyList<IBuildingBlock> _newBuildingBlocks;
+
+      protected override void Context()
+      {
+         base.Context();
+         _module = new Module();
+         _newBuildingBlocks = new List<IBuildingBlock> { new InitialConditionsBuildingBlock() };
+         _addBuildingBlocksToModulePresenter = A.Fake<IAddBuildingBlocksToModulePresenter>();
+         A.CallTo(() => _context.ApplicationController.Start<IAddBuildingBlocksToModulePresenter>()).Returns(_addBuildingBlocksToModulePresenter);
+         A.CallTo(() => _addBuildingBlocksToModulePresenter.AddBuildingBlocksToModule(_module)).Returns(_newBuildingBlocks);
+      }
+
+      protected override void Because()
+      {
+         sut.AddBuildingBlocksToModule(_module);
+      }
+
+      [Observation]
+      public void the_task_adds_building_blocks_with_commands()
+      {
+         A.CallTo(() => _context.Context.AddToHistory(A<AddMultipleBuildingBlocksToModuleCommand>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_adding_initial_conditions_building_blocks : concern_for_InteractionTasksForModule
+   {
+      private Module _module;
+      private IAddBuildingBlocksToModulePresenter _addBuildingBlocksToModulePresenter;
+      private IReadOnlyList<IBuildingBlock> _newBuildingBlocks;
+
+      protected override void Context()
+      {
+         base.Context();
+         _module = new Module();
+         _newBuildingBlocks = new List<IBuildingBlock> { new InitialConditionsBuildingBlock() };
+         _addBuildingBlocksToModulePresenter = A.Fake<IAddBuildingBlocksToModulePresenter>();
+         A.CallTo(() => _context.ApplicationController.Start<IAddBuildingBlocksToModulePresenter>()).Returns(_addBuildingBlocksToModulePresenter);
+         A.CallTo(() => _addBuildingBlocksToModulePresenter.AddInitialConditionsToModule(_module)).Returns(_newBuildingBlocks);
+      }
+
+      protected override void Because()
+      {
+         sut.AddNewInitialConditionsBuildingBlock(_module);
+      }
+
+      [Observation]
+      public void the_task_adds_building_blocks_with_commands()
+      {
+         A.CallTo(() => _context.Context.AddToHistory(A<AddMultipleBuildingBlocksToModuleCommand>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_adding_parameter_values_building_blocks : concern_for_InteractionTasksForModule
+   {
+      private Module _module;
+      private IAddBuildingBlocksToModulePresenter _addBuildingBlocksToModulePresenter;
+      private IReadOnlyList<IBuildingBlock> _newBuildingBlocks;
+
+      protected override void Context()
+      {
+         base.Context();
+         _module = new Module();
+         _newBuildingBlocks = new List<IBuildingBlock> { new ParameterValuesBuildingBlock() };
+         _addBuildingBlocksToModulePresenter = A.Fake<IAddBuildingBlocksToModulePresenter>();
+         A.CallTo(() => _context.ApplicationController.Start<IAddBuildingBlocksToModulePresenter>()).Returns(_addBuildingBlocksToModulePresenter);
+         A.CallTo(() => _addBuildingBlocksToModulePresenter.AddParameterValuesToModule(_module)).Returns(_newBuildingBlocks);
+      }
+
+      protected override void Because()
+      {
+         sut.AddNewParameterValuesBuildingBlock(_module);
+      }
+
+      [Observation]
+      public void the_task_adds_building_blocks_with_commands()
+      {
+         A.CallTo(() => _context.Context.AddToHistory(A<AddMultipleBuildingBlocksToModuleCommand>._)).MustHaveHappened();
+      }
+   }
+
    public class When_loading_from_PKML_an_observer_BB : concern_for_InteractionTasksForModule
    {
       private Module _module;

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.194" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.194" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.195" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.195" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Re-using the standard "AddBuildingBlocks" dialog to add either Parameter Values or Initial Conditions building blocks when a user right clicks on the folder node.

Also, double click expands/contracts the folder node similar to other collector/folder nodes