### PR TITLE
Fixes #1190 and Fixes #1101

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1878,6 +1878,20 @@ namespace MoBi.Assets
 
             return $"Also import {individual} and {expression}?";
          }
+
+         public static string CouldNotAddExpressionsDuplicatingMolecule(IReadOnlyList<string> allNames)
+         {
+            if(allNames.Count == 1)
+               return $"The expression could not be added because an expression is already selected for the protein{Environment.NewLine}{namesList(allNames)}";
+
+            return $"Expressions could not be added because expressions are already selected for the protein{Environment.NewLine}{namesList(allNames)}";
+         }
+
+         private static string namesList(IReadOnlyList<string> allNames)
+         {
+            var listBullet = $"{Environment.NewLine} - ";
+            return $"{listBullet}{string.Join(listBullet, allNames)}";
+         }
       }
 
       public static class Validation

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1884,11 +1884,10 @@ namespace MoBi.Assets
          {
             var sb = new StringBuilder();
             sb.Append($"Expression profiles cannot be added for");
-            sb.Append(Environment.NewLine);
+            sb.AppendLine();
             sb.Append(namesList(proteinNames));
-            sb.Append(Environment.NewLine);
-            sb.Append(Environment.NewLine);
-            if(proteinNames.Count > 1)
+            sb.AppendLine();
+            if (proteinNames.Count > 1)
                sb.Append("because an expression profile is already selected for those proteins");
             else
                sb.Append("because an expression profile is already selected for that protein");
@@ -1898,7 +1897,8 @@ namespace MoBi.Assets
          private static string namesList(IReadOnlyList<string> allNames)
          {
             var sb = new StringBuilder();
-            allNames.Each(name => sb.Append($"{Environment.NewLine} - {name}"));
+            sb.AppendLine();
+            sb.AppendLine(allNames.ToString("\n"));
             return sb.ToString();
          }
       }

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Text;
 using OSPSuite.Assets;
 using OSPSuite.Assets.Extensions;
 using OSPSuite.Core.Domain;
@@ -1879,18 +1880,26 @@ namespace MoBi.Assets
             return $"Also import {individual} and {expression}?";
          }
 
-         public static string CouldNotAddExpressionsDuplicatingMolecule(IReadOnlyList<string> allNames)
+         public static string CouldNotAddExpressionProfilesDuplicatingProtein(IReadOnlyList<string> proteinNames)
          {
-            if(allNames.Count == 1)
-               return $"The expression could not be added because an expression is already selected for the protein{Environment.NewLine}{namesList(allNames)}";
-
-            return $"Expressions could not be added because expressions are already selected for the protein{Environment.NewLine}{namesList(allNames)}";
+            var sb = new StringBuilder();
+            sb.Append($"Expression profiles cannot be added for");
+            sb.Append(Environment.NewLine);
+            sb.Append(namesList(proteinNames));
+            sb.Append(Environment.NewLine);
+            sb.Append(Environment.NewLine);
+            if(proteinNames.Count > 1)
+               sb.Append("because an expression profile is already selected for those proteins");
+            else
+               sb.Append("because an expression profile is already selected for that protein");
+            return sb.ToString();
          }
 
          private static string namesList(IReadOnlyList<string> allNames)
          {
-            var listBullet = $"{Environment.NewLine} - ";
-            return $"{listBullet}{string.Join(listBullet, allNames)}";
+            var sb = new StringBuilder();
+            allNames.Each(name => sb.Append($"{Environment.NewLine} - {name}"));
+            return sb.ToString();
          }
       }
 

