### PR TITLE
Fixes #1152 crash when selecting a neighbor in a neighborhood after opening the diagram

### DIFF
--- a/src/MoBi.Presentation/Presenter/BaseDiagram/MoBiBaseDiagramPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/BaseDiagram/MoBiBaseDiagramPresenter.cs
@@ -102,8 +102,11 @@ namespace MoBi.Presentation.Presenter.BaseDiagram
       /// </summary>
       public void Handle(EntitySelectedEvent eventToHandle)
       {
-         if (DiagramManager == null) return;
-         if (!DiagramManager.MustHandleExisting(eventToHandle.ObjectBase.Id)) return;
+         if (DiagramManager == null) 
+            return;
+
+         if (!DiagramManager.MustHandleExisting(eventToHandle.ObjectBase.Id)) 
+            return;
 
          IBaseNode baseNode = DiagramModel.GetNode(eventToHandle.ObjectBase.Id);
          if (baseNode == null) return;

--- a/src/MoBi.Presentation/Presenter/BaseDiagram/MoBiBaseDiagramPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/BaseDiagram/MoBiBaseDiagramPresenter.cs
@@ -19,7 +19,6 @@ using OSPSuite.Presentation.Views;
 using OSPSuite.Utility.Container;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
-using IContainer = OSPSuite.Utility.Container.IContainer;
 
 namespace MoBi.Presentation.Presenter.BaseDiagram
 {
@@ -86,10 +85,7 @@ namespace MoBi.Presentation.Presenter.BaseDiagram
          _neighborhoodPopupMenu = _diagramPopupMenu;
       }
 
-      protected override IDiagramOptions GetDiagramOptions()
-      {
-         return _userSettings.DiagramOptions;
-      }
+      protected override IDiagramOptions GetDiagramOptions() => _userSettings.DiagramOptions;
 
       public PointF CurrentInsertLocation
       {
@@ -102,16 +98,16 @@ namespace MoBi.Presentation.Presenter.BaseDiagram
       /// </summary>
       public void Handle(EntitySelectedEvent eventToHandle)
       {
-         if (DiagramManager == null) 
+         if (DiagramManager == null)
             return;
 
-         if (!DiagramManager.MustHandleExisting(eventToHandle.ObjectBase.Id)) 
+         if (!DiagramManager.MustHandleExisting(eventToHandle.ObjectBase.Id))
             return;
 
-         IBaseNode baseNode = DiagramModel.GetNode(eventToHandle.ObjectBase.Id);
+         var baseNode = DiagramModel.GetNode(eventToHandle.ObjectBase.Id);
          if (baseNode == null) return;
 
-         IContainerBase parentContainer = baseNode.GetParent();
+         var parentContainer = baseNode.GetParent();
 
          // Show node and parents
          baseNode.Hidden = false;
@@ -120,8 +116,7 @@ namespace MoBi.Presentation.Presenter.BaseDiagram
          _view.ExpandParents(baseNode);
 
          // Expand parent
-         var parentContainerNode = parentContainer as IContainerNode;
-         if (parentContainerNode != null)
+         if (parentContainer is IContainerNode parentContainerNode)
             Focus(parentContainerNode);
 
          _view.ClearSelection();
@@ -198,10 +193,7 @@ namespace MoBi.Presentation.Presenter.BaseDiagram
          }
       }
 
-      protected IDiagramModel LoadDiagramTemplate(string diagramTemplateXmlFilePath)
-      {
-         return _diagramTask.LoadDiagramTemplate(diagramTemplateXmlFilePath);
-      }
+      protected IDiagramModel LoadDiagramTemplate(string diagramTemplateXmlFilePath) => _diagramTask.LoadDiagramTemplate(diagramTemplateXmlFilePath);
 
       public void ApplyLayoutTemplateToSelection()
       {
@@ -229,6 +221,7 @@ namespace MoBi.Presentation.Presenter.BaseDiagram
                break;
             }
          }
+
          _view.Refresh();
       }
 
@@ -249,31 +242,19 @@ namespace MoBi.Presentation.Presenter.BaseDiagram
          });
       }
 
-      private static bool isGoLink(GoObject goLink)
-      {
-         return goLink is GoLink;
-      }
+      private static bool isGoLink(GoObject goLink) => goLink is GoLink;
 
-      private static bool isBaseLink(GoObject baseLink)
-      {
-         return baseLink is IBaseLink;
-      }
+      private static bool isBaseLink(GoObject baseLink) => baseLink is IBaseLink;
 
