### PR TITLE
Fixes #1201 Deleting a module with an open building block leaves editors open

### DIFF
--- a/src/MoBi.Core/Commands/RemoveModuleCommand.cs
+++ b/src/MoBi.Core/Commands/RemoveModuleCommand.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;

--- a/src/MoBi.Core/Commands/RemoveModuleCommand.cs
+++ b/src/MoBi.Core/Commands/RemoveModuleCommand.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
@@ -27,7 +29,17 @@ namespace MoBi.Core.Commands
          context.Unregister(_module);
 
          _serializationStream = context.Serialize(_module);
-         context.PublishEvent(new RemovedEvent(_module, project));
+
+         // When removing a module, we are implicitly removing all the building blocks it contains.
+         var removedObjects = allRemovedObjectsFrom(_module);
+         context.PublishEvent(new RemovedEvent(removedObjects));
+      }
+
+      private List<IObjectBase> allRemovedObjectsFrom(Module module)
+      {
+         var removedObjects = new List<IObjectBase> { module };
+         removedObjects.AddRange(module.BuildingBlocks);
+         return removedObjects;
       }
 
       public override void RestoreExecutionData(IMoBiContext context)


### PR DESCRIPTION
Fixes #1201

# Description
If a module is removed from a project, any editors that are open for the modules building blocks should be closed.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):