--- a/src/MoBi.Presentation/Presenter/EditIndividualAndExpressionConfigurationsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditIndividualAndExpressionConfigurationsPresenter.cs
@@ -98,7 +98,8 @@ namespace MoBi.Presentation.Presenter
 
       private void removeSelectedExpression(ITreeNode selectedNode)
       {
-         if (!(selectedNode.TagAsObject is ExpressionProfileBuildingBlock expression))
+         var expression = expressionProfileFromNode(selectedNode);
+         if (expression == null)
             return;
 
          _selectedExpressions.Remove(expression);
@@ -110,14 +111,20 @@ namespace MoBi.Presentation.Presenter
       {
          // We need the ToList because all nodes must be evaluated, then we are testing if any
          // nodes failed to be added to the selection
-         var nodesNotAdded = selectedNodes.Where(x => !addSelectedExpression(x)).Select(x => x.TagAsObject as ExpressionProfileBuildingBlock).ToList();
+         var nodesNotAdded = selectedNodes.Where(x => !addSelectedExpression(x)).Select(expressionProfileFromNode).ToList();
          if (nodesNotAdded.Any())
-            _dialogCreator.MessageBoxError(AppConstants.Captions.CouldNotAddExpressionsDuplicatingMolecule(nodesNotAdded.AllNames()));
+            _dialogCreator.MessageBoxInfo(AppConstants.Captions.CouldNotAddExpressionProfilesDuplicatingProtein(nodesNotAdded.Select(x => x.MoleculeName).Distinct().ToList()));
+      }
+
+      private static ExpressionProfileBuildingBlock expressionProfileFromNode(ITreeNode treeNode)
+      {
+         return treeNode.TagAsObject as ExpressionProfileBuildingBlock;
       }
 
       private bool addSelectedExpression(ITreeNode selectedNode)
       {
-         if (!(selectedNode.TagAsObject is ExpressionProfileBuildingBlock expression))
+         var expression = expressionProfileFromNode(selectedNode);
+         if (expression == null)
             return false;
 
          if (_selectedExpressions.Any(x => Equals(expression.MoleculeName, x.MoleculeName)))
@@ -148,7 +155,8 @@ namespace MoBi.Presentation.Presenter
 
       public bool CanDrop(ITreeNode dragNode, ITreeNode targetNode)
       {
-         return targetNode?.TagAsObject is ExpressionProfileBuildingBlock;
+         var expression = expressionProfileFromNode(targetNode);
+         return expression != null;
       }
 
       public void MoveNode(ITreeNode dragNode, ITreeNode targetNode)

--- a/src/MoBi.UI/Views/EditIndividualAndExpressionConfigurationsView.cs
+++ b/src/MoBi.UI/Views/EditIndividualAndExpressionConfigurationsView.cs
@@ -85,12 +85,12 @@ namespace MoBi.UI.Views
 
       private void simulationTreeSelectionChanged()
       {
-         _presenter.SimulationExpressionSelectionChanged(treeViewSelectionToTreeNodeList(simulationExpressionsTree.Selection));
+         _presenter.SimulationExpressionSelectionChanged(treeViewSelectionToTreeNodeList(simulationExpressionsTree));
       }
 
       private void projectTreeSelectionChanged()
       {
-         _presenter.ProjectExpressionSelectionChanged(treeViewSelectionToTreeNodeList(projectExpressionsTree.TreeView.Selection));
+         _presenter.ProjectExpressionSelectionChanged(treeViewSelectionToTreeNodeList(projectExpressionsTree.TreeView));
       }
 
       public bool EnableAdd
@@ -123,18 +123,18 @@ namespace MoBi.UI.Views
       private void removeSelectedExpressions()
       {
          projectExpressionsTree.TreeView.Selection.Clear();
-         _presenter.RemoveSelectedExpressions(treeViewSelectionToTreeNodeList(simulationExpressionsTree.Selection));
+         _presenter.RemoveSelectedExpressions(treeViewSelectionToTreeNodeList(simulationExpressionsTree));
       }
 
       private void addSelectedExpressions()
       {
          simulationExpressionsTree.Selection.Clear();
-         _presenter.AddSelectedExpressions(treeViewSelectionToTreeNodeList(projectExpressionsTree.TreeView.Selection));
+         _presenter.AddSelectedExpressions(treeViewSelectionToTreeNodeList(projectExpressionsTree.TreeView));
       }
 
-      private IReadOnlyList<ITreeNode> treeViewSelectionToTreeNodeList(TreeListSelection treeViewSelection)
+      private IReadOnlyList<ITreeNode> treeViewSelectionToTreeNodeList(UxTreeView treeView)
       {
-         return treeViewSelection.All().Where(x => x.Tag is ITreeNode).Select(x => x.Tag as ITreeNode).ToList();
+         return treeView.Selection.All().Select(treeView.NodeFrom).ToList();
       }
 
       protected virtual void TreeMouseMove(MouseEventArgs e)
@@ -172,7 +172,7 @@ namespace MoBi.UI.Views
 
       private TreeListNode treeListNodeFor(UxTreeView treeView, ITreeNode treeNodeToAdd)
       {
-         return treeView.Nodes.Single(x => Equals(x.Tag, treeNodeToAdd));
+         return treeView.Nodes.First(x => Equals(x.Tag, treeNodeToAdd));
       }
 
       private void disposeBinders()

--- a/src/MoBi.UI/Views/EditIndividualAndExpressionConfigurationsView.cs
+++ b/src/MoBi.UI/Views/EditIndividualAndExpressionConfigurationsView.cs
@@ -161,18 +161,13 @@ namespace MoBi.UI.Views
       public void AddUnusedExpression(ITreeNode treeNodeToAdd)
       {
          projectExpressionsTree.TreeView.AddNode(treeNodeToAdd);
-         projectExpressionsTree.TreeView.Selection.Add(treeListNodeFor(projectExpressionsTree.TreeView, treeNodeToAdd));
+         projectExpressionsTree.TreeView.Selection.Add(projectExpressionsTree.TreeView.NodeFrom(treeNodeToAdd));
       }
 
       public void AddUsedExpression(ITreeNode treeNodeToAdd)
       {
          simulationExpressionsTree.AddNode(treeNodeToAdd);
-         simulationExpressionsTree.Selection.Add(treeListNodeFor(simulationExpressionsTree, treeNodeToAdd));
-      }
-
-      private TreeListNode treeListNodeFor(UxTreeView treeView, ITreeNode treeNodeToAdd)
-      {
-         return treeView.Nodes.First(x => Equals(x.Tag, treeNodeToAdd));
+         simulationExpressionsTree.Selection.Add(simulationExpressionsTree.NodeFrom(treeNodeToAdd));
       }
 
       private void disposeBinders()

--- a/tests/MoBi.Tests/Presentation/EditIndividualAndExpressionConfigurationsPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditIndividualAndExpressionConfigurationsPresenterSpecs.cs
@@ -4,11 +4,13 @@ using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Repository;
 using MoBi.Core.Services;
 using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Nodes;
 using MoBi.Presentation.Presenter;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Nodes;
 using OSPSuite.Presentation.Presenters.Nodes;
 using OSPSuite.Utility.Extensions;
@@ -23,15 +25,17 @@ namespace MoBi.Presentation
       protected ITreeNodeFactory _treeNodeFactory;
       protected ISelectedIndividualToIndividualSelectionDTOMapper _selectedIndividualDTOMapper;
       protected IEditIndividualAndExpressionConfigurationsView _view;
+      protected IDialogCreator _dialogCreator;
 
       protected override void Context()
       {
+         _dialogCreator = A.Fake<IDialogCreator>();
          _projectRetriever = A.Fake<IMoBiProjectRetriever>();
          _buildingBlockRepository = new BuildingBlockRepository(_projectRetriever);
          _treeNodeFactory = A.Fake<ITreeNodeFactory>();
          _selectedIndividualDTOMapper = A.Fake<ISelectedIndividualToIndividualSelectionDTOMapper>();
          _view = A.Fake<IEditIndividualAndExpressionConfigurationsView>();
-         sut = new EditIndividualAndExpressionConfigurationsPresenter(_view, _selectedIndividualDTOMapper, _treeNodeFactory, _buildingBlockRepository);
+         sut = new EditIndividualAndExpressionConfigurationsPresenter(_view, _selectedIndividualDTOMapper, _treeNodeFactory, _buildingBlockRepository, _dialogCreator);
       }
    }
 
@@ -108,7 +112,7 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.RemoveSelectedExpression(_treeNode);
+         sut.RemoveSelectedExpressions(new[] { _treeNode });
       }
 
       [Observation]