-      private void unlinkBaseNodes(IBaseLink baseLink, GoLink goLink)
-      {
-         Unlink(baseLink.GetFromNode(), baseLink.GetToNode(), goLink.FromPort.UserObject, goLink.ToPort.UserObject);
-      }
+      private void unlinkBaseNodes(IBaseLink baseLink, GoLink goLink) => Unlink(baseLink.GetFromNode(), baseLink.GetToNode(), goLink.FromPort.UserObject, goLink.ToPort.UserObject);
 
       private void unlinkNeighborhoodNode(GoObject itemToDelete)
       {
-         var neighborhoodNode = (INeighborhoodNode) itemToDelete;
+         var neighborhoodNode = (INeighborhoodNode)itemToDelete;
          Unlink(neighborhoodNode.FirstNeighbor, neighborhoodNode.SecondNeighbor, null, null);
       }
 
-      public void Undo()
-      {
-         DiagramModel.Undo();
-      }
+      public void Undo() => DiagramModel.Undo();
 
       public void Handle(AddedEvent eventToHandle)
       {
@@ -284,9 +265,10 @@ namespace MoBi.Presentation.Presenter.BaseDiagram
          if (DiagramManager.InsertLocationHasChanged())
          {
             // move node to "free" location
-            var freeNodes = new List<IHasLayoutInfo> {addedNode};
+            var freeNodes = new List<IHasLayoutInfo> { addedNode };
             Layout(addedNode.GetParent(), AppConstants.Diagram.Base.LayoutDepthChildren, freeNodes);
          }
+
          DiagramManager.UpdateInsertLocation();
       }
    }

--- a/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
@@ -112,7 +112,7 @@ namespace MoBi.Presentation.Presenter
       private void raiseEntitySelectedEvent(ObjectBaseDTO objectBaseDTO)
       {
          // First and second neighbor node selections should not trigger an EntitySelectedEvent
-         // because the are not ObjectBase
+         // because they are not a selectable entity
          if(objectBaseDTO.ObjectBase != null)
             _context.PublishEvent(new EntitySelectedEvent(objectBaseDTO.ObjectBase, this));
       }

--- a/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
@@ -112,6 +112,7 @@ namespace MoBi.Presentation.Presenter
       private void raiseEntitySelectedEvent(ObjectBaseDTO objectBaseDTO)
       {
          // First and second neighbor node selections should not trigger an EntitySelectedEvent
+         // because the are not ObjectBase
          if(objectBaseDTO.ObjectBase != null)
             _context.PublishEvent(new EntitySelectedEvent(objectBaseDTO.ObjectBase, this));
       }

--- a/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
@@ -111,7 +111,9 @@ namespace MoBi.Presentation.Presenter
 
       private void raiseEntitySelectedEvent(ObjectBaseDTO objectBaseDTO)
       {
-         _context.PublishEvent(new EntitySelectedEvent(objectBaseDTO.ObjectBase, this));
+         // First and second neighbor node selections should not trigger an EntitySelectedEvent
+         if(objectBaseDTO.ObjectBase != null)
+            _context.PublishEvent(new EntitySelectedEvent(objectBaseDTO.ObjectBase, this));
       }
 
       public override void ReleaseFrom(IEventPublisher eventPublisher)

--- a/tests/MoBi.Tests/Presentation/HierarchicalStructurePresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/HierarchicalStructurePresenterSpecs.cs
@@ -108,4 +108,48 @@ namespace MoBi.Presentation
          A.CallTo(() => _context.PublishEvent(A<EntitySelectedEvent>._)).MustNotHaveHappened();
       }
    }
+
+   internal class When_selecting_a_node_with_an_object_base : concern_for_HierarchicalStructurePresenter
+   {
+      private ObjectBaseDTO _dto;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dto = new ObjectBaseDTO(new Container());
+      }
+
+      protected override void Because()
+      {
+         sut.Select(_dto);
+      }
+
+      [Observation]
+      public void should_raise_entity_selected_event()
+      {
+         A.CallTo(() => _context.PublishEvent(A<EntitySelectedEvent>.That.Matches(x => x.ObjectBase.Equals(_dto.ObjectBase)))).MustHaveHappened();
+      }
+   }
+
+   internal class When_selecting_a_node_without_an_object_base : concern_for_HierarchicalStructurePresenter
+   {
+      private ObjectBaseDTO _dto;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dto = new ObjectBaseDTO();
+      }
+
+      protected override void Because()
+      {
+         sut.Select(_dto);
+      }
+
+      [Observation]
+      public void should_not_raise_entity_selected_event()
+      {
+         A.CallTo(() => _context.PublishEvent(A<EntitySelectedEvent>._)).MustNotHaveHappened();
+      }
+   }
 }


### PR DESCRIPTION
Fixes #1152

# Description
When first or second neighbor nodes are selected in a spatial structure, the diagram manager does not handle a case where the EntitySelectedEvent is built without an ObjectBase.

I chose not to publish the event in this case, but alternatively, we could handle the case where the event is handled without ObjectBase

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):