### PR TITLE
Fixes #1143 select individual when exporting container from spatial structure

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+Fixes #
+
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Type of change
+
+Please mark relevant options with an `x` in the brackets.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
+- [ ] Other (please describe):
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Integration tests
+- [ ] Unit tests
+- [ ] Manual tests 
+- [ ] No tests required
+
+# Reviewer checklist
+
+Mark everything that needs to be checked before merging the PR.
+
+- [ ] Check if the code is well documented
+- [ ] Check if the behavior is what is expected
+- [ ] Check if the code is well tested
+- [ ] Check if the code is readable and well formatted
+- [ ] Additional checks (document below if any)
+
+# Screenshots (if appropriate):
+
+# Questions (if appropriate):

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1095,8 +1095,8 @@ namespace MoBi.Assets
 
          public static string AddExistingFromTemplate(string objectTypeName) => $"Load {objectTypeName} from Template...";
          
-         public static string AddModuleWithBuildingBlocks => $"Create Module";
-         public static string SaveWithIndividual => "Save With Individual";
+         public static string AddModuleWithBuildingBlocks = "Create Module";
+         public static string SaveWithIndividual = "Save With Individual";
          public static string EditDefaultSimulationSettings = "Edit Default Simulation Settings";
          public static string SaveProjectSimulationSettings = "Save Default Simulation Settings";
          public static string LoadProjectSimulationSettings = "Load Default Simulation Settings";
@@ -1579,8 +1579,7 @@ namespace MoBi.Assets
          public static readonly string SelectSpatialStructureAndMolecules = "Select a spatial structure and molecules building block";
          public static readonly string SelectSpatialStructure = "Select a spatial structure";
          public static readonly string ExtendDescription = "<b><i>Initial conditions</i> will be created for molecules in all physical containers in the selected <i>spatial structure</i></b>";
-         public static string ExportContainerDescription(string exportedContainerPath) => $"Select an individual and file path for container export. Parameters from the individual that match the path " +
-                                                                                          $"{exportedContainerPath} will be addd to the container before exporting.";
+         public static string ExportContainerDescription(string exportedContainerPath) => $"Select an individual and file path for container export. Parameters from the individual that match the path {exportedContainerPath} will be addd to the container before exporting.";
          public static readonly string SelectIndividualAndPathForContainerExport = "Select an individual and path for container export";
 
          public static readonly string AddInterval = "Add Interval";

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1090,6 +1090,7 @@ namespace MoBi.Assets
          public static string AddExistingFromTemplate(string objectTypeName) => $"Load {objectTypeName} from Template...";
          
          public static string AddModuleWithBuildingBlocks => $"Create Module";
+         public static string SaveWithIndividual => "Save With Individual";
          public static string EditDefaultSimulationSettings = "Edit Default Simulation Settings";
          public static string SaveProjectSimulationSettings = "Save Default Simulation Settings";
          public static string LoadProjectSimulationSettings = "Load Default Simulation Settings";
@@ -1572,6 +1573,9 @@ namespace MoBi.Assets
          public static readonly string SelectSpatialStructureAndMolecules = "Select a spatial structure and molecules building block";
          public static readonly string SelectSpatialStructure = "Select a spatial structure";
          public static readonly string ExtendDescription = "<b><i>Initial conditions</i> will be created for molecules in all physical containers in the selected <i>spatial structure</i></b>";
+         public static readonly string ExportContainerDescription = "When exporting a container, you must select an individual and path for the export";
+         public static readonly string SelectIndividualAndPathForContainerExport = "Select an individual and path for container export";
+
          public static string CouldNotResolveSource(string sourceType) => $"{sourceType} source not defined";
          public static readonly string CurveName = "Curve Name";
          public static readonly string XDataPath = "X-Path";

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1579,7 +1579,8 @@ namespace MoBi.Assets
          public static readonly string SelectSpatialStructureAndMolecules = "Select a spatial structure and molecules building block";
          public static readonly string SelectSpatialStructure = "Select a spatial structure";
          public static readonly string ExtendDescription = "<b><i>Initial conditions</i> will be created for molecules in all physical containers in the selected <i>spatial structure</i></b>";
-         public static readonly string ExportContainerDescription = "When exporting a container, you must select an individual and path for the export";
+         public static string ExportContainerDescription(string exportedContainerPath) => $"Select an individual and file path for container export. Parameters from the individual that match the path " +
+                                                                                          $"{exportedContainerPath} will be addd to the container before exporting.";
          public static readonly string SelectIndividualAndPathForContainerExport = "Select an individual and path for container export";
 
          public static readonly string AddInterval = "Add Interval";

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.232" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.236" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.232" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.236" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.232" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.236" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.232" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.236" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/DTO/IndividualAndFilePathDTO.cs
+++ b/src/MoBi.Presentation/DTO/IndividualAndFilePathDTO.cs
@@ -13,6 +13,7 @@ namespace MoBi.Presentation.DTO
       public string FilePath { get; set; }
       public IndividualBuildingBlock IndividualBuildingBlock { get; set; }
       public string Name { get; set; }
+      public ObjectPath ContainerPath { get; set; }
 
       public IndividualAndFilePathDTO()
       {

--- a/src/MoBi.Presentation/DTO/IndividualAndFilePathDTO.cs
+++ b/src/MoBi.Presentation/DTO/IndividualAndFilePathDTO.cs
@@ -1,0 +1,38 @@
+﻿using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Extensions;
+using OSPSuite.Presentation.DTO;
+using OSPSuite.Utility.Validation;
+using System.Collections.Generic;
+using OSPSuite.Assets;
+
+namespace MoBi.Presentation.DTO
+{
+   public class IndividualAndFilePathDTO : ValidatableDTO, IWithName
+   {
+      public string FilePath { get; set; }
+      public IndividualBuildingBlock IndividualBuildingBlock { get; set; }
+      public string Name { get; set; }
+
+      public IndividualAndFilePathDTO()
+      {
+         Rules.AddRange(AllRules.All);
+      }
+
+      private static class AllRules
+      {
+         public static IReadOnlyList<IBusinessRule> All { get; } = new IBusinessRule[]
+         {
+            CreateRule.For<IndividualAndFilePathDTO>()
+               .Property(x => x.FilePath)
+               .WithRule((dto, name) => name.StringIsNotEmpty())
+               .WithError(Validation.ValueIsRequired),
+
+            CreateRule.For<IndividualAndFilePathDTO>()
+               .Property(x => x.IndividualBuildingBlock)
+               .WithRule((dto, buildingBlock) => buildingBlock != null)
+               .WithError(Validation.ValueIsRequired)
+         };
+      }
+   }
+}

--- a/src/MoBi.Presentation/DTO/IndividualAndFilePathDTO.cs
+++ b/src/MoBi.Presentation/DTO/IndividualAndFilePathDTO.cs
@@ -1,10 +1,11 @@
-﻿using OSPSuite.Core.Domain;
+﻿using System.Collections.Generic;
+using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Extensions;
 using OSPSuite.Presentation.DTO;
 using OSPSuite.Utility.Validation;
-using System.Collections.Generic;
-using OSPSuite.Assets;
+using static MoBi.Assets.AppConstants.Captions;
 
 namespace MoBi.Presentation.DTO
 {
@@ -14,6 +15,8 @@ namespace MoBi.Presentation.DTO
       public IndividualBuildingBlock IndividualBuildingBlock { get; set; }
       public string Name { get; set; }
       public ObjectPath ContainerPath { get; set; }
+
+      public string Description => ExportContainerDescription(ContainerPath?.PathAsString);
 
       public IndividualAndFilePathDTO()
       {

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuFor.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuFor.cs
@@ -52,10 +52,11 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
 
             _allMenuItems = new List<IMenuBarItem> {CreateEditItemFor(objectBase)};
 
-            if (dto.Name.IsSpecialName()) return this;
+            if (dto.Name.IsSpecialName()) 
+               return this;
 
             _allMenuItems.Add(CreateRenameItemFor(objectBase));
-            _allMenuItems.Add(createSaveItemFor(objectBase));
+            AddSaveItems(objectBase);
             _allMenuItems.Add(CreateDeleteItemFor(objectBase));
             return this;
          }
@@ -63,6 +64,11 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          {
             return new EmptyContextMenu();
          }
+      }
+
+      protected virtual void AddSaveItems(TObjectBase objectBase)
+      {
+         _allMenuItems.Add(createSaveItemFor(objectBase));
       }
 
       protected abstract IMenuBarItem CreateDeleteItemFor(TObjectBase objectBase);

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForContainer.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForContainer.cs
@@ -6,6 +6,7 @@ using MoBi.Presentation.UICommand;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Extensions;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.MenuAndBars;
 using OSPSuite.Presentation.Presenters;
@@ -91,6 +92,7 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
       {
          base.InitializeWith(dto, presenter);
          var container = _context.Get<IContainer>(dto.Id);
+         
          if (!dto.Name.IsSpecialName())
          {
             _allMenuItems.Add(CreateAddNewItemFor(container));
@@ -99,6 +101,19 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
 
          _allMenuItems.Add(CreateAddNewChild<IDistributedParameter>(container));
          return this;
+      }
+
+      protected override void AddSaveItems(IContainer container)
+      {
+         base.AddSaveItems(container);
+         _allMenuItems.Add(createSaveWithIndividualFor(container));
+      }
+
+      private IMenuBarItem createSaveWithIndividualFor(IContainer containerToSave)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.SaveWithIndividual.WithEllipsis())
+            .WithCommandFor<SaveWithIndividualUICommand, IContainer>(containerToSave, _container)
+            .WithIcon(ApplicationIcons.PKMLSave);
       }
    }
 

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.232" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.236" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/SelectFolderAndIndividualFromProjectPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectFolderAndIndividualFromProjectPresenter.cs
@@ -13,32 +13,22 @@ namespace MoBi.Presentation.Presenter
    public interface ISelectFolderAndIndividualFromProjectPresenter : IDisposablePresenter
    {
       /// <summary>
-      /// Opens a dialog where the user will select an IndividualBuildingBlock from the project and a file path to export
+      ///    Opens a dialog where the user will select an IndividualBuildingBlock from the project and a file path to export
       /// </summary>
-      void GetPathAndIndividualForExport(IContainer container);
+      (string, IndividualBuildingBlock) GetPathAndIndividualForExport(IContainer container);
 
       /// <summary>
-      /// Returns a list of all IndividualBuildingBlocks in the project
+      ///    Returns a list of all IndividualBuildingBlocks in the project
       /// </summary>
       IReadOnlyList<IndividualBuildingBlock> AllIndividuals { get; }
 
       /// <summary>
-      /// Opens a dialog for the user to select file path
+      ///    Opens a dialog for the user to select file path
       /// </summary>
       /// <returns>The path if dialog is dismissed with ok, empty string if canceled</returns>
       string BrowseFilePath();
-
-      /// <summary>
-      /// After dismissing the dialog, this returns the selected IndividualBuildingBlock or null if the dialog was canceled
-      /// </summary>
-      IndividualBuildingBlock SelectedIndividual { get; }
-      
-      /// <summary>
-      /// After dismissing the dialog, this returns the selected file path for export, or an empty string if the dialog was canceled
-      /// </summary>
-      string SelectedFilePath { get; }
    }
