### PR TITLE
FIxes #1157 "Events" should not be allowed as name for any container

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -2097,7 +2097,8 @@ namespace MoBi.Assets
          "SRND",
          "TAN",
          "TANH",
-         "NEQ"
+         "NEQ",
+         "EVENTS"
       };
 
       public static readonly string None = "<None>";


### PR DESCRIPTION
Fixes #1157

# Description
Added the word "Events" to a list of words that are not allowed to be used for container names
## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/42c4ec29-52d6-436b-b618-5205d5ce2d5c)

# Questions (if appropriate):