### PR TITLE
Fixes  #1154 Limit renaming related entites to module

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1289,7 +1289,7 @@ namespace MoBi.Assets
          public static readonly string BuildingBlockExplorer = "Building Block Explorer";
          public static readonly string WarningsCaption = "Solver Warnings";
          public static readonly string HistoryBrowser = "History";
-         public static readonly string RenameWizardCaption = "Rename also";
+         public static readonly string RenameRelatedEntities = "Rename related entities";
          public static readonly string AddReactionMolecule = "Molecule Name";
          public static readonly string NewName = "New Name";
          public static readonly string Tag = "Tag";

--- a/src/MoBi.Presentation/Tasks/Edit/EditTasksForTransporterMoleculeContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTasksForTransporterMoleculeContainer.cs
@@ -9,7 +9,6 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
-using OSPSuite.Core.Services;
 using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation.Tasks.Edit
@@ -72,7 +71,7 @@ namespace MoBi.Presentation.Tasks.Edit
             Description = AppConstants.Commands.RenameDescription(transporterMoleculeContainer, newName)
          };
 
-         if (CheckUsagesFor(newName, transporterMoleculeContainer.TransportName, transporterMoleculeContainer, commandCollector))
+         if (CheckUsagesFor(newName, transporterMoleculeContainer.TransportName, transporterMoleculeContainer, commandCollector, buildingBlock.Module))
          {
             commandCollector.AddCommand(new EditObjectBasePropertyInBuildingBlockCommand(transporterMoleculeContainer.PropertyName(x => x.TransportName), newName, oldTransportName, transporterMoleculeContainer, buildingBlock) { ObjectType = ObjectName });
          }

--- a/src/MoBi.UI/Views/SelectRenamingView.cs
+++ b/src/MoBi.UI/Views/SelectRenamingView.cs
@@ -53,7 +53,7 @@ namespace MoBi.UI.Views
       public override void InitializeResources()
       {
          base.InitializeResources();
-         Text = AppConstants.Captions.RenameWizardCaption;
+         Text = AppConstants.Captions.RenameRelatedEntities;
          chkShouldRename.Text = AppConstants.Captions.ShouldRenameDependentObjects;
       }
 

--- a/tests/MoBi.Tests/Presentation/Tasks/EditTaskForContainerSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/EditTaskForContainerSpecs.cs
@@ -207,12 +207,18 @@ namespace MoBi.Presentation.Tasks
       private IContainer _container;
       private SpatialStructure _spatialStructure;
       private IMoBiCommand _renameCommand;
+      private Module _module;
+      private IBuildingBlock _moleculesBuildingBlock;
 
       protected override void Context()
       {
          base.Context();
          _container = new Container().WithName("OLD");
          _spatialStructure = new SpatialStructure();
+         _module = new Module().WithName("Module");
+         _moleculesBuildingBlock = new MoleculeBuildingBlock();
+         _module.Add(_spatialStructure);
+         _module.Add(_moleculesBuildingBlock);
          A.CallTo(_interactionTaskContext.NamingTask).WithReturnType<string>().Returns("NEW");
 
          A.CallTo(() => _interactionTaskContext.Context.AddToHistory(A<IMoBiCommand>._))
@@ -222,6 +228,13 @@ namespace MoBi.Presentation.Tasks
       protected override void Because()
       {
          sut.Rename(_container, _spatialStructure);
+      }
+
+      [Observation]
+      public void the_check_name_visitor_should_be_used_to_find_related_renames_from_the_module()
+      {
+         A.CallTo(() => _interactionTaskContext.CheckNamesVisitor.GetPossibleChangesFrom(_container, "NEW", _spatialStructure, "OLD")).MustHaveHappened();
+         A.CallTo(() => _interactionTaskContext.CheckNamesVisitor.GetPossibleChangesFrom(_container, "NEW", _moleculesBuildingBlock, "OLD")).MustHaveHappened();
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #1154 

# Description
The original code would search for related entities to rename among all building blocks in a project. Now we want to limit the scope of renaming to the module.

There are a few extra cases to handle - the edit task is used to rename entities that do not belong in a module. For example, IndividualBuildingBlock, and simulation.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):