-   
+
    public class SelectFolderAndIndividualFromProjectPresenter : MoBiDisposablePresenter<ISelectFolderAndIndividualFromProjectView, ISelectFolderAndIndividualFromProjectPresenter>, ISelectFolderAndIndividualFromProjectPresenter
    {
       private readonly IBuildingBlockRepository _buildingBlockRepository;
@@ -53,7 +43,7 @@ namespace MoBi.Presentation.Presenter
          _objectPathFactory = objectPathFactory;
       }
 
-      public void GetPathAndIndividualForExport(IContainer container)
+      public (string, IndividualBuildingBlock) GetPathAndIndividualForExport(IContainer container)
       {
          _dto = new IndividualAndFilePathDTO
          {
@@ -61,20 +51,12 @@ namespace MoBi.Presentation.Presenter
          }.WithName(container.Name);
          _view.BindTo(_dto);
          _view.Display();
-         
-         if (!_view.Canceled)
-            return;
-         
-         _dto.IndividualBuildingBlock = null;
-         _dto.FilePath = string.Empty;
+
+         return _view.Canceled ? (string.Empty, null) : (_dto.FilePath, _dto.IndividualBuildingBlock);
       }
 
-      public string SelectedFilePath => _dto.FilePath;
-      
       public IReadOnlyList<IndividualBuildingBlock> AllIndividuals => _buildingBlockRepository.IndividualsCollection;
-      
-      public IndividualBuildingBlock SelectedIndividual => _dto.IndividualBuildingBlock;
-      
+
       public string BrowseFilePath() => _editTaskForContainer.BrowseSavePathFor(_dto.Name);
    }
 }

--- a/src/MoBi.Presentation/Presenter/SelectFolderAndIndividualFromProjectPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectFolderAndIndividualFromProjectPresenter.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using MoBi.Core.Domain.Repository;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter.BasePresenter;
+using MoBi.Presentation.Tasks.Edit;
+using MoBi.Presentation.Views;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Presentation.Presenters;
+
+namespace MoBi.Presentation.Presenter
+{
+   public interface ISelectFolderAndIndividualFromProjectPresenter : IDisposablePresenter
+   {
+      /// <summary>
+      /// Opens a dialog where the user will select an IndividualBuildingBlock from the project and a file path to export
+      /// </summary>
+      /// <param name="name"></param>
+      void GetPathAndIndividualForExport(string name);
+
+      /// <summary>
+      /// Returns a list of all IndividualBuildingBlocks in the project
+      /// </summary>
+      IReadOnlyList<IndividualBuildingBlock> AllIndividuals { get; }
+
+      /// <summary>
+      /// Opens a dialog for the user to select file path
+      /// </summary>
+      /// <returns>The path if dialog is dismissed with ok, empty string if canceled</returns>
+      string BrowseFilePath();
+
+      /// <summary>
+      /// After dismissing the dialog, this returns the selected IndividualBuildingBlock or null if the dialog was canceled
+      /// </summary>
+      IndividualBuildingBlock SelectedIndividual { get; }
+      
+      /// <summary>
+      /// After dismissing the dialog, this returns the selected file path for export, or an empty string if the dialog was canceled
+      /// </summary>
+      string SelectedFilePath { get; }
+   }
+   
+   public class SelectFolderAndIndividualFromProjectPresenter : MoBiDisposablePresenter<ISelectFolderAndIndividualFromProjectView, ISelectFolderAndIndividualFromProjectPresenter>, ISelectFolderAndIndividualFromProjectPresenter
+   {
+      private readonly IBuildingBlockRepository _buildingBlockRepository;
+      private readonly IEditTaskForContainer _editTaskForContainer;
+      private IndividualAndFilePathDTO _dto;
+
+      public SelectFolderAndIndividualFromProjectPresenter(ISelectFolderAndIndividualFromProjectView view, IBuildingBlockRepository buildingBlockRepository, IEditTaskForContainer editTaskForContainer) : base(view)
+      {
+         _buildingBlockRepository = buildingBlockRepository;
+         _editTaskForContainer = editTaskForContainer;
+      }
+
+      public void GetPathAndIndividualForExport(string name)
+      {
+         _dto = new IndividualAndFilePathDTO().WithName(name);
+         _view.BindTo(_dto);
+         _view.Display();
+         
+         if (!_view.Canceled)
+            return;
+         
+         _dto.IndividualBuildingBlock = null;
+         _dto.FilePath = string.Empty;
+      }
+
+      public string SelectedFilePath => _dto.FilePath;
+      
+      public IReadOnlyList<IndividualBuildingBlock> AllIndividuals => _buildingBlockRepository.IndividualsCollection;
+      
+      public IndividualBuildingBlock SelectedIndividual => _dto.IndividualBuildingBlock;
+      
+      public string BrowseFilePath() => _editTaskForContainer.BrowseSavePathFor(_dto.Name);
+   }
+}

--- a/src/MoBi.Presentation/Presenter/SelectFolderAndIndividualFromProjectPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectFolderAndIndividualFromProjectPresenter.cs
@@ -15,8 +15,7 @@ namespace MoBi.Presentation.Presenter
       /// <summary>
       /// Opens a dialog where the user will select an IndividualBuildingBlock from the project and a file path to export
       /// </summary>
-      /// <param name="name"></param>
-      void GetPathAndIndividualForExport(string name);
+      void GetPathAndIndividualForExport(IContainer container);
 
       /// <summary>
       /// Returns a list of all IndividualBuildingBlocks in the project
