### PR TITLE
Fixes #1232 Remove autohide columns in path and value grid views

### DIFF
--- a/src/MoBi.Presentation/Extensions/BreadCrumbExtensions.cs
+++ b/src/MoBi.Presentation/Extensions/BreadCrumbExtensions.cs
@@ -8,9 +8,9 @@ namespace MoBi.Presentation.Extensions
 {
    public static class BreadCrumbsExtensions
    {
-      public static bool HasAtLeastTwoDistinctValues<T>(this IEnumerable<BreadCrumbsDTO<T>> breadcrumbs, int pathElementIndex) where T : IValidatable, INotifier
+      public static bool HasAtLeastOneValue<T>(this IEnumerable<BreadCrumbsDTO<T>> breadcrumbs, int pathElementIndex) where T : IValidatable, INotifier
       {
-         return breadcrumbs.Select(x => x.PathElementByIndex(pathElementIndex)).Distinct().Count() >= 2;
+         return breadcrumbs.Select(x => x.PathElementByIndex(pathElementIndex)).Any(x => !string.IsNullOrEmpty(x));
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/CalculateScaleDivisorsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/CalculateScaleDivisorsPresenter.cs
@@ -121,9 +121,9 @@ namespace MoBi.Presentation.Presenter
          };
       }
 
-      public bool HasAtLeastTwoDistinctValues(int pathElementIndex)
+      public bool HasAtLeastOneValue(int pathElementIndex)
       {
-         return _scaleDivisors.HasAtLeastTwoDistinctValues(pathElementIndex);
+         return _scaleDivisors.HasAtLeastOneValue(pathElementIndex);
       }
       public async Task StartScaleDivisorsCalculation()
       {

--- a/src/MoBi.Presentation/Presenter/ExpressionProfileBuildingBlockPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ExpressionProfileBuildingBlockPresenter.cs
@@ -59,9 +59,9 @@ namespace MoBi.Presentation.Presenter
 
       public override object Subject => _buildingBlock;
 
-      public bool HasAtLeastTwoDistinctValues(int pathElementIndex)
+      public bool HasAtLeastOneValue(int pathElementIndex)
       {
-         return _expressionProfileBuildingBlockDTO.ParameterDTOs.HasAtLeastTwoDistinctValues(pathElementIndex);
+         return _expressionProfileBuildingBlockDTO.ParameterDTOs.HasAtLeastOneValue(pathElementIndex);
       }
 
       public void Handle(RenamedEvent eventToHandle)

--- a/src/MoBi.Presentation/Presenter/IBreadCrumbsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/IBreadCrumbsPresenter.cs
@@ -2,6 +2,6 @@
 {
    public interface IBreadCrumbsPresenter 
    {
-      bool HasAtLeastTwoDistinctValues(int pathElementIndex);
+      bool HasAtLeastOneValue(int pathElementIndex);
    }
 }

--- a/src/MoBi.Presentation/Presenter/IndividualBuildingBlockPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/IndividualBuildingBlockPresenter.cs
@@ -44,9 +44,9 @@ namespace MoBi.Presentation.Presenter
 
       public override object Subject => _buildingBlock;
 
-      public bool HasAtLeastTwoDistinctValues(int pathElementIndex)
+      public bool HasAtLeastOneValue(int pathElementIndex)
       {
-         return _individualBuildingBlockDTO.Parameters.HasAtLeastTwoDistinctValues(pathElementIndex);
+         return _individualBuildingBlockDTO.Parameters.HasAtLeastOneValue(pathElementIndex);
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/PathAndValueModuleBuildingBlockPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/PathAndValueModuleBuildingBlockPresenter.cs
@@ -241,9 +241,9 @@ namespace MoBi.Presentation.Presenter
 
       public abstract override void AddNewFormula(TStartValueDTO startValueDTO);
 
-      public bool HasAtLeastTwoDistinctValues(int pathElementIndex)
+      public bool HasAtLeastOneValue(int pathElementIndex)
       {
-         return _startValueDTOs.HasAtLeastTwoDistinctValues(pathElementIndex);
+         return _startValueDTOs.HasAtLeastOneValue(pathElementIndex);
       }
 
       public void HandleBuildingBlockEvent(BuildingBlockEvent eventToHandle)

--- a/src/MoBi.UI/Views/BasePathAndValueEntityView.cs
+++ b/src/MoBi.UI/Views/BasePathAndValueEntityView.cs
@@ -232,7 +232,7 @@ namespace MoBi.UI.Views
       {
          for (var i = 0; i < _pathElementsColumns.Count; i++)
          {
-            _pathElementsColumns[i].Visible = _presenter.HasAtLeastTwoDistinctValues(i);
+            _pathElementsColumns[i].Visible = _presenter.HasAtLeastOneValue(i);
          }
       }
 

--- a/src/MoBi.UI/Views/CalculateScaleDivisorsView.cs
+++ b/src/MoBi.UI/Views/CalculateScaleDivisorsView.cs
@@ -95,7 +95,7 @@ namespace MoBi.UI.Views
       {
          for (int i = 0; i < _pathElementsColumns.Count; i++)
          {
-            _pathElementsColumns[i].Visible = _presenter.HasAtLeastTwoDistinctValues(i);
+            _pathElementsColumns[i].Visible = _presenter.HasAtLeastOneValue(i);
          }
       }
 

--- a/src/MoBi.UI/Views/ExpressionProfileBuildingBlockView.cs
+++ b/src/MoBi.UI/Views/ExpressionProfileBuildingBlockView.cs
@@ -188,7 +188,7 @@ namespace MoBi.UI.Views
 
       private void initColumnVisibility()
       {
-         _pathElementsColumns.Each(column => column.Visible = _presenter.HasAtLeastTwoDistinctValues(_pathElementsColumns.IndexOf(column)));
+         _pathElementsColumns.Each(column => column.Visible = _presenter.HasAtLeastOneValue(_pathElementsColumns.IndexOf(column)));
       }
 
       public void AttachPresenter(IExpressionProfileBuildingBlockPresenter presenter)

--- a/src/MoBi.UI/Views/IndividualBuildingBlockView.cs
+++ b/src/MoBi.UI/Views/IndividualBuildingBlockView.cs
@@ -186,7 +186,7 @@ namespace MoBi.UI.Views
 
       private void initColumnVisibility()
       {
-         _pathElementsColumns.Each(column => column.Visible = _presenter.HasAtLeastTwoDistinctValues(_pathElementsColumns.IndexOf(column)));
+         _pathElementsColumns.Each(column => column.Visible = _presenter.HasAtLeastOneValue(_pathElementsColumns.IndexOf(column)));
       }
 
       public void BindTo(IndividualBuildingBlockDTO buildingBlockDTO)

--- a/tests/MoBi.Tests/Presentation/ExpressionProfileBuildingBlockPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ExpressionProfileBuildingBlockPresenterSpecs.cs
@@ -68,8 +68,10 @@ namespace MoBi.Presentation
          [Observation]
          public void should_find_distinct_paths_only_where_appropriate()
          {
-            sut.HasAtLeastTwoDistinctValues(0).ShouldBeFalse();
-            sut.HasAtLeastTwoDistinctValues(1).ShouldBeTrue();
+            sut.HasAtLeastOneValue(0).ShouldBeTrue();
+            sut.HasAtLeastOneValue(1).ShouldBeTrue();
+            sut.HasAtLeastOneValue(2).ShouldBeFalse();
+            sut.HasAtLeastOneValue(3).ShouldBeFalse();
          }
       }
 

--- a/tests/MoBi.Tests/Presentation/IndividualBuildingBlockPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/IndividualBuildingBlockPresenterSpecs.cs
@@ -88,8 +88,10 @@ namespace MoBi.Presentation
          [Observation]
          public void should_find_distinct_paths_only_where_appropriate()
          {
-            sut.HasAtLeastTwoDistinctValues(0).ShouldBeFalse();
-            sut.HasAtLeastTwoDistinctValues(1).ShouldBeTrue();
+            sut.HasAtLeastOneValue(0).ShouldBeTrue();
+            sut.HasAtLeastOneValue(1).ShouldBeTrue();
+            sut.HasAtLeastOneValue(2).ShouldBeFalse();
+            sut.HasAtLeastOneValue(3).ShouldBeFalse();
          }
       }
 


### PR DESCRIPTION
Fixes #1232

# Description
In path and value grids, we are going to automatically show any path element column that has values. Formerly, if there was only one value in a path element column it would be hidden by default.

So, often PathElement 0 would be hidden because it would have one value of the top container 'Organism'. Now we are going to show this column.

We still hide columns that have no values.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):