### PR TITLE
Fixes #1158 Usability issue: adding a new module should expand it

### DIFF
--- a/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
@@ -88,9 +88,33 @@ namespace MoBi.Presentation.Presenter.Main
          _editBuildingBlockStarter.EditMolecule(moleculeBuildingBlock, moleculeBuilder);
       }
 
+
+      private void editSingleBuildingBlockModule(Module module)
+      {
+         if (module.BuildingBlocks.Count != 1) 
+            return;
+
+         var buildingBlock = module.BuildingBlocks.First();
+         NodeDoubleClicked(_view.NodeById(buildingBlock.Id));
+      }
+
+      private void expandNodes(IReadOnlyList<ITreeNode> treeNodes)
+      {
+         treeNodes.Each(_view.ExpandNode);
+      }
+
       public void Handle(AddedEvent<Module> eventToHandle)
       {
-         addModule(eventToHandle.AddedObject);
+         var moduleToAdd = eventToHandle.AddedObject;
+         var addedNode = addModule(moduleToAdd);
+
+         expandNodes(new List<ITreeNode>
+         {
+            addedNode,
+            _view.NodeByType(MoBiRootNodeTypes.ModulesFolder)
+         });
+
+         editSingleBuildingBlockModule(moduleToAdd);
       }
 
       public void Handle(AddedEvent<IndividualBuildingBlock> eventToHandle)
@@ -218,7 +242,7 @@ namespace MoBi.Presentation.Presenter.Main
             _view.AddNode(_treeNodeFactory.CreateFor(MoBiRootNodeTypes.IndividualsFolder));
             _view.AddNode(_treeNodeFactory.CreateFor(RootNodeTypes.ObservedDataFolder));
 
-            project.Modules.Each(addModule);
+            project.Modules.Each(x => addModule(x));
 
             project.ExpressionProfileCollection.Each(bb => addBuildingBlockToTree(bb, MoBiRootNodeTypes.ExpressionProfilesFolder));
             project.IndividualsCollection.Each(bb => addBuildingBlockToTree(bb, MoBiRootNodeTypes.IndividualsFolder));
@@ -252,9 +276,9 @@ namespace MoBi.Presentation.Presenter.Main
          return nodeById;
       }
 
-      private void addModule(Module module)
+      private ITreeNode addModule(Module module)
       {
-         _view.AddNode(_treeNodeFactory.CreateFor(module).Under(_view.NodeByType(MoBiRootNodeTypes.ModulesFolder)));
+         return _view.AddNode(_treeNodeFactory.CreateFor(module).Under(_view.NodeByType(MoBiRootNodeTypes.ModulesFolder)));
       }
 
       public void Handle(AddedEvent eventToHandle)


### PR DESCRIPTION
Fixes #1158

# Description
When adding modules, the module explorer should automatically expand the root node and the node of the added module.
If the module contains only one building block, then that building block should be opened for editing

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):