@@ -44,17 +43,22 @@ namespace MoBi.Presentation.Presenter
    {
       private readonly IBuildingBlockRepository _buildingBlockRepository;
       private readonly IEditTaskForContainer _editTaskForContainer;
+      private readonly IObjectPathFactory _objectPathFactory;
       private IndividualAndFilePathDTO _dto;
 
-      public SelectFolderAndIndividualFromProjectPresenter(ISelectFolderAndIndividualFromProjectView view, IBuildingBlockRepository buildingBlockRepository, IEditTaskForContainer editTaskForContainer) : base(view)
+      public SelectFolderAndIndividualFromProjectPresenter(ISelectFolderAndIndividualFromProjectView view, IBuildingBlockRepository buildingBlockRepository, IEditTaskForContainer editTaskForContainer, IObjectPathFactory objectPathFactory) : base(view)
       {
          _buildingBlockRepository = buildingBlockRepository;
          _editTaskForContainer = editTaskForContainer;
+         _objectPathFactory = objectPathFactory;
       }
 
-      public void GetPathAndIndividualForExport(string name)
+      public void GetPathAndIndividualForExport(IContainer container)
       {
-         _dto = new IndividualAndFilePathDTO().WithName(name);
+         _dto = new IndividualAndFilePathDTO
+         {
+            ContainerPath = _objectPathFactory.CreateAbsoluteObjectPath(container)
+         }.WithName(container.Name);
          _view.BindTo(_dto);
          _view.Display();
          

--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
@@ -70,7 +70,7 @@ namespace MoBi.Presentation.Tasks.Edit
 
          using (var presenter = _applicationController.Start<ISelectFolderAndIndividualFromProjectPresenter>())
          {
-            presenter.GetPathAndIndividualForExport(container.Name);
+            presenter.GetPathAndIndividualForExport(container);
             filePath = presenter.SelectedFilePath;
             individual = presenter.SelectedIndividual;
          }

--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
@@ -4,10 +4,13 @@ using MoBi.Assets;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Builder;
 using MoBi.Core.Domain.Model;
+using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Interaction;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Mappers;
+using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation.Tasks.Edit
@@ -15,17 +18,37 @@ namespace MoBi.Presentation.Tasks.Edit
    public interface IEditTaskForContainer : IEditTaskFor<IContainer>
    {
       IMoBiCommand SetContainerMode(IBuildingBlock buildingBlock, IContainer container, ContainerMode containerMode);
+
+      /// <summary>
+      /// Opens a dialog for the user to select file path
+      /// </summary>
+      /// <returns>The path if dialog is dismissed with ok, empty string if canceled</returns>
+      string BrowseSavePathFor(string name);
+
+      /// <summary>
+      /// The user can select an individual to combine with the container and export combined parameters.
+      /// The individual parameters are exported if they match the path of the <paramref name="container"/> tree
+      /// </summary>
+      void SaveWithIndividual(IContainer container);
    }
 
    public class EditTaskForContainer : EditTaskFor<IContainer>, IEditTaskForContainer
    {
       private readonly IMoBiSpatialStructureFactory _spatialStructureFactory;
       private readonly IObjectPathFactory _objectPathFactory;
+      private readonly ICloneManagerForBuildingBlock _cloneManager;
+      private readonly IIndividualParameterToParameterMapper _individualParameterToParameterMapper;
 
-      public EditTaskForContainer(IInteractionTaskContext interactionTaskContext, IMoBiSpatialStructureFactory spatialStructureFactory, IObjectPathFactory objectPathFactory) : base(interactionTaskContext)
+      public EditTaskForContainer(IInteractionTaskContext interactionTaskContext, 
+         IMoBiSpatialStructureFactory spatialStructureFactory, 
+         IObjectPathFactory objectPathFactory, 
+         ICloneManagerForBuildingBlock cloneManager,
+         IIndividualParameterToParameterMapper individualParameterToParameterMapper) : base(interactionTaskContext)
       {
          _spatialStructureFactory = spatialStructureFactory;
          _objectPathFactory = objectPathFactory;
+         _cloneManager = cloneManager;
+         _individualParameterToParameterMapper = individualParameterToParameterMapper;
       }
 
       protected override IEnumerable<string> GetUnallowedNames(IContainer container, IEnumerable<IObjectBase> existingObjectsInParent)
@@ -40,43 +63,94 @@ namespace MoBi.Presentation.Tasks.Edit
          return spatialStructure.TopContainers.Select(x => x.Name).Union(AppConstants.UnallowedNames);
       }
 
-      public override void Save(IContainer entityToSerialize)
+      public void SaveWithIndividual(IContainer container)
       {
-         var fileName = _interactionTask.AskForFileToSave(AppConstants.Captions.Save, Constants.Filter.PKML_FILE_FILTER, Constants.DirectoryKey.MODEL_PART, entityToSerialize.Name);
-         if (fileName.IsNullOrEmpty()) 
+         IndividualBuildingBlock individual;
+         string filePath;
+
+         using (var presenter = _applicationController.Start<ISelectFolderAndIndividualFromProjectPresenter>())
+         {
+            presenter.GetPathAndIndividualForExport(container.Name);
+            filePath = presenter.SelectedFilePath;
+            individual = presenter.SelectedIndividual;
+         }
+         
+         if (filePath.IsNullOrEmpty() || individual == null)
+            return;
+         
+         exportContainer(container, filePath, individual);
+      }
+
+      public override void Save(IContainer container)
+      {
+         var fileName = _interactionTask.AskForFileToSave(AppConstants.Captions.Save, Constants.Filter.PKML_FILE_FILTER, Constants.DirectoryKey.MODEL_PART, container.Name);
+         if (fileName.IsNullOrEmpty())
             return;
 
-         var tmpSpatialStructure = (MoBiSpatialStructure) _spatialStructureFactory.Create();
+         exportContainer(container, fileName);
+      }
+
+      private void exportContainer(IContainer container, string fileName, IndividualBuildingBlock individual = null)
+      {
+         var tmpSpatialStructure = (MoBiSpatialStructure)_spatialStructureFactory.Create();
 
          // make a backup of the parent and reset that after as there is a side effect
          // of removing the reference to parent container.
-         var originalParent = entityToSerialize.ParentContainer;
-         var originalParentPath = entityToSerialize.ParentPath;
+         var originalParent = container.ParentContainer;
+         var originalParentPath = container.ParentPath;
          var parentPath = originalParentPath ?? _objectPathFactory.CreateAbsoluteObjectPath(originalParent);
-         //this call reset the original parent. We add it back
-         tmpSpatialStructure.AddTopContainer(entityToSerialize);
-         entityToSerialize.ParentContainer = originalParent;
+
+         var clonedEntity = _cloneManager.Clone(container, tmpSpatialStructure.FormulaCache);
+         clonedEntity.ParentPath = parentPath;
+
+         tmpSpatialStructure.AddTopContainer(clonedEntity);
+
+         addIndividualParametersToContainers(individual, clonedEntity);
 
          var existingSpatialStructure = _interactionTaskContext.Active<MoBiSpatialStructure>();
          if (existingSpatialStructure != null)
          {
-            var neighborhoods = existingSpatialStructure.GetConnectingNeighborhoods(new[] {entityToSerialize}, _objectPathFactory);
+            var neighborhoods = existingSpatialStructure.GetConnectingNeighborhoods(new[] { container }, _objectPathFactory);
             neighborhoods.Each(tmpSpatialStructure.AddNeighborhood);
             if (existingSpatialStructure.DiagramModel != null)
-               tmpSpatialStructure.DiagramModel = existingSpatialStructure.DiagramModel.CreateCopy(entityToSerialize.Id);
+               tmpSpatialStructure.DiagramModel = existingSpatialStructure.DiagramModel.CreateCopy(container.Id);
          }
 
-         //Save the parent path before we serialize to make sure it's set properly when we import
-         entityToSerialize.ParentPath = parentPath;
          _interactionTask.Save(tmpSpatialStructure, fileName);
+      }
 
-         entityToSerialize.ParentPath = originalParentPath;
+      private void addIndividualParametersToContainers(IndividualBuildingBlock individual, IContainer entityToSerialize)
+      {
+         if (individual == null || !individual.Any())
+            return; 
+         
+         var allSubContainers = entityToSerialize.GetAllContainersAndSelf<IContainer>();
+         allSubContainers.Each(container =>
+         {
+            addIndividualParametersToContainer(individual, container, _objectPathFactory.CreateObjectPathFrom(entityToSerialize.ParentPath.Concat(_objectPathFactory.CreateAbsoluteObjectPath(container)).ToArray()));
+         });
+      }
 
+      private void addIndividualParametersToContainer(IndividualBuildingBlock individual, IContainer container, ObjectPath containerPath)
+      {
+         
+         individual.Where(individualParameter => individualParameter.ContainerPath.Equals(containerPath)).Each(x => addIndividualParameterToContainer(x, container));
+      }
+
+      private void addIndividualParameterToContainer(IndividualParameter individualParameter, IContainer container)
+      {
+         var parameter = _individualParameterToParameterMapper.MapFrom(individualParameter);
+         container.Add(parameter);
       }
 
       public IMoBiCommand SetContainerMode(IBuildingBlock buildingBlock, IContainer container, ContainerMode containerMode)
       {
          return new SetContainerModeCommand(buildingBlock, container, containerMode).Run(_context);
+      }
+
+      public string BrowseSavePathFor(string name)
+      {
+         return _interactionTask.AskForFileToSave(AppConstants.Captions.Save, Constants.Filter.PKML_FILE_FILTER, Constants.DirectoryKey.MODEL_PART, name);
       }
 
       protected override IMoBiCommand GetRenameCommandFor(IContainer container, IBuildingBlock buildingBlock, string newName, string objectType)

--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
@@ -94,14 +94,9 @@ namespace MoBi.Presentation.Tasks.Edit
       {
          var tmpSpatialStructure = (MoBiSpatialStructure)_spatialStructureFactory.Create();
 
-         // make a backup of the parent and reset that after as there is a side effect
-         // of removing the reference to parent container.
-         var originalParent = container.ParentContainer;
-         var originalParentPath = container.ParentPath;
-         var parentPath = originalParentPath ?? _objectPathFactory.CreateAbsoluteObjectPath(originalParent);
-
          var clonedEntity = _cloneManager.Clone(container, tmpSpatialStructure.FormulaCache);
-         clonedEntity.ParentPath = parentPath;
+         
+         clonedEntity.ParentPath = parentPathFrom(container);
 
          tmpSpatialStructure.AddTopContainer(clonedEntity);
 
@@ -117,6 +112,11 @@ namespace MoBi.Presentation.Tasks.Edit
          }
 
          _interactionTask.Save(tmpSpatialStructure, fileName);
+      }
+
+      private ObjectPath parentPathFrom(IContainer container)
+      {
+         return container.ParentPath ?? (container.ParentContainer == null ? new ObjectPath() : _objectPathFactory.CreateAbsoluteObjectPath(container.ParentContainer));
       }
 
       private void addIndividualParametersToContainers(IndividualBuildingBlock individual, IContainer entityToSerialize)
@@ -140,6 +140,8 @@ namespace MoBi.Presentation.Tasks.Edit
       private void addIndividualParameterToContainer(IndividualParameter individualParameter, IContainer container)
       {
          var parameter = _individualParameterToParameterMapper.MapFrom(individualParameter);
+         if (container.ContainsName(parameter.Name))
+            container.RemoveChild(container.FindByName(parameter.Name));
          container.Add(parameter);
       }
 

--- a/src/MoBi.Presentation/UICommand/SaveWithIndividualUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/SaveWithIndividualUICommand.cs
@@ -1,0 +1,20 @@
+﻿using MoBi.Presentation.Tasks.Edit;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class SaveWithIndividualUICommand : ObjectUICommand<IContainer>
+   {
+      private readonly IEditTaskForContainer _editTaskForContainer;
+
+      public SaveWithIndividualUICommand(IEditTaskForContainer editTaskForContainer)
+      {
+         _editTaskForContainer = editTaskForContainer;
+      }
+      protected override void PerformExecute()
+      {
+         _editTaskForContainer.SaveWithIndividual(Subject);
+      }
+   }
+}

