### PR TITLE
Fixes #1221 For selecting neighbors and containers add the level of node for the building block

### DIFF
--- a/src/MoBi.Presentation/DTO/ContainerDTO.cs
+++ b/src/MoBi.Presentation/DTO/ContainerDTO.cs
@@ -17,10 +17,5 @@ namespace MoBi.Presentation.DTO
       public string ParentPath { get; set; }
 
       public bool ParentPathEditable { get; set; }
-
-      public void AddModuleName(string moduleName)
-      {
-         Name = $"{moduleName} - {Name}";
-      }
    }
 }

--- a/src/MoBi.Presentation/DTO/ModuleAndSpatialStructureDTO.cs
+++ b/src/MoBi.Presentation/DTO/ModuleAndSpatialStructureDTO.cs
@@ -1,0 +1,13 @@
+using OSPSuite.Core.Domain;
+
+namespace MoBi.Presentation.DTO
+{
+   public class ModuleAndSpatialStructureDTO : ObjectBaseDTO
+   {
+      public ModuleAndSpatialStructureDTO(Module module) : base(module)
+      {
+      }
+
+      public SpatialStructureDTO SpatialStructure { get; set; }
+   }
+}

--- a/src/MoBi.Presentation/DTO/SpatialStructureDTO.cs
+++ b/src/MoBi.Presentation/DTO/SpatialStructureDTO.cs
@@ -9,7 +9,7 @@ namespace MoBi.Presentation.DTO
       {
       }
 
-      public IEnumerable<ContainerDTO> TopContainers { get; set; }
+      public IReadOnlyList<ContainerDTO> TopContainers { get; set; }
       public ContainerDTO Neighborhoods { get; set; }
       public ContainerDTO MoleculeProperties { get; set; }
    }

--- a/src/MoBi.Presentation/Mappers/ModuleToModuleAndSpatialStructureDTOMapper.cs
+++ b/src/MoBi.Presentation/Mappers/ModuleToModuleAndSpatialStructureDTOMapper.cs
@@ -1,0 +1,31 @@
+﻿using MoBi.Presentation.DTO;
+using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
+using OSPSuite.Utility;
+
+namespace MoBi.Presentation.Mappers
+{
+   public interface IModuleToModuleAndSpatialStructureDTOMapper : IMapper<Module, ModuleAndSpatialStructureDTO>
+   {
+   }
+
+   public class ModuleToModuleAndSpatialStructureDTOMapper : ObjectBaseToObjectBaseDTOMapperBase, IModuleToModuleAndSpatialStructureDTOMapper
+   {
+      private readonly ISpatialStructureToSpatialStructureDTOMapper _spatialStructureToSpatialStructureDTOMapper;
+
+      public ModuleToModuleAndSpatialStructureDTOMapper(ISpatialStructureToSpatialStructureDTOMapper spatialStructureToSpatialStructureDTOMapper)
+      {
+         _spatialStructureToSpatialStructureDTOMapper = spatialStructureToSpatialStructureDTOMapper;
+      }
+
+      public ModuleAndSpatialStructureDTO MapFrom(Module module)
+      {
+         var dto = Map(new ModuleAndSpatialStructureDTO(module));
+         dto.SpatialStructure = _spatialStructureToSpatialStructureDTOMapper.MapFrom(module.SpatialStructure);
+         dto.Name = module.Name;
+         dto.Icon = ApplicationIcons.IconByName(module.Icon);
+
+         return dto;
+      }
+   }
+}

--- a/src/MoBi.Presentation/Mappers/SpatialStructureToSpatialStructureDTOMapper.cs
+++ b/src/MoBi.Presentation/Mappers/SpatialStructureToSpatialStructureDTOMapper.cs
@@ -1,7 +1,7 @@
-﻿using OSPSuite.Utility;
-using OSPSuite.Utility.Extensions;
-using MoBi.Presentation.DTO;
+﻿using MoBi.Presentation.DTO;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Utility;
+using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation.Mappers
 {
@@ -25,8 +25,6 @@ namespace MoBi.Presentation.Mappers
          dto.Neighborhoods = _containerToDTOContainerMapper.MapFrom(spatialStructure.NeighborhoodsContainer);
          dto.MoleculeProperties = _containerToDTOContainerMapper.MapFrom(spatialStructure.GlobalMoleculeDependentProperties);
          dto.Name = spatialStructure.DisplayName;
-
-         dto.TopContainers.Each(x => x.AddModuleName(spatialStructure.Module.Name));
 
          return dto;
       }

--- a/src/MoBi.Presentation/Presenter/SelectContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectContainerPresenter.cs
@@ -1,12 +1,10 @@
 ﻿using System.Linq;
 using MoBi.Assets;
-using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Repository;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Views;
 using OSPSuite.Core.Domain;
 using OSPSuite.Presentation.Presenters;
