### PR TITLE
Fixes #1052 Update/Commit - sync red/green checks with building block versions

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.205" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.209" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.205" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.209" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />

--- a/src/MoBi.Core/Domain/Extensions/BuildingBlockExtensions.cs
+++ b/src/MoBi.Core/Domain/Extensions/BuildingBlockExtensions.cs
@@ -33,14 +33,33 @@ namespace MoBi.Core.Domain.Extensions
          return formulaCache.ToList();
       }
 
+      /// <summary>
+      /// Checks that the names, types, and names of the containing module (if any) match <paramref name="name"/>
+      /// </summary>
       public static bool IsTemplateMatchFor(this IBuildingBlock buildingBlock, IBuildingBlock templateBuildingBlock, string name)
       {
-         return buildingBlock.IsNamed(name) && buildingBlock.GetType() == templateBuildingBlock.GetType();
+         return buildingBlock.IsNamed(name) && buildingBlock.GetType() == templateBuildingBlock.GetType() && buildingBlockModulesAreTemplateMatch(buildingBlock, templateBuildingBlock);
       }
 
+      /// <summary>
+      /// Checks that the names, types, and names of the containing module (if any) match
+      /// </summary>
       public static bool IsTemplateMatchFor(this IBuildingBlock buildingBlock, IBuildingBlock templateBuildingBlock)
       {
          return IsTemplateMatchFor(buildingBlock, templateBuildingBlock, templateBuildingBlock.Name);
+      }
+
+      private static bool buildingBlockModulesAreTemplateMatch(IBuildingBlock buildingBlock, IBuildingBlock templateBuildingBlock)
+      {
+         switch (buildingBlock.Module)
+         {
+            case null when templateBuildingBlock.Module == null:
+               return true;
+            case null:
+               return false;
+         }
+
+         return templateBuildingBlock.Module != null && buildingBlock.Module.IsNamed(templateBuildingBlock.Module.Name);
       }
    }
 

--- a/src/MoBi.Core/Domain/Model/MoBiSimulation.cs
+++ b/src/MoBi.Core/Domain/Model/MoBiSimulation.cs
@@ -107,7 +107,7 @@ namespace MoBi.Core.Domain.Model
 
       private bool usesModuleBuildingBlock(IBuildingBlock templateBuildingBlock)
       {
-         return BuildingBlocks().Any(buildingBlock => buildingBlock.Module.IsNamed(templateBuildingBlock.Module.Name) && buildingBlock.IsTemplateMatchFor(templateBuildingBlock));
+         return BuildingBlocks().Any(buildingBlock => buildingBlock.IsTemplateMatchFor(templateBuildingBlock));
       }
 
       public IReadOnlyList<Module> Modules => Configuration.ModuleConfigurations.Select(x => x.Module).ToList();

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -33,13 +33,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.205" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.209" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/Services/SimulationConfigurationFactory.cs
+++ b/src/MoBi.Core/Services/SimulationConfigurationFactory.cs
@@ -30,8 +30,7 @@ namespace MoBi.Core.Services
             SimulationSettings = _cloneManager.Clone(_projectRetriever.Current.SimulationSettings)
          };
 
-         _calculationMethodRepository.All().Each(
-            cm => simulationConfiguration.AddCalculationMethod(_cloneManager.Clone(cm)));
+         _calculationMethodRepository.All().Each(simulationConfiguration.AddCalculationMethod);
 
          return simulationConfiguration;
       }

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.205" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.209" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.205" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.209" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Nodes/BuildingBlockNode.cs
+++ b/src/MoBi.Presentation/Nodes/BuildingBlockNode.cs
@@ -1,0 +1,15 @@
+﻿using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Presentation.Presenters.Nodes;
+
+namespace MoBi.Presentation.Nodes
+{
+   public class BuildingBlockNode : ObjectWithIdAndNameNode<IBuildingBlock> 
+   {
+      public BuildingBlockNode(IBuildingBlock buildingBlock) : base(buildingBlock)
+      {
+         BaseIcon = buildingBlock.Icon;
+      }
+
+      public string BaseIcon { get; }
+   }
+}

--- a/src/MoBi.Presentation/Nodes/TreeNodeFactory.cs
+++ b/src/MoBi.Presentation/Nodes/TreeNodeFactory.cs
@@ -88,7 +88,7 @@ namespace MoBi.Presentation.Nodes
          var expressionProfileFolderNode = new ExpressionProfileFolderNode();
          var nodes = simulationConfiguration.ModuleConfigurations.Select(moduleConfiguration => CreateFor(new ModuleConfigurationDTO(moduleConfiguration))).ToList();
          if (simulationConfiguration.Individual != null)