--- a/src/MoBi.Presentation/UICommand/SaveWithIndividualUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/SaveWithIndividualUICommand.cs
@@ -12,6 +12,7 @@ namespace MoBi.Presentation.UICommand
       {
          _editTaskForContainer = editTaskForContainer;
       }
+
       protected override void PerformExecute()
       {
          _editTaskForContainer.SaveWithIndividual(Subject);

--- a/src/MoBi.Presentation/Views/ISelectFolderAndIndividualFromProjectView.cs
+++ b/src/MoBi.Presentation/Views/ISelectFolderAndIndividualFromProjectView.cs
@@ -1,0 +1,11 @@
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+using OSPSuite.Presentation.Views;
+
+namespace MoBi.Presentation.Views
+{
+   public interface ISelectFolderAndIndividualFromProjectView : IModalView, IView<ISelectFolderAndIndividualFromProjectPresenter>
+   {
+      void BindTo(IndividualAndFilePathDTO dto);
+   }
+}

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.232" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.236" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/Views/SelectFolderAndIndividualFromProjectView.Designer.cs
+++ b/src/MoBi.UI/Views/SelectFolderAndIndividualFromProjectView.Designer.cs
@@ -1,0 +1,191 @@
+﻿namespace MoBi.UI.Views
+{
+   partial class SelectFolderAndIndividualFromProjectView
+   {
+      /// <summary>
+      /// Required designer variable.
+      /// </summary>
+      private System.ComponentModel.IContainer components = null;
+
+      /// <summary>
+      /// Clean up any resources being used.
+      /// </summary>
+      /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+      protected override void Dispose(bool disposing)
+      {
+         if (disposing && (components != null))
+         {
+            components.Dispose();
+         }
+
+         disposeBinders();
+         base.Dispose(disposing);
+      }
+
+      #region Windows Form Designer generated code
+
+      /// <summary>
+      /// Required method for Designer support - do not modify
+      /// the contents of this method with the code editor.
+      /// </summary>
+      private void InitializeComponent()
+      {
+         this.uxLayoutControl1 = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.btnSelectFilePath = new DevExpress.XtraEditors.ButtonEdit();
+         this.cmbSelectIndividual = new OSPSuite.UI.Controls.UxComboBoxEdit();
+         this.descriptionLabel = new DevExpress.XtraEditors.LabelControl();
+         this.Root = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.layoutControlItem1 = new DevExpress.XtraLayout.LayoutControlItem();
+         this.emptySpaceItem1 = new DevExpress.XtraLayout.EmptySpaceItem();
+         this.layoutControlItemSelectIndividual = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutControlItemSelectFilePath = new DevExpress.XtraLayout.LayoutControlItem();
+         ((System.ComponentModel.ISupportInitialize)(this.tablePanel)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.uxLayoutControl1)).BeginInit();
+         this.uxLayoutControl1.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.btnSelectFilePath.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.cmbSelectIndividual.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.Root)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem1)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemSelectIndividual)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemSelectFilePath)).BeginInit();
+         this.SuspendLayout();
+         // 
+         // tablePanel
+         // 
+         this.tablePanel.Location = new System.Drawing.Point(0, 115);
+         // 
+         // uxLayoutControl1
+         // 
+         this.uxLayoutControl1.AllowCustomization = false;
+         this.uxLayoutControl1.Controls.Add(this.btnSelectFilePath);
+         this.uxLayoutControl1.Controls.Add(this.cmbSelectIndividual);
+         this.uxLayoutControl1.Controls.Add(this.descriptionLabel);
+         this.uxLayoutControl1.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.uxLayoutControl1.Location = new System.Drawing.Point(0, 0);
+         this.uxLayoutControl1.Name = "uxLayoutControl1";
+         this.uxLayoutControl1.Root = this.Root;
+         this.uxLayoutControl1.Size = new System.Drawing.Size(580, 115);
+         this.uxLayoutControl1.TabIndex = 39;
+         this.uxLayoutControl1.Text = "uxLayoutControl1";
+         // 
+         // btnSelectFilePath
+         // 
+         this.btnSelectFilePath.Location = new System.Drawing.Point(186, 36);
+         this.btnSelectFilePath.Name = "btnSelectFilePath";
+         this.btnSelectFilePath.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton()});
+         this.btnSelectFilePath.Size = new System.Drawing.Size(382, 20);
+         this.btnSelectFilePath.StyleController = this.uxLayoutControl1;
+         this.btnSelectFilePath.TabIndex = 10;
+         this.btnSelectFilePath.ButtonClick += new DevExpress.XtraEditors.Controls.ButtonPressedEventHandler(this.btnSelectFilePathClick);
+         // 
+         // cmbSelectIndividual
+         // 
+         this.cmbSelectIndividual.Location = new System.Drawing.Point(186, 12);
+         this.cmbSelectIndividual.Name = "cmbSelectIndividual";
+         this.cmbSelectIndividual.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+         this.cmbSelectIndividual.Size = new System.Drawing.Size(382, 20);
+         this.cmbSelectIndividual.StyleController = this.uxLayoutControl1;
+         this.cmbSelectIndividual.TabIndex = 8;
+         // 
+         // descriptionLabel
+         // 
+         this.descriptionLabel.AllowHtmlString = true;
+         this.descriptionLabel.AutoSizeMode = DevExpress.XtraEditors.LabelAutoSizeMode.Vertical;
+         this.descriptionLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.descriptionLabel.Location = new System.Drawing.Point(12, 60);
+         this.descriptionLabel.Name = "descriptionLabel";
+         this.descriptionLabel.Size = new System.Drawing.Size(556, 13);
+         this.descriptionLabel.StyleController = this.uxLayoutControl1;
+         this.descriptionLabel.TabIndex = 9;
+         this.descriptionLabel.Text = "containerExportDescription";
+         // 
+         // Root
+         // 
+         this.Root.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
+         this.Root.GroupBordersVisible = false;
+         this.Root.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutControlItem1,
+            this.emptySpaceItem1,
+            this.layoutControlItemSelectIndividual,
+            this.layoutControlItemSelectFilePath});
+         this.Root.Name = "Root";
+         this.Root.Size = new System.Drawing.Size(580, 115);
+         this.Root.TextVisible = false;
+         // 
+         // layoutControlItem1
+         // 
+         this.layoutControlItem1.Control = this.descriptionLabel;
+         this.layoutControlItem1.Location = new System.Drawing.Point(0, 48);
+         this.layoutControlItem1.Name = "layoutControlItem1";
+         this.layoutControlItem1.Size = new System.Drawing.Size(560, 17);
+         this.layoutControlItem1.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutControlItem1.TextVisible = false;
+         // 
+         // emptySpaceItem1
+         // 
+         this.emptySpaceItem1.AllowHotTrack = false;
+         this.emptySpaceItem1.Location = new System.Drawing.Point(0, 65);
+         this.emptySpaceItem1.Name = "emptySpaceItem1";
+         this.emptySpaceItem1.Size = new System.Drawing.Size(560, 30);
+         this.emptySpaceItem1.TextSize = new System.Drawing.Size(0, 0);
+         // 
+         // layoutControlItemSelectIndividual
+         // 
+         this.layoutControlItemSelectIndividual.Control = this.cmbSelectIndividual;
+         this.layoutControlItemSelectIndividual.Location = new System.Drawing.Point(0, 0);
+         this.layoutControlItemSelectIndividual.Name = "layoutControlItemSelectIndividual";
+         this.layoutControlItemSelectIndividual.Size = new System.Drawing.Size(560, 24);
+         this.layoutControlItemSelectIndividual.TextSize = new System.Drawing.Size(162, 13);
+         // 
+         // layoutControlItemSelectFilePath
+         // 
+         this.layoutControlItemSelectFilePath.Control = this.btnSelectFilePath;
+         this.layoutControlItemSelectFilePath.Location = new System.Drawing.Point(0, 24);
+         this.layoutControlItemSelectFilePath.Name = "layoutControlItemSelectFilePath";
+         this.layoutControlItemSelectFilePath.Size = new System.Drawing.Size(560, 24);
+         this.layoutControlItemSelectFilePath.TextSize = new System.Drawing.Size(162, 13);
+         // 
+         // SelectIndividualFromProjectView
+         // 
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.Caption = "SelectExportSettings";
+         this.ClientSize = new System.Drawing.Size(580, 158);
+         this.Controls.Add(this.uxLayoutControl1);
+         this.Name = "SelectFolderAndIndividualFromProjectView";
+         this.Text = "SelectExportSettings";
+         this.Controls.SetChildIndex(this.tablePanel, 0);
+         this.Controls.SetChildIndex(this.uxLayoutControl1, 0);
+         ((System.ComponentModel.ISupportInitialize)(this.tablePanel)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.uxLayoutControl1)).EndInit();
+         this.uxLayoutControl1.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.btnSelectFilePath.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.cmbSelectIndividual.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.Root)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem1)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemSelectIndividual)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemSelectFilePath)).EndInit();
+         this.ResumeLayout(false);
+         this.PerformLayout();
+
+      }
+
+      #endregion
+
+      private OSPSuite.UI.Controls.UxLayoutControl uxLayoutControl1;
+      private DevExpress.XtraLayout.LayoutControlGroup Root;
+      private DevExpress.XtraEditors.LabelControl descriptionLabel;
+      private OSPSuite.UI.Controls.UxComboBoxEdit cmbSelectIndividual;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlItem1;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlItemSelectIndividual;
+      private DevExpress.XtraLayout.EmptySpaceItem emptySpaceItem1;
+      private DevExpress.XtraEditors.ButtonEdit btnSelectFilePath;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlItemSelectFilePath;
+   }
+}

