### PR TITLE
1067 simulation status when a module is updated

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.214" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.213" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.213" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.214" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />

--- a/src/MoBi.Core/Commands/ModuleContentChangedCommand.cs
+++ b/src/MoBi.Core/Commands/ModuleContentChangedCommand.cs
@@ -29,12 +29,7 @@ namespace MoBi.Core.Commands
       {
          var projectRetriever = context.Resolve<IMoBiProjectRetriever>();
          var affectedSimulations = projectRetriever.Current.SimulationsUsing(changedModule);
-         affectedSimulations.Each(x => refreshSimulation(x, context));
-      }
-
-      private void refreshSimulation(IMoBiSimulation simulation, IMoBiContext context)
-      {
-         context.PublishEvent(new SimulationStatusChangedEvent(simulation));
+         affectedSimulations.Each(x => context.PublishEvent(new SimulationStatusChangedEvent(x)));
       }
 
       protected override void ClearReferences()

--- a/src/MoBi.Core/Commands/ModuleContentChangedCommand.cs
+++ b/src/MoBi.Core/Commands/ModuleContentChangedCommand.cs
@@ -1,6 +1,5 @@
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
-using MoBi.Core.Services;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Utility.Extensions;
@@ -27,8 +26,7 @@ namespace MoBi.Core.Commands
 
       protected void PublishSimulationStatusChangedEvents(Module changedModule, IMoBiContext context)
       {
-         var projectRetriever = context.Resolve<IMoBiProjectRetriever>();
-         var affectedSimulations = projectRetriever.Current.SimulationsUsing(changedModule);
+         var affectedSimulations = context.CurrentProject.SimulationsUsing(changedModule);
          affectedSimulations.Each(x => context.PublishEvent(new SimulationStatusChangedEvent(x)));
       }
 

--- a/src/MoBi.Core/Commands/ModuleContentChangedCommand.cs
+++ b/src/MoBi.Core/Commands/ModuleContentChangedCommand.cs
@@ -1,0 +1,46 @@
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Events;
+using MoBi.Core.Services;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Utility.Extensions;
+
+namespace MoBi.Core.Commands
+{
+   public abstract class ModuleContentChangedCommand<T> : MoBiReversibleCommand where T : class, IBuildingBlock
+   {
+      protected Module _existingModule;
+      private readonly string _existingModuleId;
+      protected T _buildingBlock;
+
+      protected ModuleContentChangedCommand(T buildingBlock, Module existingModule)
+      {
+         _existingModule = existingModule;
+         _existingModuleId = existingModule.Id;
+         _buildingBlock = buildingBlock;
+      }
+
+      public override void RestoreExecutionData(IMoBiContext context)
+      {
+         _existingModule = context.Get<Module>(_existingModuleId);
+      }
+
+      protected void PublishSimulationStatusChangedEvents(Module changedModule, IMoBiContext context)
+      {
+         var projectRetriever = context.Resolve<IMoBiProjectRetriever>();
+         var affectedSimulations = projectRetriever.Current.SimulationsUsing(changedModule);
+         affectedSimulations.Each(x => refreshSimulation(x, context));
+      }
+
+      private void refreshSimulation(IMoBiSimulation simulation, IMoBiContext context)
+      {
+         context.PublishEvent(new SimulationStatusChangedEvent(simulation));
+      }
+
+      protected override void ClearReferences()
+      {
+         _buildingBlock = null;
+         _existingModule = null;
+      }
+   }
+}

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -33,13 +33,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.213" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.0-VbqML" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -33,13 +33,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.214" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/Services/TemplateResolverTask.cs
+++ b/src/MoBi.Core/Services/TemplateResolverTask.cs
@@ -23,14 +23,9 @@ namespace MoBi.Core.Services
          _moBiProjectRetriever = moBiProjectRetriever;
       }
 
-      public TBuildingBlock TemplateBuildingBlockFor<TBuildingBlock>(TBuildingBlock buildingBlock) where TBuildingBlock : class, IBuildingBlock
-      {
-         return _buildingBlockRepository.All().Single(x => x.IsTemplateMatchFor(buildingBlock)) as TBuildingBlock;
-      }
+      public TBuildingBlock TemplateBuildingBlockFor<TBuildingBlock>(TBuildingBlock buildingBlock) where TBuildingBlock : class, IBuildingBlock => 
+         _buildingBlockRepository.All().Single(x => x.IsTemplateMatchFor(buildingBlock)) as TBuildingBlock;
 
-      public Module TemplateModuleFor(Module module)
-      {
-         return _moBiProjectRetriever.Current.ModuleByName(module.Name);
-      }
+      public Module TemplateModuleFor(Module module) => _moBiProjectRetriever.Current.ModuleByName(module.Name);
    }
 }

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.214" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.213" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-VbqML" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/DTO/ModuleConfigurationDTO.cs
+++ b/src/MoBi.Presentation/DTO/ModuleConfigurationDTO.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Utility.Reflection;

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.213" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.214" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Nodes/ModuleConfigurationNode.cs
+++ b/src/MoBi.Presentation/Nodes/ModuleConfigurationNode.cs
@@ -13,6 +13,8 @@ namespace MoBi.Presentation.Nodes
          Text = moduleConfiguration.Module.Name;
       }
 
