### PR TITLE
Fixes #1133 Prompt users to import more than just module

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Please mark relevant options with an `x` in the brackets.
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+- [ ] This change requires documentation changes (link at least one documentation issue):
 - [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
 - [ ] Other (please describe):
 
@@ -33,6 +33,7 @@ Mark everything that needs to be checked before merging the PR.
 - [ ] Check if the code is well tested
 - [ ] Check if the code is readable and well formatted
 - [ ] Additional checks (document below if any)
+- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected
 
 # Screenshots (if appropriate):
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ test:
 
 skip_commits:
   files:
-    - '*.md'
+    - '**/*.md'
 
 skip_branch_with_pr: true
 

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using DevExpress.Utils.Serializing;
 using OSPSuite.Assets;
+using OSPSuite.Assets.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
@@ -260,6 +260,7 @@ namespace MoBi.Assets
          public static readonly string UpdateRelativeExpressions = "Update relative expressions";
          public static readonly string UpdateProjectDefaultSimulationSettings = "Update project default simulation settings";
          public static readonly string RemoveTrackedQuantityChanges = "Remove tracked quantity changes";
+         public static readonly string AddedMultipleBuildingBlocksFromFile = "Added multiple building blocks from file";
 
          public static string DeleteResultsFromSimulation(string simulationName)
          {
@@ -1864,6 +1865,19 @@ namespace MoBi.Assets
          public static string SelectBuildingBlocksToCloneFrom(Module module)
          {
             return $"Select building blocks to clone from {module.Name}";
+         }
+
+         public static string AlsoImportIndividualsAndExpressions(int numberOfIndividuals, int numberOfExpressions)
+         {
+            var individual = "individual".PluralizeIf(numberOfIndividuals);
+            var expression = "expressions".PluralizeIf(numberOfExpressions);
+               
+            if (numberOfExpressions == 0)
+               return $"Also import {numberOfIndividuals} {individual}?";
+            else if(numberOfIndividuals == 0)
+               return $"Also import {numberOfExpressions} {expression}?";
+
+            return $"Also import {numberOfIndividuals} {individual} and {numberOfExpressions} {expression}?";
          }
       }
 

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1869,15 +1869,16 @@ namespace MoBi.Assets
 
          public static string AlsoImportIndividualsAndExpressions(int numberOfIndividuals, int numberOfExpressions)
          {
-            var individual = "individual".PluralizeIf(numberOfIndividuals);
-            var expression = "expressions".PluralizeIf(numberOfExpressions);
+            var individual = $"{numberOfIndividuals} individual".PluralizeIf(numberOfIndividuals);
+            var expression = $"{numberOfExpressions} expression".PluralizeIf(numberOfExpressions);
                
             if (numberOfExpressions == 0)
-               return $"Also import {numberOfIndividuals} {individual}?";
-            else if(numberOfIndividuals == 0)
-               return $"Also import {numberOfExpressions} {expression}?";
+               return $"Also import {individual}?";
+            
+            if(numberOfIndividuals == 0)
+               return $"Also import {expression}?";
 
-            return $"Also import {numberOfIndividuals} {individual} and {numberOfExpressions} {expression}?";
+            return $"Also import {individual} and {expression}?";
          }
       }
 

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/RootContextMenuForModule.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/RootContextMenuForModule.cs
@@ -29,16 +29,16 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
       public override IContextMenu InitializeWith(IPresenter presenter)
       {
          _allMenuItems.Add(addNewWithContent());
-         _allMenuItems.Add(loadExisting(_context.CurrentProject));
+         _allMenuItems.Add(loadExisting());
 
          return this;
       }
 
-      private IMenuBarItem loadExisting(MoBiProject project)
+      private IMenuBarItem loadExisting()
       {
          return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddExisting(ObjectTypeName))
             .WithIcon(ApplicationIcons.LoadIconFor(nameof(Module)))
-            .WithCommandFor<AddExistingCommandFor<MoBiProject, Module>, MoBiProject>(project, _container);
+            .WithCommand<LoadModuleUICommand>(_container);
       }
    }
 }

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTask.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTask.cs
@@ -10,6 +10,7 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Serialization.Exchange;
 
 namespace MoBi.Presentation.Tasks.Interaction
 {
@@ -27,6 +28,7 @@ namespace MoBi.Presentation.Tasks.Interaction
       string AskForFileToOpen(string title, string filter, string directoryKey);
       string AskForFileToSave(string title, string filter, string directoryKey, string defaultName);
       string AskForFolder(string title, string directoryKey);
+      SimulationTransfer LoadSimulationTransfer(string filePath);
    }
 
    public class InteractionTask : IInteractionTask