--- a/src/MoBi.UI/Views/SelectFolderAndIndividualFromProjectView.cs
+++ b/src/MoBi.UI/Views/SelectFolderAndIndividualFromProjectView.cs
@@ -25,7 +25,6 @@ namespace MoBi.UI.Views
       public override void InitializeResources()
       {
          base.InitializeResources();
-         descriptionLabel.Text = ExportContainerDescription;
          layoutControlItemSelectIndividual.Text = Individual;
          layoutControlItemSelectFilePath.Text = Captions.FilePath;
          Caption = SelectIndividualAndPathForContainerExport;
@@ -48,6 +47,7 @@ namespace MoBi.UI.Views
 
       public void BindTo(IndividualAndFilePathDTO dto)
       {
+         descriptionLabel.Text = ExportContainerDescription(dto.ContainerPath.PathAsString);
          _screenBinder.BindToSource(dto);
       }
 

--- a/src/MoBi.UI/Views/SelectFolderAndIndividualFromProjectView.cs
+++ b/src/MoBi.UI/Views/SelectFolderAndIndividualFromProjectView.cs
@@ -1,11 +1,11 @@
 ﻿using DevExpress.XtraEditors.Controls;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Presenter;
-using OSPSuite.UI.Views;
 using MoBi.Presentation.Views;
 using OSPSuite.Assets;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
+using OSPSuite.UI.Views;
 using static MoBi.Assets.AppConstants.Captions;
 
 namespace MoBi.UI.Views
@@ -13,13 +13,12 @@ namespace MoBi.UI.Views
    public partial class SelectFolderAndIndividualFromProjectView : BaseModalView, ISelectFolderAndIndividualFromProjectView
    {
       private readonly ScreenBinder<IndividualAndFilePathDTO> _screenBinder = new ScreenBinder<IndividualAndFilePathDTO>();
-      
+
       private ISelectFolderAndIndividualFromProjectPresenter _presenter;
 
       public SelectFolderAndIndividualFromProjectView()
       {
          InitializeComponent();
-         ExtraVisible = false;
       }
 
       public override void InitializeResources()
@@ -37,6 +36,7 @@ namespace MoBi.UI.Views
       {
          _screenBinder.Bind(x => x.IndividualBuildingBlock).To(cmbSelectIndividual).WithValues(x => _presenter.AllIndividuals);
          _screenBinder.Bind(x => x.FilePath).To(btnSelectFilePath);
+         _screenBinder.Bind(x => x.Description).To(descriptionLabel);
          RegisterValidationFor(_screenBinder, NotifyViewChanged);
       }
 
@@ -47,7 +47,6 @@ namespace MoBi.UI.Views
 
       public void BindTo(IndividualAndFilePathDTO dto)
       {
-         descriptionLabel.Text = ExportContainerDescription(dto.ContainerPath.PathAsString);
          _screenBinder.BindToSource(dto);
       }
 

--- a/src/MoBi.UI/Views/SelectFolderAndIndividualFromProjectView.cs
+++ b/src/MoBi.UI/Views/SelectFolderAndIndividualFromProjectView.cs
@@ -1,0 +1,64 @@
+﻿using DevExpress.XtraEditors.Controls;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+using OSPSuite.UI.Views;
+using MoBi.Presentation.Views;
+using OSPSuite.Assets;
+using OSPSuite.DataBinding;
+using OSPSuite.DataBinding.DevExpress;
+using static MoBi.Assets.AppConstants.Captions;
+
+namespace MoBi.UI.Views
+{
+   public partial class SelectFolderAndIndividualFromProjectView : BaseModalView, ISelectFolderAndIndividualFromProjectView
+   {
+      private readonly ScreenBinder<IndividualAndFilePathDTO> _screenBinder = new ScreenBinder<IndividualAndFilePathDTO>();
+      
+      private ISelectFolderAndIndividualFromProjectPresenter _presenter;
+
+      public SelectFolderAndIndividualFromProjectView()
+      {
+         InitializeComponent();
+         ExtraVisible = false;
+      }
+
+      public override void InitializeResources()
+      {
+         base.InitializeResources();
+         descriptionLabel.Text = ExportContainerDescription;
+         layoutControlItemSelectIndividual.Text = Individual;
+         layoutControlItemSelectFilePath.Text = Captions.FilePath;
+         Caption = SelectIndividualAndPathForContainerExport;
+         btnSelectFilePath.ReadOnly = true;
+      }
+
+      public override bool HasError => _screenBinder.HasError;
+
+      public override void InitializeBinding()
+      {
+         _screenBinder.Bind(x => x.IndividualBuildingBlock).To(cmbSelectIndividual).WithValues(x => _presenter.AllIndividuals);
+         _screenBinder.Bind(x => x.FilePath).To(btnSelectFilePath);
+         RegisterValidationFor(_screenBinder, NotifyViewChanged);
+      }
+
+      public void AttachPresenter(ISelectFolderAndIndividualFromProjectPresenter presenter)
+      {
+         _presenter = presenter;
+      }
+
+      public void BindTo(IndividualAndFilePathDTO dto)
+      {
+         _screenBinder.BindToSource(dto);
+      }
+
+      private void btnSelectFilePathClick(object sender, ButtonPressedEventArgs e)
+      {
+         btnSelectFilePath.EditValue = _presenter.BrowseFilePath();
+      }
+
+      private void disposeBinders()
+      {
+         _screenBinder.Dispose();
+      }
+   }
+}

--- a/src/MoBi.UI/Views/SelectFolderAndIndividualFromProjectView.resx
+++ b/src/MoBi.UI/Views/SelectFolderAndIndividualFromProjectView.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="_errorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/src/MoBi.UI/Views/SelectSpatialStructureAndMoleculesView.Designer.cs
+++ b/src/MoBi.UI/Views/SelectSpatialStructureAndMoleculesView.Designer.cs
@@ -30,13 +30,13 @@
       private void InitializeComponent()
       {
          this.layoutControl1 = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.descriptionLabel = new DevExpress.XtraEditors.LabelControl();
          this.cmbMolecules = new OSPSuite.UI.Controls.UxComboBoxEdit();
          this.cmbSpatialStructure = new OSPSuite.UI.Controls.UxComboBoxEdit();
          this.layoutControlGroup1 = new DevExpress.XtraLayout.LayoutControlGroup();
-         this.layoutControlItemSpatialStructure = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutControlItemMolecules = new DevExpress.XtraLayout.LayoutControlItem();
-         this.descriptionLabel = new DevExpress.XtraEditors.LabelControl();
          this.descriptionLayoutControl = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutControlItemSpatialStructure = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.tablePanel)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl1)).BeginInit();