-using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation.Presenter
 {
@@ -18,17 +16,17 @@ namespace MoBi.Presentation.Presenter
    public class SelectContainerPresenter : AbstractDisposablePresenter<ISelectObjectPathView, ISelectObjectPathPresenter>, ISelectContainerPresenter
    {
       private readonly ISelectContainerInTreePresenter _selectContainerInTreePresenter;
-      private readonly ISpatialStructureToSpatialStructureDTOMapper _spatialStructureDTOMapper;
+      private readonly IModuleToModuleAndSpatialStructureDTOMapper _moduleToModuleAndSpatialStructureDTOMapper;
       private readonly IBuildingBlockRepository _buildingBlockRepository;
 
       public SelectContainerPresenter(
          ISelectObjectPathView view,
          ISelectContainerInTreePresenter selectContainerInTreePresenter,
-         ISpatialStructureToSpatialStructureDTOMapper spatialStructureDTOMapper,
+         IModuleToModuleAndSpatialStructureDTOMapper moduleToModuleAndSpatialStructureDTOMapper,
          IBuildingBlockRepository buildingBlockRepository) : base(view)
       {
          _selectContainerInTreePresenter = selectContainerInTreePresenter;
-         _spatialStructureDTOMapper = spatialStructureDTOMapper;
+         _moduleToModuleAndSpatialStructureDTOMapper = moduleToModuleAndSpatialStructureDTOMapper;
          _buildingBlockRepository = buildingBlockRepository;
          AddSubPresenters(_selectContainerInTreePresenter);
          _view.Caption = AppConstants.Captions.SelectContainer;
@@ -45,8 +43,8 @@ namespace MoBi.Presentation.Presenter
 
       private void init()
       {
-         var list = _buildingBlockRepository.SpatialStructureCollection.MapAllUsing(_spatialStructureDTOMapper);
-         _selectContainerInTreePresenter.InitTreeStructure(list.SelectMany(x => x.TopContainers).ToList());
+         var list = _buildingBlockRepository.SpatialStructureCollection.Select(x => _moduleToModuleAndSpatialStructureDTOMapper.MapFrom(x.Module)).ToList();
+         _selectContainerInTreePresenter.InitTreeStructure(list);
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/SelectContanerInTreePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectContanerInTreePresenter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Presentation.DTO;
@@ -32,6 +31,9 @@ namespace MoBi.Presentation.Presenter
 
       private IReadOnlyList<ObjectBaseDTO> getChildren(ObjectBaseDTO parentDTO)
       {
+         if (parentDTO is ModuleAndSpatialStructureDTO moduleAndSpatialStructureDTO)
+            return moduleAndSpatialStructureDTO.SpatialStructure.TopContainers;
+
          var parent = EntityFrom(parentDTO);
          if (parent.IsAnImplementationOf<IDistributedParameter>())
             return Array.Empty<ObjectBaseDTO>();

--- a/src/MoBi.Presentation/Presenter/SelectContanerInTreePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectContanerInTreePresenter.cs
@@ -46,6 +46,12 @@ namespace MoBi.Presentation.Presenter
             !x.IsNamed(Constants.MOLECULE_PROPERTIES) && !x.IsAnImplementationOf<IParameter>()).MapAllUsing(_containerDTOMapper);
       }
 
+      public override void InitTreeStructure(IReadOnlyList<ObjectBaseDTO> entityDTOs)
+      {
+         base.InitTreeStructure(entityDTOs);
+         _view.ExpandRootNodes();
+      }
+
       public bool ContainerSelected => SelectedEntity != null;
    }
 }

--- a/src/MoBi.Presentation/Presenter/SelectObjectInTreePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectObjectInTreePresenter.cs
@@ -73,7 +73,7 @@ namespace MoBi.Presentation.Presenter
          return selectedDTO != null;
       }
 
-      public void InitTreeStructure(IReadOnlyList<ObjectBaseDTO> entityDTOs)
+      public virtual void InitTreeStructure(IReadOnlyList<ObjectBaseDTO> entityDTOs)
       {
          _view.Display(entityDTOs.Select(mapToNode).ToList());
       }

--- a/src/MoBi.Presentation/Views/ISelectEntityInTreeView.cs
+++ b/src/MoBi.Presentation/Views/ISelectEntityInTreeView.cs
@@ -11,5 +11,6 @@ namespace MoBi.Presentation.Views
       void Display(IReadOnlyList<ITreeNode> treeNodes);
       ObjectBaseDTO Selected { get; }
       ITreeNode GetNode(string id);
+      void ExpandRootNodes();
    }
 }

--- a/src/MoBi.UI/Views/SelectEntityInTreeView.cs
+++ b/src/MoBi.UI/Views/SelectEntityInTreeView.cs
@@ -58,5 +58,7 @@ namespace MoBi.UI.Views
       }
 
       public ITreeNode GetNode(string id) => _treeView.NodeById(id);
+
+      public void ExpandRootNodes() => _treeView.RootNodes.Each(x => _treeView.ExpandNode(x));
    }
 }


### PR DESCRIPTION
Fixes #1221

# Description
The view needs one hierarchical level more to make it easier to find the containers. We are skipping the level of 'SpatialStructure' which is always 1-1 in this view, and often has the name 'Organism'.

So what you get is a top level node for the module, followed by all the top containers in the modules spatial structure.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/eb078f43-f192-4495-a34e-d63142099089)

# Questions (if appropriate):