@@ -68,18 +70,14 @@ namespace MoBi.Presentation.Tasks.Interaction
          _serializationTask.SaveModelPart(entityToSerialize, fileName);
       }
 
-      public void Save<T>(T entityToSerialize, string fileName) where T : IObjectBase
-      {
-         _serializationTask.SaveModelPart(entityToSerialize, fileName);
-      }
+      public void Save<T>(T entityToSerialize, string fileName) where T : IObjectBase => _serializationTask.SaveModelPart(entityToSerialize, fileName);
 
       public virtual T Clone<T>(T objectToClone) where T : class, IObjectBase
       {
          var formulaCache = new FormulaCache();
          var clone = _cloneManagerForBuildingBlock.Clone(objectToClone, formulaCache);
 
-         var cloneBuildingBlock = clone as IBuildingBlock;
-         if (cloneBuildingBlock != null)
+         if (clone is IBuildingBlock cloneBuildingBlock)
             updateFormulaCacheOfClone(objectToClone.DowncastTo<IBuildingBlock>(), cloneBuildingBlock, formulaCache);
 
          return clone;
@@ -109,39 +107,20 @@ namespace MoBi.Presentation.Tasks.Interaction
          return !_adjustFormulasVisitor.Canceled;
       }
 
-      public string TypeFor<T>(T objectRequestingType) where T : class
-      {
-         return _objectTypeResolver.TypeFor(objectRequestingType);
-      }
+      public string TypeFor<T>(T objectRequestingType) where T : class => _objectTypeResolver.TypeFor(objectRequestingType);
 
-      public IEnumerable<string> ForbiddenNamesFor<T>(T objectBase) where T : IObjectBase
-      {
-         return _forbiddenNamesRetriever.For(objectBase);
-      }
+      public IEnumerable<string> ForbiddenNamesFor<T>(T objectBase) where T : IObjectBase => _forbiddenNamesRetriever.For(objectBase);
 
-      public string AskForFileToOpen(string title, string filter, string directoryKey)
-      {
-         return _dialogCreator.AskForFileToOpen(title, filter, directoryKey);
-      }
+      public string AskForFileToOpen(string title, string filter, string directoryKey) => _dialogCreator.AskForFileToOpen(title, filter, directoryKey);
 
-      public string AskForFolder(string title, string directoryKey)
-      {
-         return _dialogCreator.AskForFolder(title, directoryKey);
-      }
+      public string AskForFolder(string title, string directoryKey) => _dialogCreator.AskForFolder(title, directoryKey);
 
-      public string AskForFileToSave(string title, string filter, string directoryKey, string defaultName)
-      {
-         return _dialogCreator.AskForFileToSave(title, filter, directoryKey, defaultName);
-      }
+      public SimulationTransfer LoadSimulationTransfer(string filePath) => _serializationTask.Load<SimulationTransfer>(filePath);
 
-      public string IconFor<T>(T entity) where T : IObjectBase
-      {
-         return _iconRepository.IconNameFor(entity);
-      }
+      public string AskForFileToSave(string title, string filter, string directoryKey, string defaultName) => _dialogCreator.AskForFileToSave(title, filter, directoryKey, defaultName);
 
-      public bool CorrectName<T>(T objectBase, IEnumerable<string> forbiddenNames) where T : IObjectBase
-      {
-         return _nameCorrector.CorrectName(forbiddenNames, objectBase);
-      }
+      public string IconFor<T>(T entity) where T : IObjectBase => _iconRepository.IconNameFor(entity);
+
+      public bool CorrectName<T>(T objectBase, IEnumerable<string> forbiddenNames) where T : IObjectBase => _nameCorrector.CorrectName(forbiddenNames, objectBase);
    }
 }

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -25,6 +25,9 @@ namespace MoBi.Presentation.Tasks.Interaction
       IMoBiCommand AddToParent(TChild childToAdd, TParent parent, IBuildingBlock buildingBlockWithFormulaCache);
 
       TChild CreateNewEntity(TParent parent);
