### PR TITLE
Fixes #1141 Visual indication when a PK-Sim module has been changed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,10 @@ Please mark relevant options with an `x` in the brackets.
 - [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
 - [ ] Other (please describe):
 
+https://github.com/Open-Systems-Pharmacology/docs
+https://github.com/Open-Systems-Pharmacology/developer-docs
+
+
 # How Has This Been Tested?
 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.242" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.240" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.242" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.240" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />

--- a/src/MoBi.Core/Commands/AddBuildingBlockToModuleCommand.cs
+++ b/src/MoBi.Core/Commands/AddBuildingBlockToModuleCommand.cs
@@ -26,7 +26,6 @@ namespace MoBi.Core.Commands
       protected override void ExecuteWith(IMoBiContext context)
       {
          DoExecute(context);
-
          RaiseEvents(context);
       }
 
@@ -34,7 +33,7 @@ namespace MoBi.Core.Commands
       {
          if (!Silent)
             context.PublishEvent(new AddedEvent<T>(_buildingBlock, _existingModule));
-         
+
          PublishSimulationStatusChangedEvents(_existingModule, context);
       }
 

--- a/src/MoBi.Core/Commands/AddModuleCommand.cs
+++ b/src/MoBi.Core/Commands/AddModuleCommand.cs
@@ -38,13 +38,8 @@ namespace MoBi.Core.Commands
 
       private void updateImportVersion(Module module)
       {
-         if (isPKSimModuleInitialImport(module))
-            module.AddExtendedProperty(Constants.PK_SIM_MODULE_IMPORT_VERSION, module.Version);
-      }
-
-      private static bool isPKSimModuleInitialImport(Module module)
-      {
-         return module.ExtendedProperties.Contains(Constants.PK_SIM_VERSION) && !module.ExtendedProperties.Contains(Constants.PK_SIM_MODULE_IMPORT_VERSION);
+         if(string.IsNullOrEmpty(module.ModuleImportVersion))
+            module.ModuleImportVersion = module.Version;
       }
 
       public override void RestoreExecutionData(IMoBiContext context)

--- a/src/MoBi.Core/Commands/AddModuleCommand.cs
+++ b/src/MoBi.Core/Commands/AddModuleCommand.cs
@@ -10,7 +10,7 @@ namespace MoBi.Core.Commands
    public class AddModuleCommand : MoBiReversibleCommand, ISilentCommand
    {
       protected Module _module;
-      public string ModuleId { get; private set; }
+      public string ModuleId { get; }
       public bool Silent { get; set; }
 
       public AddModuleCommand(Module module)
@@ -27,12 +27,24 @@ namespace MoBi.Core.Commands
       {
          var project = context.CurrentProject;
 
+         updateImportVersion(_module);
          context.Register(_module);
 
          addToProject(project);
 
          if (!Silent)
             context.PublishEvent(new AddedEvent<Module>(_module, project));
+      }
+
+      private void updateImportVersion(Module module)
+      {
+         if (isPKSimModuleInitialImport(module))
+            module.AddExtendedProperty(Constants.PK_SIM_MODULE_IMPORT_VERSION, module.Version);
+      }
+
+      private static bool isPKSimModuleInitialImport(Module module)
+      {
+         return module.ExtendedProperties.Contains(Constants.PK_SIM_VERSION) && !module.ExtendedProperties.Contains(Constants.PK_SIM_MODULE_IMPORT_VERSION);
       }
 
       public override void RestoreExecutionData(IMoBiContext context)

--- a/src/MoBi.Core/Commands/AddSimulationCommand.cs
+++ b/src/MoBi.Core/Commands/AddSimulationCommand.cs
@@ -3,6 +3,8 @@ using OSPSuite.Core.Commands.Core;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
 using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
+using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Core.Commands
 {
@@ -25,7 +27,14 @@ namespace MoBi.Core.Commands
          var project = context.CurrentProject;
          context.Register(_simulation);
          project.AddSimulation(_simulation);
+         _simulation.Modules.Each(setModuleImportVersion);
          context.PublishEvent(new SimulationAddedEvent(_simulation));
+      }
+
+      private static void setModuleImportVersion(Module module)
+      {
+         if (string.IsNullOrEmpty(module.ModuleImportVersion))
+            module.ModuleImportVersion = module.Version;
       }
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)

--- a/src/MoBi.Core/Events/Events.cs
+++ b/src/MoBi.Core/Events/Events.cs
@@ -202,6 +202,16 @@ namespace MoBi.Core.Events
       }
    }
 