@@ -44,9 +44,9 @@
          ((System.ComponentModel.ISupportInitialize)(this.cmbMolecules.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.cmbSpatialStructure.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup1)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemSpatialStructure)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemMolecules)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.descriptionLayoutControl)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemSpatialStructure)).BeginInit();
          this.SuspendLayout();
          // 
          // tablePanel
@@ -68,6 +68,18 @@
          this.layoutControl1.Size = new System.Drawing.Size(457, 98);
          this.layoutControl1.TabIndex = 1;
          this.layoutControl1.Text = "layoutControl1";
+         // 
+         // descriptionLabel
+         // 
+         this.descriptionLabel.AllowHtmlString = true;
+         this.descriptionLabel.AutoSizeMode = DevExpress.XtraEditors.LabelAutoSizeMode.Vertical;
+         this.descriptionLabel.Location = new System.Drawing.Point(12, 60);
+         this.descriptionLabel.Name = "descriptionLabel";
+         this.descriptionLabel.Size = new System.Drawing.Size(433, 26);
+         this.descriptionLabel.StyleController = this.layoutControl1;
+         this.descriptionLabel.TabIndex = 6;
+         this.descriptionLabel.Text = "Initial conditions will be created for all physical containers in the spatial str" +
+    "ucture for each molecule";
          // 
          // cmbMolecules
          // 
@@ -102,15 +114,6 @@
          this.layoutControlGroup1.Size = new System.Drawing.Size(457, 98);
          this.layoutControlGroup1.TextVisible = false;
          // 
-         // layoutControlItemSpatialStructure
-         // 
-         this.layoutControlItemSpatialStructure.Control = this.cmbSpatialStructure;
-         this.layoutControlItemSpatialStructure.CustomizationFormText = "layoutControlItemSpatialStructure";
-         this.layoutControlItemSpatialStructure.Location = new System.Drawing.Point(0, 24);
-         this.layoutControlItemSpatialStructure.Name = "layoutControlItemSpatialStructure";
-         this.layoutControlItemSpatialStructure.Size = new System.Drawing.Size(437, 24);
-         this.layoutControlItemSpatialStructure.TextSize = new System.Drawing.Size(164, 13);
-         // 
          // layoutControlItemMolecules
          // 
          this.layoutControlItemMolecules.Control = this.cmbMolecules;
@@ -120,18 +123,6 @@
          this.layoutControlItemMolecules.Size = new System.Drawing.Size(437, 24);
          this.layoutControlItemMolecules.TextSize = new System.Drawing.Size(164, 13);
          // 
-         // descriptionLabel
-         // 
-         this.descriptionLabel.AllowHtmlString = true;
-         this.descriptionLabel.AutoSizeMode = DevExpress.XtraEditors.LabelAutoSizeMode.Vertical;
-         this.descriptionLabel.Location = new System.Drawing.Point(12, 60);
-         this.descriptionLabel.Name = "descriptionLabel";
-         this.descriptionLabel.Size = new System.Drawing.Size(433, 26);
-         this.descriptionLabel.StyleController = this.layoutControl1;
-         this.descriptionLabel.TabIndex = 6;
-         this.descriptionLabel.Text = "Initial conditions will be created for all physical containers in the spatial str" +
-    "ucture for each molecule";
-         // 
          // descriptionLayoutControl
          // 
          this.descriptionLayoutControl.Control = this.descriptionLabel;
@@ -140,6 +131,15 @@
          this.descriptionLayoutControl.Size = new System.Drawing.Size(437, 30);
          this.descriptionLayoutControl.TextSize = new System.Drawing.Size(0, 0);
          this.descriptionLayoutControl.TextVisible = false;
+         // 
+         // layoutControlItemSpatialStructure
+         // 
+         this.layoutControlItemSpatialStructure.Control = this.cmbSpatialStructure;
+         this.layoutControlItemSpatialStructure.CustomizationFormText = "layoutControlItemSpatialStructure";
+         this.layoutControlItemSpatialStructure.Location = new System.Drawing.Point(0, 24);
+         this.layoutControlItemSpatialStructure.Name = "layoutControlItemSpatialStructure";
+         this.layoutControlItemSpatialStructure.Size = new System.Drawing.Size(437, 24);
+         this.layoutControlItemSpatialStructure.TextSize = new System.Drawing.Size(164, 13);
          // 
          // SelectSpatialStructureAndMoleculesView
          // 
@@ -159,9 +159,9 @@
          ((System.ComponentModel.ISupportInitialize)(this.cmbMolecules.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.cmbSpatialStructure.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup1)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemSpatialStructure)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemMolecules)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.descriptionLayoutControl)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemSpatialStructure)).EndInit();
          this.ResumeLayout(false);
          this.PerformLayout();
 

--- a/src/MoBi.UI/Views/UserSettingsView.cs
+++ b/src/MoBi.UI/Views/UserSettingsView.cs
@@ -1,6 +1,5 @@
 ﻿using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