+      IMoBiCommand AddItemsToProject(IReadOnlyCollection<TChild> itemsToAdd, TParent parent, IBuildingBlock buildingBlockWithFormulaCache);
+      IMoBiCommand AddItemsToProjectFromFile(string filename, TParent parent, IBuildingBlock buildingBlockWithFormulaCache);
+      string AskForPKMLFileToOpen();
    }
 
    public abstract class InteractionTasksForChildren<TParent, TChild> : InteractionTasksForChildren<TParent, TChild, IEditTaskFor<TChild>>
@@ -140,10 +143,10 @@ namespace MoBi.Presentation.Tasks.Interaction
       public virtual IMoBiCommand AddExisting(TParent parent, IBuildingBlock buildingBlockWithFormulaCache)
       {
          var filename = AskForPKMLFileToOpen();
-         return addItemsToProjectFromFile(filename, parent, buildingBlockWithFormulaCache);
+         return AddItemsToProjectFromFile(filename, parent, buildingBlockWithFormulaCache);
       }
 
-      protected string AskForPKMLFileToOpen()
+      public string AskForPKMLFileToOpen()
       {
          return InteractionTask.AskForFileToOpen(AppConstants.Dialog.Load(_editTask.ObjectName), Constants.Filter.PKML_FILE_FILTER, Constants.DirectoryKey.MODEL_PART);
       }
@@ -152,10 +155,10 @@ namespace MoBi.Presentation.Tasks.Interaction
       {
          _interactionTaskContext.UpdateTemplateDirectories();
          var filename = InteractionTask.AskForFileToOpen(AppConstants.Dialog.LoadFromTemplate(_editTask.ObjectName), Constants.Filter.PKML_FILE_FILTER, Constants.DirectoryKey.TEMPLATE);
-         return addItemsToProjectFromFile(filename, parent, buildingBlockWithFormulaCache);
+         return AddItemsToProjectFromFile(filename, parent, buildingBlockWithFormulaCache);
       }
 
-      private IMoBiCommand addItemsToProjectFromFile(string filename, TParent parent, IBuildingBlock buildingBlockWithFormulaCache)
+      public IMoBiCommand AddItemsToProjectFromFile(string filename, TParent parent, IBuildingBlock buildingBlockWithFormulaCache)
       {
          if (filename.IsNullOrEmpty())
             return new MoBiEmptyCommand();

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -25,8 +25,8 @@ namespace MoBi.Presentation.Tasks.Interaction
       IMoBiCommand AddToParent(TChild childToAdd, TParent parent, IBuildingBlock buildingBlockWithFormulaCache);
 
       TChild CreateNewEntity(TParent parent);
-      IMoBiCommand AddItemsToProject(IReadOnlyCollection<TChild> itemsToAdd, TParent parent, IBuildingBlock buildingBlockWithFormulaCache);
-      IMoBiCommand AddItemsToProjectFromFile(string filename, TParent parent, IBuildingBlock buildingBlockWithFormulaCache);
+      IMoBiCommand AddItemsToProject(IReadOnlyCollection<TChild> itemsToAdd, TParent parent, IBuildingBlock buildingBlockWithFormulaCache = null);
+      IMoBiCommand AddItemsToProjectFromFile(string filename, TParent parent, IBuildingBlock buildingBlockWithFormulaCache = null);
       string AskForPKMLFileToOpen();
    }
 
@@ -158,7 +158,7 @@ namespace MoBi.Presentation.Tasks.Interaction
          return AddItemsToProjectFromFile(filename, parent, buildingBlockWithFormulaCache);
       }
 
-      public IMoBiCommand AddItemsToProjectFromFile(string filename, TParent parent, IBuildingBlock buildingBlockWithFormulaCache)
+      public IMoBiCommand AddItemsToProjectFromFile(string filename, TParent parent, IBuildingBlock buildingBlockWithFormulaCache = null)
       {
          if (filename.IsNullOrEmpty())
             return new MoBiEmptyCommand();
@@ -171,7 +171,7 @@ namespace MoBi.Presentation.Tasks.Interaction
          return InteractionTask.LoadItems<TChild>(filename);
       }
 