+   public class ModuleStatusChangedEvent
+   {
+      public Module Module { get; }
+
+      public ModuleStatusChangedEvent(Module module)
+      {
+         Module = module;
+      }
+   }
+
    public class SimulationStatusChangedEvent
    {
       public IMoBiSimulation Simulation { get; }

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.242" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.240" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.241" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/Services/BuildingBlockVersionUpdater.cs
+++ b/src/MoBi.Core/Services/BuildingBlockVersionUpdater.cs
@@ -39,7 +39,7 @@ namespace MoBi.Core.Services
          if (!_projectRetriever.Current.Modules.SelectMany(x => x.BuildingBlocks).Contains(buildingBlock))
             return;
 
-         refreshModule(_projectRetriever.Current.Modules.Single(x => x.BuildingBlocks.Contains(buildingBlock)));
+         refreshModule(buildingBlock.Module);
       }
 
       private void refreshModule(Module module)

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.242" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.240" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.241" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.240" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.242" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Nodes/ModuleConfigurationNode.cs
+++ b/src/MoBi.Presentation/Nodes/ModuleConfigurationNode.cs
@@ -11,6 +11,7 @@ namespace MoBi.Presentation.Nodes
       {
          Id = moduleConfiguration.Module.Id;
          Text = moduleConfiguration.Module.Name;
+         Icon = BaseIcon;
       }
 
       public string ModuleName => Tag.Module.Name;
@@ -21,6 +22,6 @@ namespace MoBi.Presentation.Nodes
       }
 
       public override string Id { get; }
-      public ApplicationIcon BaseIcon => ApplicationIcons.Module;
+      public ApplicationIcon BaseIcon => Tag.Module.IsPKSimModule? ApplicationIcons.PKSimModule : ApplicationIcons.Module;
    }
 }

--- a/src/MoBi.Presentation/Nodes/ModuleConfigurationNode.cs
+++ b/src/MoBi.Presentation/Nodes/ModuleConfigurationNode.cs
@@ -22,6 +22,6 @@ namespace MoBi.Presentation.Nodes
       }
 
       public override string Id { get; }
-      public ApplicationIcon BaseIcon => Tag.Module.IsPKSimModule? ApplicationIcons.PKSimModule : ApplicationIcons.Module;
+      public ApplicationIcon BaseIcon => ApplicationIcons.IconByName(Tag.Module.Icon);
    }
 }

