### PR TITLE
Fixes #1064 Simulation Configuration Building Block context menus

### DIFF
--- a/src/MoBi.Presentation/DTO/ObjectBaseDTO.cs
+++ b/src/MoBi.Presentation/DTO/ObjectBaseDTO.cs
@@ -132,6 +132,16 @@ namespace MoBi.Presentation.DTO
       }
    }
 
+   public class SimulationBuildingBlockViewItem : IViewItem
+   {
+      public IBuildingBlock BuildingBlock { get; }
+
+      public SimulationBuildingBlockViewItem(IBuildingBlock buildingBlockNode)
+      {
+         BuildingBlock = buildingBlockNode;
+      }
+   }
+
    public class SimulationViewItem : ObjectBaseDTO
    {
       public IMoBiSimulation Simulation { get; }

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForSimulationBuildingBlock.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForSimulationBuildingBlock.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using MoBi.Core.Services;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.UICommand;
+using OSPSuite.Assets;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.MenuAndBars;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
+
+namespace MoBi.Presentation.MenusAndBars.ContextMenus
+{
+   public class ContextMenuForSimulationBuildingBlock :  ContextMenuBase
+   {
+      private readonly IContainer _container;
+      private readonly IList<IMenuBarItem> _allMenuItems;
+      private readonly ITemplateResolverTask _templateResolverTask;
+
+      public ContextMenuForSimulationBuildingBlock(IContainer container)
+      {
+         _container = container;
+         _templateResolverTask = _container.Resolve<ITemplateResolverTask>();
+         _allMenuItems = new List<IMenuBarItem>();
+      }
+
+      public IContextMenu InitializeWith(SimulationBuildingBlockViewItem viewItem, IPresenterWithContextMenu<IViewItem> presenter)
+      {
+         var buildingBlockViewItem = viewItem.DowncastTo<SimulationBuildingBlockViewItem>();
+
+         var simulationBuildingBlock = buildingBlockViewItem.BuildingBlock;
+         var projectBuildingBlock = _templateResolverTask.TemplateBuildingBlockFor(simulationBuildingBlock);
+         if (projectBuildingBlock.Version != simulationBuildingBlock.Version)
+         {
+            _allMenuItems.Add(createDiffItem(simulationBuildingBlock));
+         }
+         
+
+         return this;
+      }
+
+      private IMenuBarItem createDiffItem(IBuildingBlock simulationBuildingBlock)
+      {
+         var item = CreateMenuButton.WithCaption(MenuNames.Diff)
+            .WithCommand(_container.Resolve<ShowBuildingBlockDiffUICommand>().Initialize(simulationBuildingBlock))
+            .WithIcon(ApplicationIcons.Comparison);
+         
+         return item;
+      }
+
+      public override IEnumerable<IMenuBarItem> AllMenuItems()
+      {
+         return _allMenuItems;
+      }
+   }
+
+   public class ContextMenuSpecificationFactoryForSimulationBuildingBlockViewItem : IContextMenuSpecificationFactory<IViewItem>
+   {
+      private readonly IContainer _container;
+
+      public ContextMenuSpecificationFactoryForSimulationBuildingBlockViewItem(IContainer container)
+      {
+         _container = container;
+      }
+
+      public IContextMenu CreateFor(IViewItem viewItem, IPresenterWithContextMenu<IViewItem> presenter)
+      {
+         var contextMenu = new ContextMenuForSimulationBuildingBlock(_container);
+         return contextMenu.InitializeWith(viewItem.DowncastTo<SimulationBuildingBlockViewItem>(), presenter);
+      }
+
+      public bool IsSatisfiedBy(IViewItem viewItem, IPresenterWithContextMenu<IViewItem> presenter)
+      {
+         return viewItem is SimulationBuildingBlockViewItem;
+      }
+   }
+}

--- a/src/MoBi.Presentation/Presenter/Main/SimulationExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/SimulationExplorerPresenter.cs
@@ -161,6 +161,11 @@ namespace MoBi.Presentation.Presenter.Main
          if (treeNode.TagAsObject is ClassifiableSimulation simulation)
             return ContextMenuFor(new SimulationViewItem(simulation.Simulation));
 
+         if (treeNode.TagAsObject is IBuildingBlock buildingBlock)
+         {
+            return ContextMenuFor(new SimulationBuildingBlockViewItem(buildingBlock));
+         }
+
          return base.ContextMenuFor(treeNode);
       }
 