-      public IMoBiCommand AddItemsToProject(IReadOnlyCollection<TChild> itemsToAdd, TParent parent, IBuildingBlock buildingBlockWithFormulaCache)
+      public IMoBiCommand AddItemsToProject(IReadOnlyCollection<TChild> itemsToAdd, TParent parent, IBuildingBlock buildingBlockWithFormulaCache = null)
       {
          if (itemsToAdd == null || !itemsToAdd.Any())
             return new MoBiEmptyCommand();

--- a/src/MoBi.Presentation/Tasks/ModuleLoader.cs
+++ b/src/MoBi.Presentation/Tasks/ModuleLoader.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+using MoBi.Assets;
+using MoBi.Core.Commands;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Helper;
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Services;
+using OSPSuite.Utility.Extensions;
+
+namespace MoBi.Presentation.Tasks
+{
+   public interface IModuleLoader
+   {
+      IMoBiCommand LoadModule(MoBiProject parent);
+   }
+
+   public class ModuleLoader : IModuleLoader
+   {
+      private readonly IInteractionTasksForModule _moduleTask;
+      private readonly IInteractionTasksForExpressionProfileBuildingBlock _expressionTask;
+      private readonly IInteractionTasksForIndividualBuildingBlock _individualTask;
+      private readonly IInteractionTaskContext _interactionTaskContext;
+
+      public ModuleLoader(IInteractionTasksForModule moduleTask, IInteractionTasksForExpressionProfileBuildingBlock expressionTask, IInteractionTasksForIndividualBuildingBlock individualTask, IInteractionTaskContext interactionTaskContext)
+      {
+         _moduleTask = moduleTask;
+         _expressionTask = expressionTask;
+         _individualTask = individualTask;
+         _interactionTaskContext = interactionTaskContext;
+      }
+
+      public IMoBiCommand LoadModule(MoBiProject parent)
+      {
+         var filename = _moduleTask.AskForPKMLFileToOpen();
+
+         if (filename.IsNullOrEmpty())
+            return new MoBiEmptyCommand();
+
+         try
+         {
+            // If the user is adding modules from a simulation transfer, optionally add other building blocks
+            return addFromSimulationTransfer(parent, filename);
+         }
+         catch
+         {
+            // If the user is not loading from a simulation transfer, only add modules
+            return _moduleTask.AddItemsToProjectFromFile(filename, parent, null);
+         }
+      }
+
+      private IMoBiCommand addFromSimulationTransfer(MoBiProject parent, string filename)
+      {
+         var configuration = _interactionTaskContext.InteractionTask.LoadSimulationTransfer(filename).Simulation.Configuration;
+
+         var macroCommand = new MoBiMacroCommand
+         {
+            CommandType = AppConstants.Commands.AddCommand,
+            ObjectType = new ObjectTypeResolver().TypeFor<BuildingBlock>(),
+            Description = AppConstants.Commands.AddedMultipleBuildingBlocksFromFile
+         };
+
+         var modules = configuration.ModuleConfigurations.Select(x => x.Module).ToList();
+         var individuals = configuration.Individual == null ? new List<IndividualBuildingBlock>() : new List<IndividualBuildingBlock> { configuration.Individual };
+         var expressions = configuration.ExpressionProfiles;
+
+         macroCommand.Add(_moduleTask.AddItemsToProject(modules, parent, null));
+
+         if (!addAdditionalBuildingBlocksConfirmed(individuals.Count, expressions.Count))
+            return macroCommand;
+
+         macroCommand.Add(_individualTask.AddItemsToProject(individuals, parent, null));
+         macroCommand.Add(_expressionTask.AddItemsToProject(expressions, parent, null));
+
+         return macroCommand;
+      }
+
+      private bool addAdditionalBuildingBlocksConfirmed(int numberOfIndividuals, int numberOfExpressions)
+      {
+         // Do not prompt if there are no additional building blocks to add
+         if (numberOfIndividuals == 0 && numberOfExpressions == 0)
+            return false;
+
+         return ViewResult.Yes == _interactionTaskContext.DialogCreator.MessageBoxYesNo(AppConstants.Captions.AlsoImportIndividualsAndExpressions(numberOfIndividuals, numberOfExpressions));
+      }
+   }
+}

--- a/src/MoBi.Presentation/Tasks/ModuleLoader.cs
+++ b/src/MoBi.Presentation/Tasks/ModuleLoader.cs
@@ -13,7 +13,7 @@ namespace MoBi.Presentation.Tasks
 {
    public interface IModuleLoader
    {
-      IMoBiCommand LoadModule(MoBiProject parent);
+      IMoBiCommand LoadModule(MoBiProject project);
    }
 
    public class ModuleLoader : IModuleLoader
@@ -31,7 +31,7 @@ namespace MoBi.Presentation.Tasks
          _interactionTaskContext = interactionTaskContext;
       }
 
-      public IMoBiCommand LoadModule(MoBiProject parent)
+      public IMoBiCommand LoadModule(MoBiProject project)
       {
          var filename = _moduleTask.AskForPKMLFileToOpen();
 
@@ -41,16 +41,16 @@ namespace MoBi.Presentation.Tasks
          try
          {
             // If the user is adding modules from a simulation transfer, optionally add other building blocks
-            return addFromSimulationTransfer(parent, filename);
+            return addFromSimulationTransfer(project, filename);
          }
          catch
          {
             // If the user is not loading from a simulation transfer, only add modules
-            return _moduleTask.AddItemsToProjectFromFile(filename, parent, null);
+            return _moduleTask.AddItemsToProjectFromFile(filename, project);
          }
       }
 
-      private IMoBiCommand addFromSimulationTransfer(MoBiProject parent, string filename)
+      private IMoBiCommand addFromSimulationTransfer(MoBiProject project, string filename)
       {
          var configuration = _interactionTaskContext.InteractionTask.LoadSimulationTransfer(filename).Simulation.Configuration;
 
@@ -65,13 +65,13 @@ namespace MoBi.Presentation.Tasks
          var individuals = configuration.Individual == null ? new List<IndividualBuildingBlock>() : new List<IndividualBuildingBlock> { configuration.Individual };
          var expressions = configuration.ExpressionProfiles;
 
-         macroCommand.Add(_moduleTask.AddItemsToProject(modules, parent, null));
+         macroCommand.Add(_moduleTask.AddItemsToProject(modules, project));
 
          if (!addAdditionalBuildingBlocksConfirmed(individuals.Count, expressions.Count))
             return macroCommand;
 
-         macroCommand.Add(_individualTask.AddItemsToProject(individuals, parent, null));
-         macroCommand.Add(_expressionTask.AddItemsToProject(expressions, parent, null));
+         macroCommand.Add(_individualTask.AddItemsToProject(individuals, project));
+         macroCommand.Add(_expressionTask.AddItemsToProject(expressions, project));
 
          return macroCommand;
       }

--- a/src/MoBi.Presentation/UICommand/LoadModuleUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/LoadModuleUICommand.cs
@@ -1,0 +1,23 @@
+using MoBi.Core.Services;
+using MoBi.Presentation.Tasks;
+using OSPSuite.Presentation.MenuAndBars;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class LoadModuleUICommand : IUICommand
+   {
+      private readonly IModuleLoader _moduleLoader;
+      private readonly IMoBiProjectRetriever _projectRetriever;
+
+      public LoadModuleUICommand(IModuleLoader moduleLoader, IMoBiProjectRetriever projectRetriever)
+      {
+         _moduleLoader = moduleLoader;
+         _projectRetriever = projectRetriever;
+      }
+
+      public void Execute()
+      {
+         _moduleLoader.LoadModule(_projectRetriever.Current);
+      }
+   }
+}

