### PR TITLE
Fixes #1127 Warning SetValueOrigin hides method from base class

### DIFF
--- a/src/MoBi.Presentation/Presenter/PathAndValueBuildingBlockPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/PathAndValueBuildingBlockPresenter.cs
@@ -177,11 +177,6 @@ namespace MoBi.Presentation.Presenter
          _view.BindTo(_startValueDTOs);
       }
 
-      public void SetValueOrigin(TStartValueDTO startValueDTO, ValueOrigin newValueOrigin)
-      {
-         AddCommand(_startValuesTask.SetValueOrigin(_buildingBlock, newValueOrigin, StartValueFrom(startValueDTO)));
-      }
-
       public void SetValue(TStartValueDTO startValueDTO, double? valueInDisplayUnit)
       {
          AddCommand(_startValuesTask.SetValue(_buildingBlock, valueInDisplayUnit, StartValueFrom(startValueDTO)));


### PR DESCRIPTION
Little oopsie from a previous bug fix.