### PR TITLE
Fixes #1224 When extending initial conditions pick the a spatial structure from the same module if present

### DIFF
--- a/src/MoBi.Presentation/DTO/MoleculeSelectionDTO.cs
+++ b/src/MoBi.Presentation/DTO/MoleculeSelectionDTO.cs
@@ -16,13 +16,15 @@ namespace MoBi.Presentation.DTO
          Rules.Add(AllRules.SelectedMoleculesHaveUniqueNames);
       }
 
-      public string BuildingBlock { get; set; }
+      public IBuildingBlock BuildingBlock => MoleculeBuilder.BuildingBlock;
+      public string BuildingBlockDisplayName => BuildingBlock.ToString();
 
       public string MoleculeName => MoleculeBuilder?.Name;
 
       public MoleculeBuilder MoleculeBuilder { get; set; }
 
-      public bool Selected {
+      public bool Selected
+      {
          get => _selected;
          set
          {
@@ -33,7 +35,7 @@ namespace MoBi.Presentation.DTO
 
       public string Icon => MoleculeBuilder.Icon;
       public SelectSpatialStructureAndMoleculesDTO ParentDTO { get; set; }
-
+      
       private static class AllRules
       {
          public static IBusinessRule SelectedMoleculesHaveUniqueNames { get; } =

--- a/src/MoBi.Presentation/DTO/SelectSpatialStructureAndMoleculesDTO.cs
+++ b/src/MoBi.Presentation/DTO/SelectSpatialStructureAndMoleculesDTO.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using MoBi.Assets;
-using MoBi.Core.Domain.Model;
+using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Presentation.DTO;
 using OSPSuite.Utility.Validation;
 
@@ -11,7 +11,7 @@ namespace MoBi.Presentation.DTO
    {
       private readonly List<MoleculeSelectionDTO> _molecules = new List<MoleculeSelectionDTO>();
       private readonly List<MoleculeSelectionDTO> _selectedMolecules = new List<MoleculeSelectionDTO>();
-      public MoBiSpatialStructure SpatialStructure { get; set; }
+      public SpatialStructure SpatialStructure { get; set; }
       public IReadOnlyList<MoleculeSelectionDTO> Molecules => _molecules;
       public IReadOnlyList<MoleculeSelectionDTO> SelectedMolecules => _selectedMolecules;
 

--- a/src/MoBi.Presentation/Mappers/SelectSpatialStructureAndMoleculesDTOMapper.cs
+++ b/src/MoBi.Presentation/Mappers/SelectSpatialStructureAndMoleculesDTOMapper.cs
@@ -26,14 +26,13 @@ namespace MoBi.Presentation.Mappers
 
       private void createMoleculeDTOs(MoleculeBuildingBlock buildingBlock, SelectSpatialStructureAndMoleculesDTO parentDTO)
       {
-         buildingBlock.Each(x => createMoleculeDTO(x, buildingBlock.ToString(), parentDTO));
+         buildingBlock.Each(x => createMoleculeDTO(x, parentDTO));
       }
 
-      private void createMoleculeDTO(MoleculeBuilder molecule, string buildingBlockName, SelectSpatialStructureAndMoleculesDTO parentDTO)
+      private void createMoleculeDTO(MoleculeBuilder molecule, SelectSpatialStructureAndMoleculesDTO parentDTO)
       {
          parentDTO.AddMolecule(new MoleculeSelectionDTO
          {
-            BuildingBlock = buildingBlockName,
             MoleculeBuilder = molecule
          });
       }

--- a/src/MoBi.Presentation/Tasks/Interaction/InitialConditionsTask.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InitialConditionsTask.cs
@@ -175,7 +175,7 @@ namespace MoBi.Presentation.Tasks.Interaction
 
       public override void ExtendStartValueBuildingBlock(TBuildingBlock initialConditionsBuildingBlock)
       {
-         var (spatialStructure, molecules) = SelectBuildingBlocksForExtend();
+         var (spatialStructure, molecules) = SelectBuildingBlocksForExtend(initialConditionsBuildingBlock.Module.Molecules, initialConditionsBuildingBlock.Module.SpatialStructure);
          if (spatialStructure == null || molecules == null || !molecules.Any())
             return;
 

--- a/src/MoBi.Presentation/Tasks/Interaction/StartValuesTask.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/StartValuesTask.cs
@@ -273,7 +273,7 @@ namespace MoBi.Presentation.Tasks.Interaction
          return new AddBuildingBlockToModuleCommand<TBuildingBlock>(itemToAdd, parent);
       }
 
-      protected (MoBiSpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules) SelectBuildingBlocksForExtend()
+      protected (SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules) SelectBuildingBlocksForExtend(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure)
       {
          var moleculeBlockCollection = _interactionTaskContext.BuildingBlockRepository.MoleculeBlockCollection;
          var spatialStructureCollection = _interactionTaskContext.BuildingBlockRepository.SpatialStructureCollection;
@@ -290,7 +290,7 @@ namespace MoBi.Presentation.Tasks.Interaction
 
          using (var selectorPresenter = Context.Resolve<ISelectSpatialStructureAndMoleculesPresenter>())
          {
-            selectorPresenter.SelectBuildingBlocksForExtend();
+            selectorPresenter.SelectBuildingBlocksForExtend(defaultMolecules, defaultSpatialStructure);
             return (selectorPresenter.SelectedSpatialStructure, selectorPresenter.SelectedMolecules);
          }
       }

--- a/src/MoBi.UI/Views/SelectSpatialStructureAndMoleculesView.cs
+++ b/src/MoBi.UI/Views/SelectSpatialStructureAndMoleculesView.cs
@@ -77,14 +77,10 @@ namespace MoBi.UI.Views
 
          _gridViewBinder = new GridViewBinder<MoleculeSelectionDTO>(gridView);
 
-         var colBuildingBlock = _gridViewBinder.Bind(dto => dto.BuildingBlock).AsReadOnly();
+         var colBuildingBlock = _gridViewBinder.Bind(dto => dto.BuildingBlockDisplayName).AsReadOnly();
          colBuildingBlock.XtraColumn.GroupIndex = 0;
 
-         _gridViewBinder.
-            AutoBind(dto => dto.MoleculeName).
-            WithRepository(configureMoleculeRepository).
-            WithCaption(Molecule).
-            AsReadOnly();
+         _gridViewBinder.AutoBind(dto => dto.MoleculeName).WithRepository(configureMoleculeRepository).WithCaption(Molecule).AsReadOnly();
          RegisterValidationFor(_screenBinder);
       }
 

--- a/tests/MoBi.Tests/Presentation/SelectSpatialStructureAndMoleculesPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectSpatialStructureAndMoleculesPresenterSpecs.cs
@@ -15,14 +15,56 @@ namespace MoBi.Presentation
    {
       protected IBuildingBlockRepository _buildingBlockRepository;
       protected ISelectSpatialStructureAndMoleculesView _view;
-      private ISelectSpatialStructureAndMoleculesDTOMapper _mapper;
+      protected ISelectSpatialStructureAndMoleculesDTOMapper _mapper;
 
       protected override void Context()
       {
          _view = A.Fake<ISelectSpatialStructureAndMoleculesView>();
-         _mapper = A.Fake<ISelectSpatialStructureAndMoleculesDTOMapper>();
+         _mapper = new SelectSpatialStructureAndMoleculesDTOMapper();
          _buildingBlockRepository = A.Fake<IBuildingBlockRepository>();
          sut = new SelectSpatialStructureAndMoleculesPresenter(_view, _buildingBlockRepository, _mapper);
+      }
+   }
+
+   public class When_initializing_the_view_with_default_building_blocks : concern_for_SelectSpatialStructureAndMoleculesPresenter
+   {
+      private MoleculeBuildingBlock _moleculeBuildingBlock;
+      private MoBiSpatialStructure _moBiSpatialStructure;
+      private MoBiSpatialStructure _unselectedSpatialStructure;
+      private MoleculeBuilder _molecule;
+      private MoleculeBuildingBlock[] _moleculeBuildingBlocks;
+      private MoBiSpatialStructure[] _moBiSpatialStructures;
+      private MoleculeBuildingBlock _unselectedMoleculeBuildingBlock;
+      private MoleculeBuilder _unselectedMolecule;
+
+      protected override void Context()
+      {
+         base.Context();
+         _molecule = new MoleculeBuilder();
+         _unselectedMolecule = new MoleculeBuilder();
+         _moleculeBuildingBlock = new MoleculeBuildingBlock { _molecule };
+         _unselectedMoleculeBuildingBlock = new MoleculeBuildingBlock { _unselectedMolecule };
+
+         _moleculeBuildingBlocks = new[] { _unselectedMoleculeBuildingBlock, _moleculeBuildingBlock };
+         A.CallTo(() => _buildingBlockRepository.MoleculeBlockCollection).Returns(_moleculeBuildingBlocks);
+         _moBiSpatialStructure = new MoBiSpatialStructure();
+         _unselectedSpatialStructure = new MoBiSpatialStructure();
+         _moBiSpatialStructures = new[] { _unselectedSpatialStructure, _moBiSpatialStructure };
+         A.CallTo(() => _buildingBlockRepository.SpatialStructureCollection).Returns(_moBiSpatialStructures);
+         A.CallTo(() => _view.Canceled).Returns(false);
+      }
+
+      protected override void Because()
+      {
+         sut.SelectBuildingBlocksForExtend(_moleculeBuildingBlock, _moBiSpatialStructure);
+      }
+
+      [Observation]
+      public void the_selections_should_be_null_or_empty()
+      {
+         sut.SelectedMolecules.ShouldContain(_molecule);
+         sut.SelectedMolecules.ShouldNotContain(_unselectedMolecule);
+         sut.SelectedSpatialStructure.ShouldBeEqualTo(_moBiSpatialStructure);
       }
    }
 
@@ -38,7 +80,7 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.SelectBuildingBlocksForExtend();
+         sut.SelectBuildingBlocksForExtend(null, null);
       }
 
       [Observation]
@@ -60,7 +102,7 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.SelectBuildingBlocksForExtend();
+         sut.SelectBuildingBlocksForExtend(null, null);
       }
 
       [Observation]

--- a/tests/MoBi.Tests/Presentation/Tasks/InitialConditionsTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InitialConditionsTaskSpecs.cs
@@ -1,9 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using OSPSuite.BDDHelper;
-using OSPSuite.BDDHelper.Extensions;
-using OSPSuite.Core.Commands.Core;
-using OSPSuite.Utility.Extensions;
 using FakeItEasy;
 using MoBi.Assets;
 using MoBi.Core.Commands;
@@ -18,11 +14,15 @@ using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Edit;
 using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Assets;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
-using OSPSuite.Assets;
+using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation.Tasks
 {
@@ -43,7 +43,10 @@ namespace MoBi.Presentation.Tasks
          _editTask = A.Fake<IEditTasksForBuildingBlock<InitialConditionsBuildingBlock>>();
          _initialConditionsCreator = A.Fake<IInitialConditionsCreator>();
          _cloneManagerForBuildingBlock = A.Fake<ICloneManagerForBuildingBlock>();
-         _initialConditionsBuildingBlock = new InitialConditionsBuildingBlock();
+         _initialConditionsBuildingBlock = new InitialConditionsBuildingBlock
+         {
+            Module = new Module()
+         };
          _reactionDimensionRetriever = A.Fake<IReactionDimensionRetriever>();
          _moleculeResolver = A.Fake<IMoleculeResolver>();
          _moleculeBuilderTask = A.Fake<IInteractionTasksForMoleculeBuilder>();
@@ -147,8 +150,8 @@ namespace MoBi.Presentation.Tasks
                Dimension = d,
                IsQuantitySpecified = true
             },
-            new ImportedQuantityDTO {Name = "C1", ContainerPath = new ObjectPath("that", "path"), QuantityInBaseUnit = 2.0, Dimension = d},
-            new ImportedQuantityDTO {Name = "C1", ContainerPath = new ObjectPath("the", "path"), QuantityInBaseUnit = 3.0, Dimension = d}
+            new ImportedQuantityDTO { Name = "C1", ContainerPath = new ObjectPath("that", "path"), QuantityInBaseUnit = 2.0, Dimension = d },
+            new ImportedQuantityDTO { Name = "C1", ContainerPath = new ObjectPath("the", "path"), QuantityInBaseUnit = 3.0, Dimension = d }
          };
 
          _initialConditionsBuildingBlock.Add(_firstStartValueRef);
@@ -213,10 +216,10 @@ namespace MoBi.Presentation.Tasks
          base.Context();
          _startValues = new List<InitialCondition>
          {
-            new InitialCondition {Name = "M1", IsPresent = true},
-            new InitialCondition {Name = "M2", IsPresent = false},
-            new InitialCondition {Name = "M3", IsPresent = true},
-            new InitialCondition {Name = "M4", IsPresent = false}
+            new InitialCondition { Name = "M1", IsPresent = true },
+            new InitialCondition { Name = "M2", IsPresent = false },
+            new InitialCondition { Name = "M3", IsPresent = true },
+            new InitialCondition { Name = "M4", IsPresent = false }
          };
          _startValues.Each(_initialConditionsBuildingBlock.Add);
       }