--- a/src/MoBi.Presentation/UICommand/NewModuleWithBuildingBlocksUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/NewModuleWithBuildingBlocksUICommand.cs
@@ -1,4 +1,3 @@
-using MoBi.Core.Domain.Model;
 using MoBi.Presentation.Tasks.Interaction;
 using OSPSuite.Presentation.MenuAndBars;
 
@@ -8,7 +7,7 @@ namespace MoBi.Presentation.UICommand
    {
       private readonly IInteractionTasksForModule _interactionTasks;
 
-      public NewModuleWithBuildingBlocksUICommand(IInteractionTasksForModule interactionTasksForModule, IMoBiContext context)
+      public NewModuleWithBuildingBlocksUICommand(IInteractionTasksForModule interactionTasksForModule)
       {
          _interactionTasks = interactionTasksForModule;
       }

--- a/tests/MoBi.Tests/Presentation/Tasks/ModuleLoaderSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/ModuleLoaderSpecs.cs
@@ -1,0 +1,162 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Exceptions;
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Serialization.Exchange;
+using OSPSuite.Core.Services;
+
+namespace MoBi.Presentation.Tasks
+{
+   internal class concern_for_ModuleLoader : ContextSpecification<ModuleLoader>
+   {
+      protected MoBiProject _project;
+      protected SimulationTransfer _simulationTransfer;
+      protected MoBiSimulation _moBiSimulation;
+      protected IInteractionTasksForIndividualBuildingBlock _individualTask;
+      protected IInteractionTasksForExpressionProfileBuildingBlock _expressionTask;
+      protected IInteractionTasksForModule _moduleTask;
+      protected IInteractionTaskContext _interactionTaskContext;
+
+      protected override void Context()
+      {
+         base.Context();
+         _interactionTaskContext = A.Fake<IInteractionTaskContext>();
+         _moduleTask = A.Fake<IInteractionTasksForModule>();
+         _expressionTask = A.Fake<IInteractionTasksForExpressionProfileBuildingBlock>();
+         _individualTask = A.Fake<IInteractionTasksForIndividualBuildingBlock>();
+         _project = new MoBiProject();
+         _simulationTransfer = new SimulationTransfer();
+
+         _moBiSimulation = new MoBiSimulation();
+         _simulationTransfer.Simulation = _moBiSimulation;
+
+         _moBiSimulation.Configuration = new SimulationConfiguration();
+         _moBiSimulation.Configuration.AddModuleConfiguration(new ModuleConfiguration(new Module().WithName("module")));
+         AddAdditionalBuildingBlocks();
+
+         A.CallTo(() => _interactionTaskContext.InteractionTask.CorrectName(A<Module>._, A<IEnumerable<string>>._)).Returns(true);
+         A.CallTo(() => _moduleTask.AskForPKMLFileToOpen()).Returns("filePath");
+
+         sut = new ModuleLoader(_moduleTask, _expressionTask, _individualTask, _interactionTaskContext);
+      }
+
+      protected virtual void AddAdditionalBuildingBlocks()
+      {
+         _moBiSimulation.Configuration.Individual = new IndividualBuildingBlock().WithName("individual");
+         _moBiSimulation.Configuration.AddExpressionProfile(new ExpressionProfileBuildingBlock().WithName("expressionProfile1"));
+         _moBiSimulation.Configuration.AddExpressionProfile(new ExpressionProfileBuildingBlock().WithName("expressionProfile2"));
+      }
+   }
+
+   internal class When_loading_from_pkml_with_module_pkml : concern_for_ModuleLoader
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _interactionTaskContext.InteractionTask.LoadSimulationTransfer(A<string>._)).Throws(() => new NotMatchingSerializationFileException("exception"));
+         A.CallTo(() => _interactionTaskContext.InteractionTask.LoadItems<Module>("filePath")).Returns(new[] { new Module() });
+         A.CallTo(() => _interactionTaskContext.DialogCreator.MessageBoxYesNo(A<string>._, ViewResult.Yes)).Returns(ViewResult.Yes);
+      }
+
+      protected override void Because()
+      {
+         sut.LoadModule(_project);
+      }
+
+      [Observation]
+      public void the_module_is_loaded_using_the_interaction_task()
+      {
+         A.CallTo(() => _moduleTask.AddItemsToProjectFromFile("filePath", _project, null)).MustHaveHappened();
+      }
+   }
+
+   internal class When_loading_from_pkml_with_simulation_transfer_pkml_and_user_confirms_additional_building_blocks : concern_for_ModuleLoader
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _interactionTaskContext.InteractionTask.LoadSimulationTransfer(A<string>._)).Returns(_simulationTransfer);
+         A.CallTo(() => _interactionTaskContext.DialogCreator.MessageBoxYesNo(A<string>._, ViewResult.Yes)).Returns(ViewResult.Yes);
+      }
+
+      protected override void Because()
+      {
+         sut.LoadModule(_project);
+      }
+
+      [Observation]
+      public void the_tasks_should_be_used_to_add_elements_to_projects()
+      {
+         A.CallTo(() => _moduleTask.AddItemsToProject(A<IReadOnlyCollection<Module>>.That.Matches(x => x.Contains(_moBiSimulation.Modules.Single())), _project, null)).MustHaveHappened();
+         A.CallTo(() => _individualTask.AddItemsToProject(A<IReadOnlyCollection<IndividualBuildingBlock>>.That.Matches(x => x.ElementAt(0).Equals(_moBiSimulation.Configuration.Individual)), _project, null)).MustHaveHappened();
+         A.CallTo(() => _expressionTask.AddItemsToProject(A<IReadOnlyCollection<ExpressionProfileBuildingBlock>>.That.Matches(x => x.ElementAt(0).Equals(_moBiSimulation.Configuration.ExpressionProfiles[0])), _project, null)).MustHaveHappened();
+         A.CallTo(() => _expressionTask.AddItemsToProject(A<IReadOnlyCollection<ExpressionProfileBuildingBlock>>.That.Matches(x => x.ElementAt(1).Equals(_moBiSimulation.Configuration.ExpressionProfiles[1])), _project, null)).MustHaveHappened();
+      }
+   }
+
+   internal class When_loading_from_pkml_with_simulation_transfer_pkml_and_user_declines_additional_building_blocks : concern_for_ModuleLoader
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _interactionTaskContext.InteractionTask.LoadSimulationTransfer(A<string>._)).Returns(_simulationTransfer);
+         A.CallTo(() => _interactionTaskContext.DialogCreator.MessageBoxYesNo(A<string>._, ViewResult.Yes)).Returns(ViewResult.No);
+      }
+
+      protected override void Because()
+      {
+         sut.LoadModule(_project);
+      }
+
+      [Observation]
+      public void the_module_is_still_loaded_using_the_interaction_task()
+      {
+         A.CallTo(() => _moduleTask.AddItemsToProject(A<IReadOnlyCollection<Module>>.That.Matches(x => x.Contains(_moBiSimulation.Modules.Single())), _project, null)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_tasks_should_not_be_used_to_add_elements_to_projects()
+      {
+         A.CallTo(() => _individualTask.AddItemsToProject(A<IReadOnlyCollection<IndividualBuildingBlock>>._, A<MoBiProject>._, null)).MustNotHaveHappened();
+         A.CallTo(() => _expressionTask.AddItemsToProject(A<IReadOnlyCollection<ExpressionProfileBuildingBlock>>._, A<MoBiProject>._, null)).MustNotHaveHappened();
+         A.CallTo(() => _expressionTask.AddItemsToProject(A<IReadOnlyCollection<ExpressionProfileBuildingBlock>>._, A<MoBiProject>._, null)).MustNotHaveHappened();
+      }
+   }
+
+   internal class When_loading_from_pkml_with_simulation_transfer_pkml_and_there_arent_additional_building_blocks : concern_for_ModuleLoader
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _interactionTaskContext.InteractionTask.LoadSimulationTransfer(A<string>._)).Returns(_simulationTransfer);
+         A.CallTo(() => _interactionTaskContext.DialogCreator.MessageBoxYesNo(A<string>._, ViewResult.Yes)).Returns(ViewResult.Yes);
+      }
+
+      protected override void AddAdditionalBuildingBlocks()
+      {
+         // do not add anything
+      }
+
+      protected override void Because()
+      {
+         sut.LoadModule(_project);
+      }
+
+      [Observation]
+      public void the_user_should_not_be_prompted_to_import_additions()
+      {
+         A.CallTo(() => _interactionTaskContext.DialogCreator.MessageBoxYesNo(A<string>._, ViewResult.Yes)).MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void the_module_is_still_loaded_using_the_interaction_task()
+      {
+         A.CallTo(() => _moduleTask.AddItemsToProject(A<IReadOnlyCollection<Module>>.That.Matches(x => x.Contains(_moBiSimulation.Modules.Single())), _project, null)).MustHaveHappened();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #1133

# Description
If the user loads modules from a PKML file, this new feature checks if they are loading them directly from a SimulationTransfer. If so, the user is prompted to optionally load Individuals and Expressions from the SimulationTranfer.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)

# Screenshots (if appropriate):
Text and pluralization is different if there is only one building block, or if there is only building blocks for one of the types.
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/3d22b0c6-1969-4678-8c5b-dfe761f7f52f)

![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/038da507-2bc8-44e1-a7e7-de4abe0f6258)


# Questions (if appropriate):