+      public string ModuleName => Tag.Module.Name;
+
       protected override void UpdateText()
       {
          Text = Tag.Module.Name;

--- a/src/MoBi.Presentation/Nodes/ModuleConfigurationNode.cs
+++ b/src/MoBi.Presentation/Nodes/ModuleConfigurationNode.cs
@@ -1,4 +1,5 @@
 ﻿using MoBi.Presentation.DTO;
+using OSPSuite.Assets;
 using OSPSuite.Presentation.Nodes;
 
 namespace MoBi.Presentation.Nodes
@@ -18,5 +19,6 @@ namespace MoBi.Presentation.Nodes
       }
 
       public override string Id { get; }
+      public ApplicationIcon BaseIcon => ApplicationIcons.Module;
    }
 }

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
@@ -10,6 +10,7 @@ using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Edit;
 using OSPSuite.Assets;
 using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Services;
@@ -31,7 +32,9 @@ namespace MoBi.Presentation.Tasks.Interaction
       /// <summary>
       ///    Returns the project building block that matches <paramref name="buildingBlock" />
       /// </summary>
-      IBuildingBlock TemplateBuildingBlockFor(IBuildingBlock buildingBlock);
+      TBuildingBlock TemplateBuildingBlockFor<TBuildingBlock>(TBuildingBlock buildingBlock) where TBuildingBlock : class, IBuildingBlock;
+
+      Module TemplateModuleFor(Module module);
    }
 
    public class InteractionTasksForSimulation : InteractionTasksForChildren<MoBiProject, IMoBiSimulation>, IInteractionTasksForSimulation
@@ -85,13 +88,18 @@ namespace MoBi.Presentation.Tasks.Interaction
          return macroCommand;
       }
 
-      public IBuildingBlock TemplateBuildingBlockFor(IBuildingBlock buildingBlock)
+      public TBuildingBlock TemplateBuildingBlockFor<TBuildingBlock>(TBuildingBlock buildingBlock) where TBuildingBlock : class, IBuildingBlock
       {
          // In the repository, there should always be exactly one template match. A template match requires
          // building block name/type and module name match. There could be multiple building blocks with the
          // same name and type but they would have to have different parent modules. For building blocks
          // without a parent module, two building blocks cannot have the same name and type
          return _templateResolverTask.TemplateBuildingBlockFor(buildingBlock);
+      }
+
+      public Module TemplateModuleFor(Module module)
+      {
+         return _templateResolverTask.TemplateModuleFor(module);
       }
 
       public IMoBiCommand CreateSimulation()

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.214" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.0.0.4" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.213" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.213" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.213" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-VbqML" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.214" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-VbqML" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.214" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/Core/Commands/AddBuildingBlockToModuleCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/AddBuildingBlockToModuleCommandSpecs.cs
@@ -1,7 +1,6 @@
 using FakeItEasy;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
-using MoBi.Core.Services;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -14,7 +13,6 @@ namespace MoBi.Core.Commands
       protected EventGroupBuildingBlock _bb;
       protected Module _existingModule;
       protected IMoBiContext _context;
-      private IMoBiProjectRetriever _projectRetriever;
       protected IMoBiSimulation _affectedSimulation;
       private MoBiProject _project;
 
@@ -25,11 +23,9 @@ namespace MoBi.Core.Commands
          _project = new MoBiProject();
          _existingModule = new Module().WithId("existingModuleId");
          _affectedSimulation.Configuration.AddModuleConfiguration(new ModuleConfiguration(_existingModule));
-         _projectRetriever = A.Fake<IMoBiProjectRetriever>();
          _context = A.Fake<IMoBiContext>();
-         A.CallTo(() => _context.Resolve<IMoBiProjectRetriever>()).Returns(_projectRetriever);
          _project.AddSimulation(_affectedSimulation);
-         A.CallTo(() => _projectRetriever.Current).Returns(_project);
+         A.CallTo(() => _context.CurrentProject).Returns(_project);
          _bb = new EventGroupBuildingBlock().WithId("newEventGroupBuildingBlockId");
          sut = new AddBuildingBlockToModuleCommand<IBuildingBlock>(_bb, _existingModule);
       }

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.213" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-VbqML" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.214" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.214" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.214" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.213" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.213" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-VbqML" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-VbqML" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
If you add a building block to a module simulations using that module should be marked as out of sync.

Special attention for initial conditions and parameter values, because the module can have multiple instances, but only one can be in use in a simulation so adding those does not change the sync status.

Remove is similar, except it is also not possible to remove a building block from a module if the building block is in use. Again, only IC's and PV's can be removed from a module that's in use, and only if they are not selected.