--- a/src/MoBi.Presentation/Tasks/SimulationComparisonTask.cs
+++ b/src/MoBi.Presentation/Tasks/SimulationComparisonTask.cs
@@ -7,7 +7,7 @@ namespace MoBi.Presentation.Tasks
 {
    public interface ISimulationComparisonTask
    {
-      void ShowDifferencesBetween(IBuildingBlock templateBuildingBlock, IBuildingBlock simulationBuildingBlock);
+      void ShowDifferencesBetween(IBuildingBlock projectBuildingBlock, IBuildingBlock simulationBuildingBlock);
    }
 
    public class SimulationComparisonTask : ISimulationComparisonTask
@@ -19,9 +19,9 @@ namespace MoBi.Presentation.Tasks
          _eventPublisher = eventPublisher;
       }
 
-      public void ShowDifferencesBetween(IBuildingBlock templateBuildingBlock, IBuildingBlock simulationBuildingBlock)
+      public void ShowDifferencesBetween(IBuildingBlock projectBuildingBlock, IBuildingBlock simulationBuildingBlock)
       {
-         _eventPublisher.PublishEvent(new StartComparisonEvent(templateBuildingBlock, simulationBuildingBlock, leftCaption: ObjectTypes.BuildingBlock, rightCaption: ObjectTypes.Simulation));
+         _eventPublisher.PublishEvent(new StartComparisonEvent(projectBuildingBlock, simulationBuildingBlock, leftCaption: ObjectTypes.BuildingBlock, rightCaption: ObjectTypes.Simulation));
       }
    }
 }

--- a/src/MoBi.Presentation/UICommand/ShowBuildingBlockDiffUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/ShowBuildingBlockDiffUICommand.cs
@@ -1,5 +1,5 @@
 ﻿using OSPSuite.Presentation.MenuAndBars;
-using MoBi.Core.Domain.Model;
+using MoBi.Core.Services;
 using MoBi.Presentation.Tasks;
 using OSPSuite.Core.Domain.Builder;
 
@@ -8,26 +8,24 @@ namespace MoBi.Presentation.UICommand
    public class ShowBuildingBlockDiffUICommand : IUICommand
    {
       private readonly ISimulationComparisonTask _simulationComparisonTask;
-      private IBuildingBlock _templateBuildingBlock;
-      private IMoBiSimulation _simulation;
+      private IBuildingBlock _simulationBuildingBlock;
+      private readonly ITemplateResolverTask _templateResolverTask;
 
-      public ShowBuildingBlockDiffUICommand(ISimulationComparisonTask simulationComparisonTask)
+      public ShowBuildingBlockDiffUICommand(ISimulationComparisonTask simulationComparisonTask, ITemplateResolverTask templateResolverTask)
       {
+         _templateResolverTask = templateResolverTask;
          _simulationComparisonTask = simulationComparisonTask;
       }
 
-      public ShowBuildingBlockDiffUICommand Initialize(IBuildingBlock templateBuildingBlock, IMoBiSimulation simulation)
+      public ShowBuildingBlockDiffUICommand Initialize(IBuildingBlock simulationBuildingBlock)
       {
-         _templateBuildingBlock = templateBuildingBlock;
-         _simulation = simulation;
+         _simulationBuildingBlock = simulationBuildingBlock;
          return this;
       }
 
       public void Execute()
       {
-         // var buildingBlockInfo = _simulation.MoBiBuildConfiguration.BuildingInfoForTemplate(_templateBuildingBlock);
-         // var simulationBuildingBlock = buildingBlockInfo.UntypedBuildingBlock;
-         // _simulationComparisonTask.ShowDifferencesBetween(_templateBuildingBlock, simulationBuildingBlock);
+         _simulationComparisonTask.ShowDifferencesBetween(_templateResolverTask.TemplateBuildingBlockFor(_simulationBuildingBlock), _simulationBuildingBlock);
       }
    }
 }


### PR DESCRIPTION
I think that only 'Show Differences' is necessary right now. We haven't committed to updating single building blocks to my knowledge.

That can be easily added to the context menu if we decide.