### PR TITLE
Fixes #1090 SynchronizeParameterValueCommand does not undo the changes

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -261,6 +261,7 @@ namespace MoBi.Assets
          public static readonly string ParameterType = "parameter";
          public static readonly string UpdateRelativeExpressions = "Update relative expressions";
          public static readonly string UpdateProjectDefaultSimulationSettings = "Update project default simulation settings";
+         public static readonly string RemoveTrackedQuantityChanges = "Remove tracked quantity changes";
 
          public static string DeleteResultsFromSimulation(string simulationName)
          {

--- a/src/MoBi.Core/Commands/ClearOriginalQuantitiesTrackerCommand.cs
+++ b/src/MoBi.Core/Commands/ClearOriginalQuantitiesTrackerCommand.cs
@@ -1,0 +1,31 @@
+﻿using MoBi.Assets;
+using MoBi.Core.Domain.Model;
+using OSPSuite.Assets;
+
+namespace MoBi.Core.Commands
+{
+   public class ClearOriginalQuantitiesTrackerCommand : MoBiCommand
+   {
+      private IMoBiSimulation _simulation;
+
+      public ClearOriginalQuantitiesTrackerCommand(IMoBiSimulation simulation)
+      {
+         _simulation = simulation;
+         ObjectType = ObjectTypes.Simulation;
+         Description = AppConstants.Commands.RemoveTrackedQuantityChanges;
+         CommandType = AppConstants.Commands.DeleteCommand;
+         
+         Visible = false;
+      }
+
+      protected override void ExecuteWith(IMoBiContext context)
+      {
+         _simulation.ClearOriginalQuantities();
+      }
+
+      protected override void ClearReferences()
+      {
+         _simulation = null;
+      }
+   }
+}

--- a/src/MoBi.Core/Commands/SynchronizeInitialConditionCommand.cs
+++ b/src/MoBi.Core/Commands/SynchronizeInitialConditionCommand.cs
@@ -4,6 +4,7 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using MoBi.Assets;
+using OSPSuite.Assets;
 
 namespace MoBi.Core.Commands
 {
@@ -25,6 +26,8 @@ namespace MoBi.Core.Commands
          _quantityId = quantity.Id;
          _initialCondition = initialCondition;
          _moleculeAmount = quantity as MoleculeAmount ?? quantity.ParentContainer as MoleculeAmount;
+         ObjectType = ObjectTypes.InitialCondition;
+         CommandType = AppConstants.Commands.UpdateCommand;
       }
 
       protected override void ExecuteWith(IMoBiContext context)

--- a/src/MoBi.Core/Commands/SynchronizeParameterValueCommand.cs
+++ b/src/MoBi.Core/Commands/SynchronizeParameterValueCommand.cs
@@ -3,7 +3,7 @@ using MoBi.Core.Domain.Model;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using MoBi.Assets;
-using MoBi.Core.Helper;
+using OSPSuite.Assets;
 
 namespace MoBi.Core.Commands
 {
@@ -19,8 +19,7 @@ namespace MoBi.Core.Commands
          _parameterId = parameter.Id;
          _parameterValue = parameterValue;
          CommandType = AppConstants.Commands.UpdateCommand;
-         ObjectType = new ObjectTypeResolver().TypeFor<ParameterValue>();
-         
+         ObjectType = ObjectTypes.ParameterValue;
       }
 
       protected override void ExecuteWith(IMoBiContext context)

--- a/src/MoBi.Presentation/Tasks/SimulationCommitTask.cs
+++ b/src/MoBi.Presentation/Tasks/SimulationCommitTask.cs
@@ -78,9 +78,11 @@ namespace MoBi.Presentation.Tasks
          else
             macroCommand.AddRange(updateParameterValuesFromSimulationChanges(simulationWithChanges, lastModuleConfiguration));
 
+         macroCommand.Add(new ClearOriginalQuantitiesTrackerCommand(simulationWithChanges));
+         
          macroCommand.Run(_context);
 
-         simulationWithChanges.ClearOriginalQuantities();
+         
 
          _context.PublishEvent(new SimulationStatusChangedEvent(simulationWithChanges));
          return macroCommand;


### PR DESCRIPTION
Non reversible command added at the end.

I verified that if I put this command in first, the whole macro is non-reversible. It doesn't matter.