-            nodes.Add(createWithIcon(simulationConfiguration.Individual));
+            nodes.Add(CreateFor(simulationConfiguration.Individual));
 
          simulationConfiguration.ExpressionProfiles.Each(x => createAndAddNodeUnder(expressionProfileFolderNode, x));
          nodes.Add(expressionProfileFolderNode);
@@ -169,13 +169,8 @@ namespace MoBi.Presentation.Nodes
             return;
 
          // TODO this used to use buildingBlockInfo to create the tree SIMULATION_CONFIGURATION
-         createWithIcon(buildingBlock)
+         CreateFor(buildingBlock)
             .Under(rootNode);
-      }
-
-      private ITreeNode createWithIcon(IBuildingBlock buildingBlock)
-      {
-         return CreateFor(buildingBlock);
       }
 
       public ITreeNode CreateFor(CurveChart chart)

--- a/src/MoBi.Presentation/Nodes/TreeNodeFactory.cs
+++ b/src/MoBi.Presentation/Nodes/TreeNodeFactory.cs
@@ -55,11 +55,6 @@ namespace MoBi.Presentation.Nodes
          var simNode = new SimulationNode(classifiableSimulation);
          var simulation = classifiableSimulation.Simulation;
 
-
-         //TODO SIMULATION_CONFIGURATION
-         // if (simulation.MoBiBuildConfiguration.HasChangedBuildingBlocks())
-         //    simNode.Icon = ApplicationIcons.SimulationRed;
-
          createFor(simulation.Configuration).Each(x => simNode.AddChild(x));
 
          if (simulation.ResultsDataRepository != null)
@@ -136,12 +131,12 @@ namespace MoBi.Presentation.Nodes
          if (buildingBlock is MoleculeBuildingBlock moleculeBuildingBlock)
             return CreateFor(moleculeBuildingBlock);
 
-         return createFor(buildingBlock);
+         return createForBuildingBlock(buildingBlock);
       }
 
       public ITreeNode CreateFor(MoleculeBuildingBlock moleculeBuildingBlock)
       {
-         var moleculeBuildingBlockNode = createFor(moleculeBuildingBlock);
+         var moleculeBuildingBlockNode = createForBuildingBlock(moleculeBuildingBlock);
          foreach (var molecule in moleculeBuildingBlock)
          {
             var moleculeNode = CreateFor(molecule);
@@ -154,6 +149,12 @@ namespace MoBi.Presentation.Nodes
       public ITreeNode CreateFor(MoleculeBuilder moleculeBuilder)
       {
          return createFor(moleculeBuilder);
+      }
+
+      private ITreeNode createForBuildingBlock(IBuildingBlock buildingBlock) 
+      {
+         return new BuildingBlockNode(buildingBlock)
+            .WithIcon(ApplicationIcons.IconByName(buildingBlock.Icon));
       }
 
       private ITreeNode createFor<T>(T objectBase) where T : class, IObjectBase
@@ -174,13 +175,7 @@ namespace MoBi.Presentation.Nodes
 
       private ITreeNode createWithIcon(IBuildingBlock buildingBlock)
       {
-         var statusIcon = ApplicationIcons.GreenOverlayFor(buildingBlock.Icon);
-         // var statusIcon = buildingBlockInfo.BuildingBlockChanged
-         //    ? ApplicationIcons.RedOverlayFor(buildingBlock.Icon)
-         //    : ApplicationIcons.GreenOverlayFor(buildingBlock.Icon);
-
-         return CreateFor(buildingBlock)
-            .WithIcon(statusIcon);
+         return CreateFor(buildingBlock);
       }
 
       public ITreeNode CreateFor(CurveChart chart)

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Commands;
+using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
 using MoBi.Core.Events;
@@ -26,6 +27,8 @@ namespace MoBi.Presentation.Tasks.Interaction
       /// </summary>
       /// <returns>The executed command used to perform the removal</returns>
       IMoBiCommand RemoveMultipleSimulations(IReadOnlyList<IMoBiSimulation> simulations);
+
+      IBuildingBlock TemplateBuildingBlockFor(IBuildingBlock buildingBlock);
    }
 
    public class InteractionTasksForSimulation : InteractionTasksForChildren<MoBiProject, IMoBiSimulation>, IInteractionTasksForSimulation
@@ -74,6 +77,15 @@ namespace MoBi.Presentation.Tasks.Interaction
          });
 
          return macroCommand;