--- a/src/MoBi.Presentation/Nodes/TreeNodeFactory.cs
+++ b/src/MoBi.Presentation/Nodes/TreeNodeFactory.cs
@@ -117,7 +117,7 @@ namespace MoBi.Presentation.Nodes
 
       public ITreeNode CreateFor(ModuleConfigurationDTO moduleConfiguration)
       {
-         var moduleConfigurationNode = new ModuleConfigurationNode(moduleConfiguration).WithIcon(ApplicationIcons.Module);
+         var moduleConfigurationNode = new ModuleConfigurationNode(moduleConfiguration);
          var module = moduleConfiguration.Module;
 
          addModuleBuildingBlocks(moduleConfigurationNode, module);

--- a/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
@@ -6,6 +6,7 @@ using MoBi.Core.Events;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Nodes;
 using MoBi.Presentation.Views;
+using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
@@ -35,7 +36,9 @@ namespace MoBi.Presentation.Presenter.Main
    public class ModuleExplorerPresenter : ExplorerPresenter<IModuleExplorerView, IModuleExplorerPresenter>, IModuleExplorerPresenter,
       IListener<AddedEvent<Module>>,
       IListener<AddedEvent<IndividualBuildingBlock>>,
-      IListener<AddedEvent<ExpressionProfileBuildingBlock>>
+      IListener<AddedEvent<ExpressionProfileBuildingBlock>>,
+      IListener<ModuleStatusChangedEvent>
+
    {
       private readonly IObservedDataInExplorerPresenter _observedDataInExplorerPresenter;
       private readonly IEditBuildingBlockStarter _editBuildingBlockStarter;
@@ -259,7 +262,9 @@ namespace MoBi.Presentation.Presenter.Main
          switch (eventToHandle.AddedObject)
          {
             case IBuildingBlock buildingBlock:
-               addBuildingBlockToModule(buildingBlock, eventToHandle.Parent as Module);
+               var module = eventToHandle.Parent as Module;
+               addBuildingBlockToModule(buildingBlock, module);
+               refreshModuleIcon(module);
                break;
          }
       }
@@ -267,6 +272,18 @@ namespace MoBi.Presentation.Presenter.Main
       public void Handle(RemovedEvent eventToHandle)
       {
          RemoveNodesFor(eventToHandle.RemovedObjects);
+         if(eventToHandle.Parent is Module module)
+            refreshModuleIcon(module);
+      }
+
+      public void Handle(ModuleStatusChangedEvent eventToHandle)
+      {
+         refreshModuleIcon(eventToHandle.Module);
+      }
+
+      private void refreshModuleIcon(Module module)
+      {
+         _view.NodeById(module.Id).Icon = module.IsPKSimModule ? ApplicationIcons.PKSimModule : ApplicationIcons.Module;
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
@@ -283,7 +283,7 @@ namespace MoBi.Presentation.Presenter.Main
 
       private void refreshModuleIcon(Module module)
       {
-         _view.NodeById(module.Id).Icon = module.IsPKSimModule ? ApplicationIcons.PKSimModule : ApplicationIcons.Module;
+         _view.NodeById(module.Id).Icon = ApplicationIcons.IconByName(module.Icon);
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/Main/SimulationExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/SimulationExplorerPresenter.cs
@@ -217,7 +217,6 @@ namespace MoBi.Presentation.Presenter.Main
          buildingBlock.Icon = changedSimulationBuildingBlocks.Contains(buildingBlock.Tag) ? ApplicationIcons.RedOverlayFor(buildingBlock.BaseIcon) : ApplicationIcons.GreenOverlayFor(buildingBlock.BaseIcon);
       }
 
-
       public override IEnumerable<ClassificationTemplate> AvailableClassificationCategories(ITreeNode<IClassification> parentClassificationNode)
       {
          return Enumerable.Empty<ClassificationTemplate>();

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.240" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.242" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.240" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.240" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.241" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.242" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.241" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.242" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/Core/BuildingBlockVersionUpdaterSpecs.cs
+++ b/tests/MoBi.Tests/Core/BuildingBlockVersionUpdaterSpecs.cs
@@ -31,6 +31,7 @@ namespace MoBi.Core
       private IList<IModelCoreSimulation> _affectedSimulations;
       private IMoBiSimulation _affectedSimulation;
       private readonly uint _targetVersion = 4;
+      private Module _module;
 
       protected override void Context()
       {
@@ -50,6 +51,8 @@ namespace MoBi.Core
 
          var project = DomainHelperForSpecs.NewProject();
          project.AddSimulation(_affectedSimulation);
+         _module = new Module {_changeBuildingBlock};
+         project.AddModule(_module);
          A.CallTo(() => _projectRetriever.Current).Returns(project);
       }
 
@@ -62,6 +65,12 @@ namespace MoBi.Core
       public void should_increment_building_block_version()
       {
          _changeBuildingBlock.Version.ShouldBeEqualTo(_targetVersion);
+      }
+
+      [Observation]
+      public void should_publish_module_status_changed_event()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(A<ModuleStatusChangedEvent>.That.Matches(x => x.Module.Equals(_module)))).MustHaveHappened();
       }
 
       [Observation]

--- a/tests/MoBi.Tests/Core/Commands/AddModuleCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/AddModuleCommandSpecs.cs
@@ -51,6 +51,32 @@ namespace MoBi.Core.Commands
       }
    }
 
