### PR TITLE
Fixes #1228 V12: Crash when undoing Output interval modification

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.253" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.253" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.253" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.255" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.253" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.255" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.253" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/EditOutputSchemaPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditOutputSchemaPresenter.cs
@@ -8,8 +8,10 @@ using MoBi.Presentation.Views;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.UnitSystem;
+using OSPSuite.Core.Events;
 using OSPSuite.Presentation.DTO;
 using OSPSuite.Presentation.Presenters;
+using OSPSuite.Utility.Events;
 
 namespace MoBi.Presentation.Presenter
 {
@@ -23,7 +25,9 @@ namespace MoBi.Presentation.Presenter
       void Edit(IMoBiSimulation simulation);
    }
 
-   internal class EditOutputSchemaPresenter : AbstractSubPresenter<IEditOutputSchemaView, IEditOutputSchemaPresenter>, IEditOutputSchemaPresenter
+   internal class EditOutputSchemaPresenter : AbstractSubPresenter<IEditOutputSchemaView, IEditOutputSchemaPresenter>, 
+      IEditOutputSchemaPresenter,
+      IListener<OutputSchemaChangedEvent>
    {
       private readonly IOutputIntervalToOutputIntervalDTOMapper _intervalMapper;
       private readonly IQuantityTask _quantityTask;
@@ -99,6 +103,12 @@ namespace MoBi.Presentation.Presenter
       public bool ShowGroupCaption
       {
          set => View.ShowGroupCaption = value;
+      }
+
+      public void Handle(OutputSchemaChangedEvent eventToHandle)
+      {
+         if (eventToHandle.OutputSchema.Equals(_simulationSettings.OutputSchema))
+            bindToView();
       }
    }
 }

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.253" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.253" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.253" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.255" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/Core/Commands/AddOutputIntervalCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/AddOutputIntervalCommandSpecs.cs
@@ -1,0 +1,91 @@
+﻿using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Services;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Events;
+
+namespace MoBi.Core.Commands
+{
+   public class concern_for_AddOutputIntervalCommand : ContextSpecification<AddOutputIntervalCommand>
+   {
+      protected SimulationSettings _simulationSettings;
+      protected OutputInterval _interval;
+      protected OutputSchema _schema;
+      protected IMoBiContext _context;
+      protected IBuildingBlockVersionUpdater _buildingBlockVersionUpdater;
+      protected string _intervalId;
+
+      protected override void Context()
+      {
+         _context = A.Fake<IMoBiContext>();
+         _intervalId = "intervalId";
+         _buildingBlockVersionUpdater = A.Fake<IBuildingBlockVersionUpdater>();
+         _schema = new OutputSchema();
+         _interval = new OutputInterval().WithId(_intervalId);
+         _simulationSettings = new SimulationSettings
+         {
+            OutputSchema = _schema,
+            Id = "simulationSettingsId"
+         };
+         sut = new AddOutputIntervalCommand(_schema, _interval, _simulationSettings);
+
+         A.CallTo(() => _context.Get<SimulationSettings>(_simulationSettings.Id)).Returns(_simulationSettings);
+         A.CallTo(() => _context.Resolve<IBuildingBlockVersionUpdater>()).Returns(_buildingBlockVersionUpdater);
+      }
+   }
+
+   public class When_reverting_the_add_output_interval_command : concern_for_AddOutputIntervalCommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _context.Get<OutputInterval>(_intervalId)).Returns(_interval);
+      }
+
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_context);
+      }
+
+      [Observation]
+      public void the_interval_must_be_removed_from_the_schema()
+      {
+         _schema.Intervals.ShouldNotContain(_interval);
+      }
+   }
+
+   public class When_adding_an_output_interval_to_a_schema : concern_for_AddOutputIntervalCommand
+   {
+      protected override void Because()
+      {
+         sut.Execute(_context);
+      }
+
+      [Observation]
+      public void the_interval_must_be_registered()
+      {
+         A.CallTo(() => _context.Register(_interval)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_schema_must_contain_the_new_interval()
+      {
+         _schema.Intervals.ShouldContain(_interval);
+      }
+
+      [Observation]
+      public void an_event_must_be_raised_for_the_schema()
+      {
+         A.CallTo(() => _context.PublishEvent(A<OutputSchemaChangedEvent>.That.Matches(x => x.OutputSchema == _schema))).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_building_block_version_updater_should_update_the_building_block_version()
+      {
+         A.CallTo(() => _buildingBlockVersionUpdater.UpdateBuildingBlockVersion(_simulationSettings, true)).MustHaveHappened();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Core/Commands/RemoveOutputIntervalCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/RemoveOutputIntervalCommandSpecs.cs
@@ -1,0 +1,92 @@
+﻿using FakeItEasy;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.BDDHelper;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Services;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Events;
+
+namespace MoBi.Core.Commands
+{
+   public class concern_for_RemoveOutputIntervalCommand: ContextSpecification<RemoveOutputIntervalCommand>
+   {
+      protected SimulationSettings _simulationSettings;
+      protected OutputInterval _interval;
+      protected OutputSchema _schema;
+      protected IMoBiContext _context;
+      protected IBuildingBlockVersionUpdater _buildingBlockVersionUpdater;
+      protected string _intervalId;
+
+      protected override void Context()
+      {
+         _context = A.Fake<IMoBiContext>();
+         _intervalId = "intervalId";
+         _buildingBlockVersionUpdater = A.Fake<IBuildingBlockVersionUpdater>();
+         _schema = new OutputSchema();
+         _interval = new OutputInterval().WithId(_intervalId);
+         _schema.AddInterval(_interval);
+         _simulationSettings = new SimulationSettings
+         {
+            OutputSchema = _schema,
+            Id = "simulationSettingsId"
+         };
+         sut = new RemoveOutputIntervalCommand(_schema, _interval, _simulationSettings);
+
+         A.CallTo(() => _context.Get<SimulationSettings>(_simulationSettings.Id)).Returns(_simulationSettings);
+         A.CallTo(() => _context.Resolve<IBuildingBlockVersionUpdater>()).Returns(_buildingBlockVersionUpdater);
+      }
+   }
+
+   public class When_reverting_the_remove_output_interval_command : concern_for_RemoveOutputIntervalCommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _context.Deserialize<OutputInterval>(A<byte[]>._)).Returns(_interval);
+      }
+
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_context);
+      }
+
+      [Observation]
+      public void the_interval_must_be_added_to_the_schema()
+      {
+         _schema.Intervals.ShouldContain(_interval);
+      }
+   }
+
+   public class When_removing_an_output_interval_to_a_schema : concern_for_RemoveOutputIntervalCommand
+   {
+      protected override void Because()
+      {
+         sut.Execute(_context);
+      }
+
+      [Observation]
+      public void the_interval_must_be_unregistered()
+      {
+         A.CallTo(() => _context.Unregister(_interval)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_schema_must_not_contain_the_new_interval()
+      {
+         _schema.Intervals.ShouldNotContain(_interval);
+      }
+
+      [Observation]
+      public void an_event_must_be_raised_for_the_schema()
+      {
+         A.CallTo(() => _context.PublishEvent(A<OutputSchemaChangedEvent>.That.Matches(x => x.OutputSchema == _schema))).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_building_block_version_updater_should_update_the_building_block_version()
+      {
+         A.CallTo(() => _buildingBlockVersionUpdater.UpdateBuildingBlockVersion(_simulationSettings, true)).MustHaveHappened();
+      }
+   }
+}

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.253" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.255" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.253" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.253" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.255" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1227
Fixes #1228

# Description
Both were caused by a missing registration of simulation settings during simulation construction as well as missing registration when adding intervals themselves.

There were also no events being used to communicate when an output schema was updated a change in the output intervals collection

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):