@@ -245,10 +248,10 @@ namespace MoBi.Presentation.Tasks
          base.Context();
          _startValues = new List<InitialCondition>
          {
-            new InitialCondition {Name = "M1", NegativeValuesAllowed = true},
-            new InitialCondition {Name = "M2", NegativeValuesAllowed = false},
-            new InitialCondition {Name = "M3", NegativeValuesAllowed = true},
-            new InitialCondition {Name = "M4", NegativeValuesAllowed = false}
+            new InitialCondition { Name = "M1", NegativeValuesAllowed = true },
+            new InitialCondition { Name = "M2", NegativeValuesAllowed = false },
+            new InitialCondition { Name = "M3", NegativeValuesAllowed = true },
+            new InitialCondition { Name = "M4", NegativeValuesAllowed = false }
          };
          _startValues.Each(_initialConditionsBuildingBlock.Add);
       }
@@ -376,7 +379,7 @@ namespace MoBi.Presentation.Tasks
          _startValue.Value.Value.ShouldBeEqualTo(TARGET_BASE_VALUE);
       }
    }
-   
+
    public abstract class When_cloning_a_molecule_start_values_building_block : concern_for_InitialConditionsTask
    {
       protected InitialConditionsBuildingBlock _buildingBlockToClone;
@@ -468,7 +471,7 @@ namespace MoBi.Presentation.Tasks
       [Observation]
       public void the_spatial_structure_and_molecule_selection_presenter_is_used_to_select_the_building_blocks()
       {
-         A.CallTo(() => _presenter.SelectBuildingBlocksForExtend()).MustHaveHappened();
+         A.CallTo(() => _presenter.SelectBuildingBlocksForExtend(null, null)).MustHaveHappened();
       }
    }
 


### PR DESCRIPTION
Fixes #1224

# Description
When you extend initial conditions you select a spatial structure and molecules building block to create new initial conditions.

By default, the view can pre-select the spatial structure from the same module, and I extended that request to include the molecules, too.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/8dc5061c-6cfb-417a-ab15-3cf91dd4900f)


# Questions (if appropriate):