-using DevExpress.Utils;
 using MoBi.Assets;
 using MoBi.Presentation.Settings;
 using MoBi.Presentation.UICommand;

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.232" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.236" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.232" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.236" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.232" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.236" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/CreateSimulationConfigurationPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/CreateSimulationConfigurationPresenterSpecs.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using FakeItEasy;
+﻿using FakeItEasy;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
 using MoBi.Core.Services;
@@ -9,7 +8,6 @@ using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Presenter.Simulation;
 using MoBi.Presentation.Settings;
-using MoBi.Presentation.Tasks;
 using MoBi.Presentation.Views;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
@@ -111,7 +109,7 @@ namespace MoBi.Presentation
       {
          sut.CreateBasedOn(_simulation, false);
       }
-      
+
       [Observation]
       public void the_forbidden_names_must_not_be_initialized()
       {

--- a/tests/MoBi.Tests/Presentation/IndividualAndFilePathDTOSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/IndividualAndFilePathDTOSpecs.cs
@@ -1,0 +1,62 @@
+﻿using MoBi.Presentation.DTO;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Utility.Validation;
+
+namespace MoBi.Presentation
+{
+   public class concern_for_IndividualAndFilePathDTO : ContextSpecification<IndividualAndFilePathDTO>
+   {
+      protected override void Context()
+      {
+         sut = new IndividualAndFilePathDTO();
+      }
+   }
+
+   public class When_the_dto_has_path_and_individual : concern_for_IndividualAndFilePathDTO
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.FilePath = "filepath";
+         sut.IndividualBuildingBlock = new IndividualBuildingBlock();
+      }
+
+      [Observation]
+      public void the_validation_fails()
+      {
+         sut.IsValid().ShouldBeTrue();
+      }
+   }
+
+   public class When_the_dto_does_not_have_individual : concern_for_IndividualAndFilePathDTO
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.FilePath = "filepath";
+      }
+
+      [Observation]
+      public void the_validation_fails()
+      {
+         sut.IsValid().ShouldBeFalse();
+      }
+   }
+
+   public class When_the_dto_does_not_have_filepath : concern_for_IndividualAndFilePathDTO
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.IndividualBuildingBlock = new IndividualBuildingBlock();
+      }
+
+      [Observation]
+      public void the_validation_fails()
+      {
+         sut.IsValid().ShouldBeFalse();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/SelectFolderAndIndividualFromProjectPresenter.cs
+++ b/tests/MoBi.Tests/Presentation/SelectFolderAndIndividualFromProjectPresenter.cs
@@ -1,0 +1,80 @@
+﻿using FakeItEasy;
+using FakeItEasy.Core;
+using MoBi.Core.Domain.Repository;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Tasks.Edit;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain.Builder;
+
+namespace MoBi.Presentation
+{
+   public class concern_for_SelectFolderAndIndividualFromProjectPresenter : ContextSpecification<SelectFolderAndIndividualFromProjectPresenter>
+   {
+      protected IEditTaskForContainer _editTaskForContainer;
+      protected IBuildingBlockRepository _buildingBlockRepository;
+      protected ISelectFolderAndIndividualFromProjectView _view;
+
+      protected override void Context()
+      {
+         _view = A.Fake<ISelectFolderAndIndividualFromProjectView>();
+         _buildingBlockRepository = A.Fake<IBuildingBlockRepository>();
+         _editTaskForContainer = A.Fake<IEditTaskForContainer>();
+
+         sut = new SelectFolderAndIndividualFromProjectPresenter(_view, _buildingBlockRepository, _editTaskForContainer);
+      }
+   }
+
+   public abstract class When_gathering_the_file_path_and_individual_building_block_from_user : concern_for_SelectFolderAndIndividualFromProjectPresenter
+   {
+      protected string _filePath;
+      protected IndividualBuildingBlock _individualBuildingBlock;
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _view.Canceled).Returns(Cancelled);
+         _individualBuildingBlock = new IndividualBuildingBlock();
+         _filePath = "FilePath";
+         A.CallTo(() => _view.BindTo(A<IndividualAndFilePathDTO>._)).Invokes(x =>
+         {
+            var dto = x.Arguments.Get<IndividualAndFilePathDTO>(0);
+            dto.FilePath = _filePath;
+            dto.IndividualBuildingBlock = _individualBuildingBlock;
+         });
+      }
+
+      public abstract bool Cancelled { get; }
+
+      protected override void Because()
+      {
+         sut.GetPathAndIndividualForExport("name");
+      }
+   }
+
+   public class When_the_user_does_not_cancel_the_selection : When_gathering_the_file_path_and_individual_building_block_from_user
+   {
+      public override bool Cancelled => false;
+
+      [Observation]
+      public void the_properties_should_return_selected_values()
+      {
+         sut.SelectedFilePath.ShouldBeEqualTo(_filePath);
+         sut.SelectedIndividual.ShouldBeEqualTo(_individualBuildingBlock);
+      }
+   }
+
+   public class When_the_user_cancels_the_selection : When_gathering_the_file_path_and_individual_building_block_from_user
+   {
+      public override bool Cancelled => true;
+
+      [Observation]
+      public void the_properties_should_return_null_or_empty()
+      {
+         sut.SelectedFilePath.ShouldBeEmpty();
+         sut.SelectedIndividual.ShouldBeNull();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/SelectFolderAndIndividualFromProjectPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectFolderAndIndividualFromProjectPresenterSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using FakeItEasy;
-using FakeItEasy.Core;
 using MoBi.Core.Domain.Repository;
 using MoBi.Helpers;
 using MoBi.Presentation.DTO;
@@ -33,6 +32,8 @@ namespace MoBi.Presentation
    {
       protected string _filePath;
       protected IndividualBuildingBlock _individualBuildingBlock;
+      protected IndividualBuildingBlock _selectedIndividual;
+      protected string _selectedPath;
 
       protected override void Context()
       {
@@ -52,7 +53,7 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.GetPathAndIndividualForExport(new Container().WithName("name"));
+         (_selectedPath, _selectedIndividual) = sut.GetPathAndIndividualForExport(new Container().WithName("name"));
       }
    }
 
@@ -63,8 +64,8 @@ namespace MoBi.Presentation
       [Observation]
       public void the_properties_should_return_selected_values()
       {
-         sut.SelectedFilePath.ShouldBeEqualTo(_filePath);
-         sut.SelectedIndividual.ShouldBeEqualTo(_individualBuildingBlock);
+         _selectedPath.ShouldBeEqualTo(_filePath);
+         _selectedIndividual.ShouldBeEqualTo(_individualBuildingBlock);
       }
    }
 
@@ -75,8 +76,8 @@ namespace MoBi.Presentation
       [Observation]
       public void the_properties_should_return_null_or_empty()
       {
-         sut.SelectedFilePath.ShouldBeEmpty();
-         sut.SelectedIndividual.ShouldBeNull();
+         _selectedPath.ShouldBeEmpty();
+         _selectedIndividual.ShouldBeNull();
       }
    }
 }

--- a/tests/MoBi.Tests/Presentation/SelectFolderAndIndividualFromProjectPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectFolderAndIndividualFromProjectPresenterSpecs.cs
@@ -1,12 +1,14 @@
 ﻿using FakeItEasy;
 using FakeItEasy.Core;
 using MoBi.Core.Domain.Repository;
+using MoBi.Helpers;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Edit;
 using MoBi.Presentation.Views;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 
 namespace MoBi.Presentation
@@ -23,7 +25,7 @@ namespace MoBi.Presentation
          _buildingBlockRepository = A.Fake<IBuildingBlockRepository>();
          _editTaskForContainer = A.Fake<IEditTaskForContainer>();
 
-         sut = new SelectFolderAndIndividualFromProjectPresenter(_view, _buildingBlockRepository, _editTaskForContainer);
+         sut = new SelectFolderAndIndividualFromProjectPresenter(_view, _buildingBlockRepository, _editTaskForContainer, new ObjectPathFactoryForSpecs());
       }
    }
 
@@ -50,7 +52,7 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.GetPathAndIndividualForExport("name");
+         sut.GetPathAndIndividualForExport(new Container().WithName("name"));
       }
    }
 

