### PR TITLE
Fixes #1188 When importing SimulationTransfer as Module name the additional building blocks

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1866,18 +1866,31 @@ namespace MoBi.Assets
             return $"Select building blocks to clone from {module.Name}";
          }
 
-         public static string AlsoImportIndividualsAndExpressions(int numberOfIndividuals, int numberOfExpressions)
+         public static string AlsoImportIndividualsAndExpressions(string individualName, IReadOnlyList<string> expressionNames)
          {
-            var individual = $"{numberOfIndividuals} individual".PluralizeIf(numberOfIndividuals);
-            var expression = $"{numberOfExpressions} expression".PluralizeIf(numberOfExpressions);
+            var numberOfIndividuals = string.IsNullOrEmpty(individualName) ? 0 : 1;
+            var numberOfExpressions = expressionNames.Count;
+            var sb = new StringBuilder();
+            
+            var expression = $"expression profile".PluralizeIf(numberOfExpressions);
                
             if (numberOfExpressions == 0)
-               return $"Also import {individual}?";
-            
-            if(numberOfIndividuals == 0)
-               return $"Also import {expression}?";
+               return $"Also import individual {individualName}?";
 
-            return $"Also import {individual} and {expression}?";
+            if (numberOfIndividuals == 0)
+            {
+               sb.Append($"Also import {expression}");
+               sb.AppendLine();
+               sb.Append(namesList(expressionNames));
+               return sb.ToString();
+            }
+
+            sb.AppendLine($"Also import individual {individualName}");
+            sb.AppendLine();
+            sb.Append($"and {expression}");
+            sb.AppendLine(namesList(expressionNames));
+
+            return sb.ToString();
          }
 
          public static string CouldNotAddExpressionProfilesDuplicatingProtein(IReadOnlyList<string> proteinNames)

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1911,7 +1911,8 @@ namespace MoBi.Assets
          {
             var sb = new StringBuilder();
             sb.AppendLine();
-            sb.AppendLine(allNames.ToString("\n"));
+            sb.Append(" - ");
+            sb.AppendLine(allNames.ToString("\n - "));
             return sb.ToString();
          }
       }

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1872,7 +1872,7 @@ namespace MoBi.Assets
             var numberOfExpressions = expressionNames.Count;
             var sb = new StringBuilder();
             
-            var expression = $"expression profile".PluralizeIf(numberOfExpressions);
+            var expression = $"Expression Profile".PluralizeIf(numberOfExpressions);
                
             if (numberOfExpressions == 0)
                return $"Also import individual {individualName}?";
@@ -1885,9 +1885,12 @@ namespace MoBi.Assets
                return sb.ToString();
             }
 
-            sb.AppendLine($"Also import individual {individualName}");
+            sb.AppendLine("Do you want to import additional building blocks?");
             sb.AppendLine();
-            sb.Append($"and {expression}");
+
+            sb.Append("<b>Individual</b>");
+            sb.AppendLine(namesList(new[] { individualName }));
+            sb.Append($"<b>{expression}</b>");
             sb.AppendLine(namesList(expressionNames));
 
             return sb.ToString();

--- a/src/MoBi.Presentation/Tasks/ModuleLoader.cs
+++ b/src/MoBi.Presentation/Tasks/ModuleLoader.cs
@@ -5,6 +5,7 @@ using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Helper;
 using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Services;
 using OSPSuite.Utility.Extensions;
@@ -62,27 +63,27 @@ namespace MoBi.Presentation.Tasks
          };
 
          var modules = configuration.ModuleConfigurations.Select(x => x.Module).ToList();
-         var individuals = configuration.Individual == null ? new List<IndividualBuildingBlock>() : new List<IndividualBuildingBlock> { configuration.Individual };
+         var individual = configuration.Individual;
          var expressions = configuration.ExpressionProfiles;
 
          macroCommand.Add(_moduleTask.AddTo(modules, project));
 
-         if (!addAdditionalBuildingBlocksConfirmed(individuals.Count, expressions.Count))
+         if (!addAdditionalBuildingBlocksConfirmed(individual, expressions))
             return macroCommand;
 
-         macroCommand.Add(_individualTask.AddTo(individuals, project));
+         macroCommand.Add(_individualTask.AddTo(new[] { individual }, project));
          macroCommand.Add(_expressionTask.AddTo(expressions, project));
 
          return macroCommand;
       }
 
-      private bool addAdditionalBuildingBlocksConfirmed(int numberOfIndividuals, int numberOfExpressions)
+      private bool addAdditionalBuildingBlocksConfirmed(IndividualBuildingBlock individual, IReadOnlyList<ExpressionProfileBuildingBlock> expressions)
       {
          // Do not prompt if there are no additional building blocks to add
-         if (numberOfIndividuals == 0 && numberOfExpressions == 0)
+         if (individual == null && expressions.Count == 0)
             return false;
 
-         return ViewResult.Yes == _interactionTaskContext.DialogCreator.MessageBoxYesNo(AppConstants.Captions.AlsoImportIndividualsAndExpressions(numberOfIndividuals, numberOfExpressions));
+         return ViewResult.Yes == _interactionTaskContext.DialogCreator.MessageBoxYesNo(AppConstants.Captions.AlsoImportIndividualsAndExpressions(individual?.Name, expressions.AllNames()));
       }
    }
 }


### PR DESCRIPTION
Fixes #1188 

# Description
In the dialog box we just number the additional building blocks that would be imported, but we can name them for more clarity.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/d74707ab-92a0-4521-8b08-b89340f514b7)

# Questions (if appropriate):