+      }
+
+      public IBuildingBlock TemplateBuildingBlockFor(IBuildingBlock buildingBlock)
+      {
+         // In the repository, there should always be exactly one template match. A template match requires
+         // building block name/type and module name match. There could be multiple building blocks with the
+         // same name and type but they would have to have different parent modules. For building blocks
+         // without a parent module, two building blocks cannot have the same name and type
+         return BuildingBlockRepository.All().Single(x => x.IsTemplateMatchFor(buildingBlock));
       }
 
       public IMoBiCommand CreateSimulation()

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.205" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.209" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.205" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.209" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.205" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.209" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/Core/Service/RenameInSimulationTaskSpecs.cs
+++ b/tests/MoBi.Tests/Core/Service/RenameInSimulationTaskSpecs.cs
@@ -107,7 +107,6 @@ namespace MoBi.Core.Service
          _project.AddSimulation(_simulation1);
          _project.AddSimulation(_simulation2);
          _templateBuildingBlock = new IndividualBuildingBlock().WithName("Individual");
-         _templateBuildingBlock.Module = new Module().WithName("moduleName");
       }
 
       private static ModuleConfiguration createModuleConfiguration()

--- a/tests/MoBi.Tests/Core/Service/SimulationConfigurationFactorySpecs.cs
+++ b/tests/MoBi.Tests/Core/Service/SimulationConfigurationFactorySpecs.cs
@@ -16,7 +16,9 @@ namespace MoBi.Core.Service
       private IMoBiProjectRetriever _projectRetriever;
       protected SimulationSettings _clonedSimulationSettings;
       private MoBiProject _currentProject;
-      protected CoreCalculationMethod _clonedMethod1, _clonedMethod2, _clonedMethod3;
+      protected CoreCalculationMethod _method3;
+      protected CoreCalculationMethod _method2;
+      protected CoreCalculationMethod _method1;
 
       protected override void Context()
       {
@@ -34,22 +36,14 @@ namespace MoBi.Core.Service
          A.CallTo(() => _projectRetriever.Current).Returns(_currentProject);
          A.CallTo(() => _cloneManager.Clone(_currentProject.SimulationSettings)).Returns(_clonedSimulationSettings);
 
-         var method1 = new CoreCalculationMethod();
-         _calculationMethodRepository.AddCalculationMethod(method1);
-         var method2 = new CoreCalculationMethod();
-         _calculationMethodRepository.AddCalculationMethod(method2);
-         var method3 = new CoreCalculationMethod();
-         _calculationMethodRepository.AddCalculationMethod(method3);
-
-         _clonedMethod1 = new CoreCalculationMethod();
-         _clonedMethod2 = new CoreCalculationMethod();
-         _clonedMethod3 = new CoreCalculationMethod();
-         A.CallTo(() => _cloneManager.Clone(method1)).Returns(_clonedMethod1);
-         A.CallTo(() => _cloneManager.Clone(method2)).Returns(_clonedMethod2);
-         A.CallTo(() => _cloneManager.Clone(method3)).Returns(_clonedMethod3);
+         _method1 = new CoreCalculationMethod();
+         _calculationMethodRepository.AddCalculationMethod(_method1);
+         _method2 = new CoreCalculationMethod();
+         _calculationMethodRepository.AddCalculationMethod(_method2);
+         _method3 = new CoreCalculationMethod();
+         _calculationMethodRepository.AddCalculationMethod(_method3);
 
          sut = new SimulationConfigurationFactory(_calculationMethodRepository, _cloneManager, _projectRetriever);
-
       }
    }
 
@@ -63,9 +57,9 @@ namespace MoBi.Core.Service
       }
 
       [Observation]
-      public void the_simulation_configuration_should_contain_clones_of_the_calculation_methods()
+      public void the_simulation_configuration_should_contain_the_original_calculation_methods()
       {
-         _simulationConfiguration.AllCalculationMethods.ShouldOnlyContain(_clonedMethod1, _clonedMethod2, _clonedMethod3);
+         _simulationConfiguration.AllCalculationMethods.ShouldOnlyContain(_method1, _method2, _method3);
       }
 
       [Observation]

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.205" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.209" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.205" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.205" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.209" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.209" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
This is just the start of working on update/commit.

For this first step, I just want to get the green/red checks working when the user updates the template building block.

In that case it's just a simple check of BuildingBlock version.

But you do not have the direct link between simulation building blocks and template building blocks that you had in version 11. Instead, we have to find the matching template based on parent module, building block name and type. Once found, the versions can be compared.