@@ -130,32 +134,54 @@ namespace MoBi.Presentation
       }
    }
 
-   public class When_adding_a_new_expression_profile_to_a_simulation_configuration : concern_for_EditIndividualAndExpressionConfigurationsPresenter
+   public class When_adding_a_new_expression_profiles_to_a_simulation_configuration : concern_for_EditIndividualAndExpressionConfigurationsPresenter
    {
       private SimulationConfiguration _simulationConfiguration;
       private ExpressionProfileBuildingBlock _expressionProfile;
       private ITreeNode _treeNode;
+      private ExpressionProfileBuildingBlock _expressionProfile2;
+      private ITreeNode _treeNode2;
 
       protected override void Context()
       {
          base.Context();
          _simulationConfiguration = new SimulationConfiguration();
 
-         _expressionProfile = new ExpressionProfileBuildingBlock().WithName("molecule|species|category");
+         _expressionProfile = new ExpressionProfileBuildingBlock().WithName("molecule|species|category").WithId("1");
+         _expressionProfile.Type = ExpressionTypes.MetabolizingEnzyme;
+
+         _expressionProfile2 = new ExpressionProfileBuildingBlock().WithName("molecule|another species|another category").WithId("2");
+         _expressionProfile2.Type = ExpressionTypes.MetabolizingEnzyme;
          var moBiProject = new MoBiProject();
 
          A.CallTo(() => _projectRetriever.Current).Returns(moBiProject);
 
          moBiProject.AddExpressionProfileBuildingBlock(_expressionProfile);
+         moBiProject.AddExpressionProfileBuildingBlock(_expressionProfile2);
          sut.Edit(_simulationConfiguration);
 
-         _treeNode = new ObjectWithIdAndNameNode<ExpressionProfileBuildingBlock>(_expressionProfile);
+         _treeNode = new BuildingBlockNode(_expressionProfile);
          A.CallTo(() => _treeNodeFactory.CreateFor(_expressionProfile)).Returns(_treeNode);
+
+         _treeNode2 = new BuildingBlockNode(_expressionProfile2);
+         A.CallTo(() => _treeNodeFactory.CreateFor(_expressionProfile2)).Returns(_treeNode2);
       }
 
       protected override void Because()
       {
-         sut.AddSelectedExpression(_treeNode);
+         sut.AddSelectedExpressions(new[] { _treeNode, _treeNode2 });
+      }
+
+      [Observation]
+      public void the_dialog_creator_should_inform_the_user_about_the_expressions_that_could_not_be_added()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxError(A<string>.That.Contains("molecule|another species|another category"))).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_node_that_cannot_be_selected_is_not_added_to_the_view()
+      {
+         A.CallTo(() => _view.AddUsedExpression(_treeNode2)).MustNotHaveHappened();
       }
 
       [Observation]
