### PR TITLE
Fixes #1084 Multiple entries for neighborhood's neighbors are added when repeatedly opening a spatial strucutre

### DIFF
--- a/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
@@ -74,10 +74,15 @@ namespace MoBi.Presentation.Presenter
       private IEnumerable<ObjectBaseDTO> neighborsOf(NeighborhoodBuilder neighborhoodBuilder)
       {
          if(neighborhoodBuilder.FirstNeighborPath!=null)
-            yield return new ObjectBaseDTO{Name = neighborhoodBuilder.FirstNeighborPath, Icon = ApplicationIcons.Neighbor };
+            yield return new ObjectBaseDTO{Name = neighborhoodBuilder.FirstNeighborPath, Icon = ApplicationIcons.Neighbor, Id = createNeighborhoodId(neighborhoodBuilder.FirstNeighbor, neighborhoodBuilder.SecondNeighbor)};
 
          if (neighborhoodBuilder.SecondNeighborPath != null)
-            yield return new ObjectBaseDTO { Name = neighborhoodBuilder.SecondNeighborPath, Icon = ApplicationIcons.Neighbor };
+            yield return new ObjectBaseDTO { Name = neighborhoodBuilder.SecondNeighborPath, Icon = ApplicationIcons.Neighbor, Id = createNeighborhoodId(neighborhoodBuilder.SecondNeighbor, neighborhoodBuilder.FirstNeighbor) };
+      }
+
+      private string createNeighborhoodId(IWithId me, IWithId myNeighbor)
+      {
+         return $"{me.Id}-{myNeighbor.Id}";
       }
 
       private ContainerType groupingTypeFor(IEntity entity)


### PR DESCRIPTION
This was caused by new GUIDs generated each time for the same neighborhood. You cannot use the id of only one neighbor because the node appears in multiple neighborhoods.