### PR TITLE
Fixes #1222 Exported organism using Save with Individual context menu

### DIFF
--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
@@ -138,9 +138,12 @@ namespace MoBi.Presentation.Tasks.Edit
 
       private void addIndividualParameterToContainer(IndividualParameter individualParameter, IContainer container, string containerPath)
       {
-         var parameterToAdd = createParameter(individualParameter);
          var targetContainer = findTargetContainer(individualParameter.ContainerPath, container, containerPath);
+         // The target container for this parameter is not found - skip
+         if (targetContainer == null)
+            return;
 
+         var parameterToAdd = createParameter(individualParameter);
          var existingParameter = targetContainer.FindByName(parameterToAdd.Name);
 
          if (existingParameter != null)

--- a/tests/MoBi.Tests/Presentation/Tasks/EditTaskForContainerSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/EditTaskForContainerSpecs.cs
@@ -77,6 +77,7 @@ namespace MoBi.Presentation.Tasks
       private IndividualBuildingBlock _individual;
       private IContainer _containerToSave;
       private Parameter _replacedParameter;
+      private IndividualParameter _parameterWithoutContainer;
 
       protected override void Context()
       {
@@ -96,6 +97,9 @@ namespace MoBi.Presentation.Tasks
 
          _individual.Add(new IndividualParameter { ContainerPath = new ObjectPath("Parent", "Container1") }.WithName("ShouldBeReplaced"));
          _individual.Add(new IndividualParameter { ContainerPath = new ObjectPath("Parent", "Container2") }.WithName("parameter2"));
+
+         _parameterWithoutContainer = new IndividualParameter { ContainerPath = new ObjectPath("Parent", "Container1", "Container3") }.WithName("ContainerDoesNotExist");
+         _individual.Add(_parameterWithoutContainer);
 
          _containerToSave = new Container().WithName("Container1").WithMode(ContainerMode.Physical).Under(_parentContainer);
          _clonedContainer = new Container().WithName("Container1").WithMode(ContainerMode.Physical);
@@ -126,6 +130,12 @@ namespace MoBi.Presentation.Tasks
       protected override void Because()
       {
          sut.SaveWithIndividual(_containerToSave);
+      }
+
+      [Observation]
+      public void the_parameter_is_not_created_when_the_container_does_not_exist()
+      {
+         A.CallTo(() => _individualParameterToParameterMapper.MapFrom(_parameterWithoutContainer)).MustNotHaveHappened();
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #1222

# Description
If you select the top container and export with individual context menu, this is the broadest case with the most paths and containers.

The original implementation did not consider that there could be paths in the individual that would not exist in the spatial structure.

Now, if a container is not found for a path from the individual building block, everything is skipped.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):