@@ -174,6 +200,12 @@ namespace MoBi.Presentation
       public void the_expression_profile_should_be_added_to_the_simulation_configuration()
       {
          sut.ExpressionProfiles.ShouldContain(_expressionProfile);
+      }
+
+      [Observation]
+      public void the_expression_profile_that_could_not_be_selected_should_not_be_added_to_the_simulation_configuration()
+      {
+         sut.ExpressionProfiles.ShouldNotContain(_expressionProfile2);
       }
    }
 

--- a/tests/MoBi.Tests/Presentation/EditIndividualAndExpressionConfigurationsPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditIndividualAndExpressionConfigurationsPresenterSpecs.cs
@@ -175,7 +175,7 @@ namespace MoBi.Presentation
       [Observation]
       public void the_dialog_creator_should_inform_the_user_about_the_expressions_that_could_not_be_added()
       {
-         A.CallTo(() => _dialogCreator.MessageBoxError(A<string>.That.Contains("molecule|another species|another category"))).MustHaveHappened();
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>.That.Contains("molecule"))).MustHaveHappened();
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #1190 Do not allow multiple expression profile for same protein
Fixes #1101 Simulation Configuration: enable multiselect

Fixes #

# Description
When configuring a simulation, it should not be possible for the user to select two expression profiles for the same protein. This is done by an error message dialog after the user selects add

Also, allow users to add/remove multiple expressions at once with the add and remove buttons

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/44d13a3b-daa3-4142-a4d5-b5733ec48c0f)


# Questions (if appropriate):