--- a/tests/MoBi.Tests/Presentation/Tasks/EditTaskForContainerSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/EditTaskForContainerSpecs.cs
@@ -14,7 +14,6 @@ using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Mappers;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Extensions;
-using Container = OSPSuite.Core.Domain.Container;
 
 namespace MoBi.Presentation.Tasks
 {
@@ -83,21 +82,20 @@ namespace MoBi.Presentation.Tasks
          base.Context();
          _parentContainer = new Container().WithName("Parent");
          _individual = new IndividualBuildingBlock().WithName("Individual");
-         _individual.Add(new IndividualParameter {ContainerPath = new ObjectPath("Parent", "Container1")}.WithName("parameter1"));
-         _individual.Add(new IndividualParameter {ContainerPath = new ObjectPath("Parent", "Container1")}.WithName("ShouldBeReplaced"));
-         _individual.Add(new IndividualParameter {ContainerPath = new ObjectPath("Parent", "Container2")}.WithName("parameter2"));
+         _individual.Add(new IndividualParameter { ContainerPath = new ObjectPath("Parent", "Container1") }.WithName("parameter1"));
+         _individual.Add(new IndividualParameter { ContainerPath = new ObjectPath("Parent", "Container1") }.WithName("ShouldBeReplaced"));
+         _individual.Add(new IndividualParameter { ContainerPath = new ObjectPath("Parent", "Container2") }.WithName("parameter2"));
          _containerToSave = new Container().WithName("Container1").WithMode(ContainerMode.Physical).Under(_parentContainer);
          _clonedContainer = new Container().WithName("Container1").WithMode(ContainerMode.Physical);
          _replacedParameter = new Parameter().WithName("ShouldBeReplaced");
          _clonedContainer.Add(_replacedParameter);
-         
+
          _tmpSpatialStructure = new MoBiSpatialStructure
          {
             NeighborhoodsContainer = new Container().WithName(Constants.NEIGHBORHOODS)
          };
 
-         A.CallTo(() => _selectIndividualFromProjectPresenter.SelectedFilePath).Returns("FilePath");
-         A.CallTo(() => _selectIndividualFromProjectPresenter.SelectedIndividual).Returns(_individual);
+         A.CallTo(() => _selectIndividualFromProjectPresenter.GetPathAndIndividualForExport(_containerToSave)).Returns(("FilePath", _individual));
          A.CallTo(() => _spatialStructureFactory.Create()).Returns(_tmpSpatialStructure);
          A.CallTo(() => _cloneManager.Clone(_containerToSave, _tmpSpatialStructure.FormulaCache)).Returns(_clonedContainer);
          A.CallTo(() => _individualParameterToParameterMapper.MapFrom(A<IndividualParameter>._)).ReturnsLazily(x => new Parameter().WithName(x.Arguments.Get<IndividualParameter>(0).Name));

--- a/tests/MoBi.Tests/Presentation/Tasks/EditTaskForContainerSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/EditTaskForContainerSpecs.cs
@@ -1,19 +1,19 @@
 ﻿using System.Linq;
-using DevExpress.Utils.Extensions;
 using FakeItEasy;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Builder;
 using MoBi.Core.Domain.Model;
 using MoBi.Helpers;
+using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Edit;
 using MoBi.Presentation.Tasks.Interaction;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
-using OSPSuite.Presentation.Presenters;
+using OSPSuite.Core.Domain.Mappers;
+using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Extensions;
-using static MoBi.Assets.ToolTips;
 using Container = OSPSuite.Core.Domain.Container;
 
 namespace MoBi.Presentation.Tasks
@@ -24,15 +24,25 @@ namespace MoBi.Presentation.Tasks
       protected IInteractionTaskContext _interactionTaskContext;
       protected IInteractionTask _interactionTask;
       protected IObjectPathFactory _objectPathFactory;
+      private IMoBiApplicationController _applicationController;
+      protected ISelectFolderAndIndividualFromProjectPresenter _selectIndividualFromProjectPresenter;
+      protected ICloneManagerForBuildingBlock _cloneManager;
+      protected IIndividualParameterToParameterMapper _individualParameterToParameterMapper;
 
       protected override void Context()
       {
          _spatialStructureFactory = A.Fake<IMoBiSpatialStructureFactory>();
          _interactionTaskContext = A.Fake<IInteractionTaskContext>();
+         _applicationController = A.Fake<IMoBiApplicationController>();
+         _selectIndividualFromProjectPresenter = A.Fake<ISelectFolderAndIndividualFromProjectPresenter>();
+         _cloneManager = A.Fake<ICloneManagerForBuildingBlock>();
+         _individualParameterToParameterMapper = A.Fake<IIndividualParameterToParameterMapper>();
+         A.CallTo(() => _applicationController.Start<ISelectFolderAndIndividualFromProjectPresenter>()).Returns(_selectIndividualFromProjectPresenter);
+         A.CallTo(() => _interactionTaskContext.ApplicationController).Returns(_applicationController);
          _interactionTask = A.Fake<IInteractionTask>();
          _objectPathFactory = new ObjectPathFactoryForSpecs();
          A.CallTo(() => _interactionTaskContext.InteractionTask).Returns(_interactionTask);
-         sut = new EditTaskForContainer(_interactionTaskContext, _spatialStructureFactory, _objectPathFactory);
+         sut = new EditTaskForContainer(_interactionTaskContext, _spatialStructureFactory, _objectPathFactory, _cloneManager, _individualParameterToParameterMapper);
       }
    }
 
@@ -56,6 +66,48 @@ namespace MoBi.Presentation.Tasks
       public void A_call_to_interaction_task_saving_the_container_must_not_have_happened()
       {
          A.CallTo(() => _spatialStructureFactory.Create()).MustNotHaveHappened();
+      }
+   }
+
+   public class When_saving_a_container_with_individual_to_pkml : concern_for_EditTaskForContainer
+   {
+      private IContainer _clonedEntity;
+      private Container _parentContainer;
+      private MoBiSpatialStructure _tmpSpatialStructure;
+      private IndividualBuildingBlock _individual;
+      private IContainer _entityToSave;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parentContainer = new Container().WithName("Parent");
+         _individual = new IndividualBuildingBlock().WithName("Individual");
+         _individual.Add(new IndividualParameter {ContainerPath = new ObjectPath("Parent", "Container1")}.WithName("parameter1"));
+         _individual.Add(new IndividualParameter {ContainerPath = new ObjectPath("Parent", "Container2")}.WithName("parameter2"));
+         _entityToSave = new Container().WithName("Container1").WithMode(ContainerMode.Physical).Under(_parentContainer);
+         _clonedEntity = new Container().WithName("Container1").WithMode(ContainerMode.Physical);
+         
+         _tmpSpatialStructure = new MoBiSpatialStructure
+         {
+            NeighborhoodsContainer = new Container().WithName(Constants.NEIGHBORHOODS)
+         };
+
+         A.CallTo(() => _selectIndividualFromProjectPresenter.SelectedFilePath).Returns("FilePath");
+         A.CallTo(() => _selectIndividualFromProjectPresenter.SelectedIndividual).Returns(_individual);
+         A.CallTo(() => _spatialStructureFactory.Create()).Returns(_tmpSpatialStructure);
+         A.CallTo(() => _cloneManager.Clone(_entityToSave, _tmpSpatialStructure.FormulaCache)).Returns(_clonedEntity);
+         A.CallTo(() => _individualParameterToParameterMapper.MapFrom(A<IndividualParameter>._)).ReturnsLazily(x => new Parameter().WithName(x.Arguments.Get<IndividualParameter>(0).Name));
+      }
+
+      protected override void Because()
+      {
+         sut.SaveWithIndividual(_entityToSave);
+      }
+
+      [Observation]
+      public void the_exported_structure_should_have_parameters_from_the_individual_if_they_match_the_container_path()
+      {
+         _tmpSpatialStructure.TopContainers.Single(x => x.Name.Equals("Container1")).Single().Name.ShouldBeEqualTo("parameter1");
       }
    }
 

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.232" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.232" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.236" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.236" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
You open the context menu and select 'Export With Individual'.  Any suggestions for this context menu are appreciated
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/b8dafcce-6442-4f95-867f-010b964fc3ab)

Can't close without specifying both individual and file path. The file path button opens the standard file browser.
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/ef1e7a35-2ec8-4750-9245-89cc35b682bb)

Ok, saves the container PKML with additional parameters from the individual where they match the container path
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/19bdac70-c715-4196-9ce3-a9f61be88aab)