+   public class When_executing_the_add_module_command_and_the_module_is_from_pk_sim_and_has_not_been_added_to_any_projects_before : concern_for_AddModuleCommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _module.AddExtendedProperty(Constants.PK_SIM_VERSION, "1");
+      }
+
+      protected override void Because()
+      {
+         sut.Execute(_context);
+      }
+
+      [Observation]
+      public void the_module_is_a_pk_sim_module()
+      {
+         _module.IsPKSimModule.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void the_module_has_its_import_version_added_to_extended_properties()
+      {
+         _module.ExtendedProperties.Contains(Constants.PK_SIM_MODULE_IMPORT_VERSION).ShouldBeTrue();
+      }
+   }
+
    public class When_executing_the_add_module_command_and_the_module_has_building_blocks : concern_for_AddModuleCommand
    {
       protected override void Context()
@@ -70,6 +96,18 @@ namespace MoBi.Core.Commands
       protected override void Because()
       {
          sut.Execute(_context);
+      }
+
+      [Observation]
+      public void the_module_doesnt_have_the_import_version_set()
+      {
+         _module.ExtendedProperties.Contains(Constants.PK_SIM_MODULE_IMPORT_VERSION).ShouldBeFalse();
+      }
+
+      [Observation]
+      public void the_module_is_not_pk_sim_module()
+      {
+         _module.IsPKSimModule.ShouldBeFalse();
       }
 
       [Observation]

--- a/tests/MoBi.Tests/Core/Commands/AddModuleCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/AddModuleCommandSpecs.cs
@@ -56,7 +56,7 @@ namespace MoBi.Core.Commands
       protected override void Context()
       {
          base.Context();
-         _module.AddExtendedProperty(Constants.PK_SIM_VERSION, "1");
+         _module.PKSimVersion= "1";
       }
 
       protected override void Because()
@@ -73,7 +73,7 @@ namespace MoBi.Core.Commands
       [Observation]
       public void the_module_has_its_import_version_added_to_extended_properties()
       {
-         _module.ExtendedProperties.Contains(Constants.PK_SIM_MODULE_IMPORT_VERSION).ShouldBeTrue();
+         _module.ModuleImportVersion.ShouldNotBeNull();
       }
    }
 
@@ -96,12 +96,6 @@ namespace MoBi.Core.Commands
       protected override void Because()
       {
          sut.Execute(_context);
-      }
-
-      [Observation]
-      public void the_module_doesnt_have_the_import_version_set()
-      {
-         _module.ExtendedProperties.Contains(Constants.PK_SIM_MODULE_IMPORT_VERSION).ShouldBeFalse();
       }
 
       [Observation]

--- a/tests/MoBi.Tests/Core/Commands/AddSelectedBuildingBlockToLastModuleConfigurationCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/AddSelectedBuildingBlockToLastModuleConfigurationCommandSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using FakeItEasy;
 using MoBi.Core.Domain.Model;
+using MoBi.Core.Events;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;

--- a/tests/MoBi.Tests/Core/Commands/RemoveSelectedBuildingBlockFromLastModuleConfigurationCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/RemoveSelectedBuildingBlockFromLastModuleConfigurationCommandSpecs.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using FakeItEasy;
 using MoBi.Core.Domain.Model;
+using MoBi.Core.Events;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -69,7 +70,7 @@ namespace MoBi.Core.Commands
       }
    }
 
-   public class When_removing_the_selected_building_block_from_the_simulation : concern_for_RemoveSelectedBuildingBlockFromLastModuleConfigurationCommand
+   public class When_removing_the_selected_building_block_module : concern_for_RemoveSelectedBuildingBlockFromLastModuleConfigurationCommand
    {
       protected override void Because()
       {

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.240" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.241" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.242" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.53" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/InteractionTasksForSimulationSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/InteractionTasksForSimulationSpecs.cs
@@ -136,6 +136,8 @@ namespace MoBi.Presentation
          _simulation.Configuration = new SimulationConfiguration();
          _configuredSimulation = new MoBiSimulation();
          _simulationConfiguration = new SimulationConfiguration();
+         _configuredSimulation.Configuration = new SimulationConfiguration();
+         _configuredSimulation.Configuration.AddModuleConfiguration(new ModuleConfiguration(new Module()));
          A.CallTo(() => _presenter.CreateBasedOn(_simulation, true)).Returns(_simulationConfiguration);
          A.CallTo(() => _applicationController.Start<ICreateSimulationConfigurationPresenter>()).Returns(_presenter);
          A.CallTo(() => _applicationController.PresenterFor(_simulation)).Returns(A.Fake<IEditSimulationPresenter>());
@@ -146,6 +148,12 @@ namespace MoBi.Presentation
       protected override void Because()
       {
          sut.CreateSimulation();
+      }
+
+      [Observation]
+      public void the_configured_simulation_modules_should_have_import_version_set()
+      {
+         _configuredSimulation.Modules.All(x => !string.IsNullOrEmpty(x.ModuleImportVersion)).ShouldBeTrue();
       }
 
       [Observation]

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.242" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.242" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.240" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.240" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.241" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.241" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1141

# Description
We are adding the concept of PK-Sim modules back. They aren't readonly, but you get an indication if a module is as-it-was-exported from PK-Sim. Building block changes trigger a change in the icon.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires documentation changes (link at least one documentation issue):
https://github.com/Open-Systems-Pharmacology/docs/issues/227
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):
