### PR TITLE
Fixes #1175 Expression Profile: Initial conditions paths should not be editable

### DIFF
--- a/src/MoBi.Presentation/DTO/ExpressionParameterDTO.cs
+++ b/src/MoBi.Presentation/DTO/ExpressionParameterDTO.cs
@@ -2,7 +2,7 @@
 
 namespace MoBi.Presentation.DTO
 {
-   public class ExpressionParameterDTO : PathAndValueEntityDTO<ExpressionParameter>, IWithFormulaDTO
+   public class ExpressionParameterDTO : PathAndValueEntityDTO<ExpressionParameter>
    {
       public ExpressionParameterDTO(ExpressionParameter expressionParameter) : base(expressionParameter)
       {

--- a/src/MoBi.Presentation/DTO/IPathAndValueEntityDTO.cs
+++ b/src/MoBi.Presentation/DTO/IPathAndValueEntityDTO.cs
@@ -1,0 +1,13 @@
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.DTO;
+
+namespace MoBi.Presentation.DTO
+{
+   public interface IPathAndValueEntityDTO : 
+      IWithDisplayUnitDTO, 
+      IWithValueOrigin, 
+      IWithName
+   {
+      ValueFormulaDTO Formula { get; set; }
+   }
+}

--- a/src/MoBi.Presentation/DTO/IndividualParameterDTO.cs
+++ b/src/MoBi.Presentation/DTO/IndividualParameterDTO.cs
@@ -2,7 +2,7 @@
 
 namespace MoBi.Presentation.DTO
 {
-   public class IndividualParameterDTO : PathAndValueEntityDTO<IndividualParameter>, IWithFormulaDTO
+   public class IndividualParameterDTO : PathAndValueEntityDTO<IndividualParameter>
    {
       public IndividualParameterDTO(IndividualParameter individualParameter) : base(individualParameter)
       {

--- a/src/MoBi.Presentation/DTO/StartValueDTO.cs
+++ b/src/MoBi.Presentation/DTO/StartValueDTO.cs
@@ -6,22 +6,12 @@ using System.Linq.Expressions;
 using MoBi.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
-using OSPSuite.Presentation.DTO;
 using OSPSuite.Utility.Extensions;
 using OSPSuite.Utility.Reflection;
 using OSPSuite.Utility.Validation;
 
 namespace MoBi.Presentation.DTO
 {
-   public interface IPathAndValueEntityDTO : IWithDisplayUnitDTO, IWithValueOrigin, IWithFormulaDTO
-   {
-   }
-
-   public interface IWithFormulaDTO
-   {
-      ValueFormulaDTO Formula { get; set; }
-   }
-
    public abstract class StartValueDTO<T> : PathAndValueEntityDTO<T> where T : PathAndValueEntity
    {
       private readonly IBuildingBlock<T> _buildingBlock;

--- a/src/MoBi.Presentation/Presenter/BuildingBlockWithInitialConditionsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/BuildingBlockWithInitialConditionsPresenter.cs
@@ -96,6 +96,11 @@ namespace MoBi.Presentation.Presenter
          setNegativeValuesAllowed(new[] { dto.InitialCondition }, negativeValuesAllowed);
       }
 
+      protected void DisablePathColumns()
+      {
+         _view.DisablePathColumns();
+      }
+
       public void HideIsPresentColumn()
       {
          _view.HideIsPresentColumn();

--- a/src/MoBi.Presentation/Presenter/ExpressionProfileInitialConditionsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ExpressionProfileInitialConditionsPresenter.cs
@@ -31,6 +31,7 @@ namespace MoBi.Presentation.Presenter
          HideDeleteView();
          HideIsPresentColumn();
          HideValueOriginColumn();
+         DisablePathColumns();
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/PathWithValueBuildingBlockPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/PathWithValueBuildingBlockPresenter.cs
@@ -19,7 +19,7 @@ namespace MoBi.Presentation.Presenter
       where TPresenter : IPresenter
       where TView : IView<TPresenter>
       where TParameter : PathAndValueEntity
-      where TParameterDTO : PathAndValueEntityDTO<TParameter>, IWithDisplayUnitDTO, IWithFormulaDTO
+      where TParameterDTO : PathAndValueEntityDTO<TParameter>, IWithDisplayUnitDTO
    {
       protected TBuildingBlock _buildingBlock;
       private readonly IInteractionTasksForPathAndValueEntity<TParent, TBuildingBlock, TParameter> _interactionTask;

--- a/src/MoBi.Presentation/Views/IPathAndValueEntitiesView.cs
+++ b/src/MoBi.Presentation/Views/IPathAndValueEntitiesView.cs
@@ -27,6 +27,7 @@ namespace MoBi.Presentation.Views
       void HideIsPresentView();
       void HideNegativeValuesAllowedView();
       void HideValueOriginColumn();
+      void DisablePathColumns();
 
       void RefreshData();
       TStartValueDTO FocusedStartValue { get; set; }

--- a/src/MoBi.UI/Views/InitialConditionsView.cs
+++ b/src/MoBi.UI/Views/InitialConditionsView.cs
@@ -24,7 +24,7 @@ namespace MoBi.UI.Views
       private readonly UxComboBoxUnit<InitialConditionDTO> _unitControl;
       private readonly UxRepositoryItemCheckEdit _checkItemRepository;
       private IGridViewBoundColumn<InitialConditionDTO, bool> _isPresentColumn;
-
+      
       public InitialConditionsView(ValueOriginBinder<InitialConditionDTO> valueOriginBinder) : base(valueOriginBinder)
       {
          InitializeComponent();
@@ -34,14 +34,10 @@ namespace MoBi.UI.Views
 
       protected override void DoInitializeBinding()
       {
+         base.DoInitializeBinding();
          _unitControl.ParameterUnitSet += setParameterUnit;
 
-         var colName = _gridViewBinder.AutoBind(dto => dto.Name)
-            .WithCaption(AppConstants.Captions.MoleculeName)
-            .WithOnValueUpdating((o, e) => OnEvent(() => OnNameSet(o, e)));
-
-         //to put the name in the first column
-         colName.XtraColumn.VisibleIndex = 0;
+         
 
          _gridViewBinder.AutoBind(dto => dto.Value)
             .WithCaption(AppConstants.Captions.Value)


### PR DESCRIPTION
Fixes #1175 

# Description

When editing parameter values of an expression profile, you cannot change name or path elements of any of the entries. That should be the same for initial conditions

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

https://github.com/Open-Systems-Pharmacology/docs
https://github.com/Open-Systems-Pharmacology/developer-docs


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/8e124b5b-f73d-4030-bd60-00984cd50833)

# Questions (if appropriate):