### PR TITLE
Fixes #1163 add output selections to project simulation settings editor

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1578,6 +1578,8 @@ namespace MoBi.Assets
          public static readonly string SelectSpatialStructureAndMolecules = "Select a spatial structure and molecules";
          public static readonly string SelectSpatialStructure = "Select a spatial structure";
          public static readonly string ExtendDescription = "<b><i>Initial conditions</i> will be created for molecules in all physical containers in the selected <i>spatial structure</i></b>";
+         public static readonly string AddDefaultCurveForNewSimulations = "Add default curve for new simulations";
+         public static readonly string ChangeDefaultCurveForNewSimulations = "Change default curve for new simulations";
          public static string ExportContainerDescription(string exportedContainerPath) => $"Select an individual and file path for container export. Parameters from the individual that match the path {exportedContainerPath} will be addd to the container before exporting.";
          public static readonly string SelectIndividualAndPathForContainerExport = "Select an individual and path for container export";
 
@@ -2029,6 +2031,11 @@ namespace MoBi.Assets
          public static string NameIsAlreadyUsedInThisContainer(string containerPath, string name)
          {
             return $"A value with the name '{name}' already exists for the container {containerPath}";
+         }
+
+         public static string ThePathIsAlreadySelectedAsAnOutput(ObjectPath objectPath)
+         {
+            return $"The path {objectPath} is already selected as an output.";
          }
       }
 

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -2033,10 +2033,7 @@ namespace MoBi.Assets
             return $"A value with the name '{name}' already exists for the container {containerPath}";
          }
 
-         public static string ThePathIsAlreadySelectedAsAnOutput(ObjectPath objectPath)
-         {
-            return $"The path {objectPath} is already selected as an output.";
-         }
+         public static string ThePathIsAlreadySelectedAsAnOutput(ObjectPath objectPath) => $"The path {objectPath} is already selected as an output.";
       }
 
       public static readonly string TimeColumnName = "Simulationtime";

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.259" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.259" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.Core/Domain/Model/MoBiContext.cs
+++ b/src/MoBi.Core/Domain/Model/MoBiContext.cs
@@ -236,7 +236,7 @@ namespace MoBi.Core.Domain.Model
             return DimensionFactory.Dimension(valueAsString);
 
          if (propertyType.IsAnImplementationOf<ObjectPath>())
-            return ObjectPathFactory.CreateObjectPathFrom(valueAsString.ToPathArray());
+            return valueAsString.ToObjectPath();
 
          if (propertyType.IsAnImplementationOf<Unit>())
             return DimensionFactory.DimensionForUnit(valueAsString).UnitOrDefault(valueAsString);

--- a/src/MoBi.Core/Domain/UnitSystem/DimensionConverter.cs
+++ b/src/MoBi.Core/Domain/UnitSystem/DimensionConverter.cs
@@ -91,11 +91,9 @@ namespace MoBi.Core.Domain.UnitSystem
    {
       private IQuantity _formulaUsable;
       private ObjectPath _useablePath;
-      private readonly ObjectPathFactory _pathFactory;
 
       public MolWeightDimensionConverterForFormulaUsable(IDimension sourceDimension, IDimension targetDimension) : base(sourceDimension, targetDimension)
       {
-         _pathFactory = new ObjectPathFactory(new AliasCreator());
       }
 
       public override bool CanResolveParameters()
@@ -104,7 +102,7 @@ namespace MoBi.Core.Domain.UnitSystem
          if (root == null)
             return false;
 
-         _useablePath = _pathFactory.CreateObjectPathFrom(root.Name, _formulaUsable.Name, Constants.Parameters.MOL_WEIGHT);
+         _useablePath = new ObjectPath(root.Name, _formulaUsable.Name, Constants.Parameters.MOL_WEIGHT);
          return _useablePath.TryResolve<IFormulaUsable>(root) != null;
       }
 
@@ -121,7 +119,7 @@ namespace MoBi.Core.Domain.UnitSystem
             return null;
 
          var root = _formulaUsable.RootContainer;
-         var useablePath = _pathFactory.CreateObjectPathFrom(root.Name, _formulaUsable.Name, Constants.Parameters.MOL_WEIGHT);
+         var useablePath = new ObjectPath(root.Name, _formulaUsable.Name, Constants.Parameters.MOL_WEIGHT);
          var entity = useablePath.Resolve<IFormulaUsable>(root);
          if (double.IsNaN(entity.Value))
             return null;

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.259" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.257" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.0-nubVh" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.259" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.257" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-nubVh" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.259" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/EditOutputSelectionsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditOutputSelectionsPresenter.cs
@@ -1,0 +1,69 @@
+﻿using MoBi.Presentation.Tasks;
+using MoBi.Presentation.Views;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Presentation.Presenters;
+
+namespace MoBi.Presentation.Presenter
+{
+   public interface IEditOutputSelectionsPresenter : ISimulationSettingsItemPresenter
+   {
+      /// <summary>
+      /// Removes the <paramref name="selection"/> from the simulation settings
+      /// </summary>
+      void RemoveOutputSelection(QuantitySelection selection);
+
+      /// <summary>
+      /// Edit the <paramref name="selection"/> in the simulation settings using the interactive editor
+      /// </summary>
+      void EditOutputSelection(QuantitySelection selection);
+
+      /// <summary>
+      /// Adds a new output selection to the simulation settings. The <paramref name="preSelectedQuantitySelection"/>
+      /// is preselected in the tree view
+      /// </summary>
+      void AddOutputSelection(QuantitySelection preSelectedQuantitySelection);
+
+      /// <summary>
+      /// Updates the <paramref name="selection"/> with the <paramref name="newSelectionPath"/>
+      /// </summary>
+      void UpdateOutputSelection(QuantitySelection selection, string newSelectionPath);
+   }
+
+   public class EditOutputSelectionsPresenter : AbstractSubPresenter<IEditOutputSelectionsView, IEditOutputSelectionsPresenter>, IEditOutputSelectionsPresenter
+   {
+      private readonly IOutputSelectionsTask _outputSelectionsTask;
+      private SimulationSettings _simulationSettings;
+
+      public EditOutputSelectionsPresenter(IEditOutputSelectionsView view, IOutputSelectionsTask outputSelectionsTask) : base(view)
+      {
+         _outputSelectionsTask = outputSelectionsTask;
+      }
+
+      public void Edit(SimulationSettings simulationSettings)
+      {
+         _simulationSettings = simulationSettings;
+         _view.BindTo(_simulationSettings.OutputSelections.AllOutputs);
+      }
+
+      public void RemoveOutputSelection(QuantitySelection selection)
+      {
+         _outputSelectionsTask.RemoveOutputSelection(_simulationSettings, selection);
+      }
+
+      public void EditOutputSelection(QuantitySelection selection)
+      {
+         _outputSelectionsTask.EditOutputSelection(_simulationSettings, selection);
+      }
+
+      public void AddOutputSelection(QuantitySelection preSelectedQuantitySelection)
+      {
+         _outputSelectionsTask.AddOutputSelection(_simulationSettings, preSelectedQuantitySelection);
+      }
+
+      public void UpdateOutputSelection(QuantitySelection selection, string newSelectionPath)
+      {
+         _outputSelectionsTask.UpdateOutputSelection(_simulationSettings, selection, newSelectionPath);
+      }
+   }
+}

--- a/src/MoBi.Presentation/Presenter/HierarchicalQuantitySelectionPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalQuantitySelectionPresenter.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Views;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using ISimulationPersistableUpdater = MoBi.Core.Services.ISimulationPersistableUpdater;
+
+namespace MoBi.Presentation.Presenter
+{
+   public interface IHierarchicalQuantitySelectionPresenter : IHierarchicalStructurePresenter
+   {
+      /// <summary>
+      /// Selects the quantity from the <paramref name="quantityPath"/> in the tree view
+      /// </summary>
+      void SelectQuantityFromPath(ObjectPath quantityPath);
+
+      /// <summary>
+      /// The path of the quantity that was selected in the tree view
+      /// </summary>
+      ObjectPath SelectedPath { get; }
+
+
+      void SelectPathFrom(IReadOnlyList<ISimulation> simulations);
+   }
+
+   public class HierarchicalQuantitySelectionPresenter : HierarchicalStructurePresenter, IHierarchicalQuantitySelectionPresenter
+   {
+      private readonly ISimulationPersistableUpdater _simulationPersistableUpdater;
+      private readonly IEntityPathResolver _entityPathResolver;
+      private IReadOnlyList<ISimulation> _simulations;
+      private ObjectBaseDTO _selection;
+      private IViewItemContextMenuFactory _contextMenuFactory;
+
+      public HierarchicalQuantitySelectionPresenter(IHierarchicalStructureView view,
+         IMoBiContext context,
+         IObjectBaseToObjectBaseDTOMapper objectBaseMapper,
+         ISimulationPersistableUpdater simulationPersistableUpdater,
+         IEntityPathResolver entityPathResolver, IViewItemContextMenuFactory contextMenuFactory) :
+         base(view, context, objectBaseMapper)
+      {
+         _simulationPersistableUpdater = simulationPersistableUpdater;
+         _entityPathResolver = entityPathResolver;
+         _contextMenuFactory = contextMenuFactory;
+      }
+
+      public void SelectPathFrom(IReadOnlyList<ISimulation> simulations)
+      {
+         _simulations = simulations;
+
+         var simulationNodes = new List<ObjectBaseDTO>();
+
+         simulationNodes.AddRange(_simulations.Select(x => _objectBaseMapper.MapFrom(x)));
+
+         _view.Show(simulationNodes);
+      }
+
+      public override IReadOnlyList<ObjectBaseDTO> GetChildObjects(ObjectBaseDTO dto, Func<IEntity, bool> predicate)
+      {
+         if (dto.ObjectBase is ISimulation simulation)
+            return GetChildrenSorted(simulation.Model.Root, hasSelectable);
+
+         return base.GetChildObjects(dto, predicate);
+      }
+
+      protected override IReadOnlyList<ObjectBaseDTO> GetChildrenSorted(IContainer container, Func<IEntity, bool> predicate)
+      {
+         // Use hasPersistable because we want to include any container that contains a persistable quantity
+         // as well as the quantities themselves.
+         return base.GetChildrenSorted(container, x => hasSelectable(x) && predicate(x));
+      }
+
+      public override void ShowContextMenu(IViewItem objectRequestingPopup, Point popupLocation)
+      {
+         var contextMenu = _contextMenuFactory.CreateFor(objectRequestingPopup, this);
+         contextMenu.Show(_view, popupLocation);
+      }
+
+      private bool hasSelectable(IEntity entity)
+      {
+         if (entityIsSelectableQuantity(entity))
+            return true;
+
+         if (entity is IContainer container)
+            return container.Any(hasSelectable);
+
+         return false;
+      }
+
+      private bool entityIsSelectableQuantity(IObjectBase entity)
+      {
+         if (entity is IQuantity quantity)
+            return _simulationPersistableUpdater.QuantityIsSelectable(quantity, forceAmountToBeSelectable: true);
+
+         return false;
+      }
+
+      public void SelectQuantityFromPath(ObjectPath quantityPath)
+      {
+         if (quantityPath == null)
+            return;
+
+         var entity = _simulations.Select(x => x.Model.Root.EntityAt<IEntity>(quantityPath)).FirstOrDefault();
+         if (entity == null)
+            return;
+
+         _view.Select(entity);
+      }
+
+      public ObjectPath SelectedPath => _selection.ObjectBase is IEntity entity ? _entityPathResolver.ObjectPathFor(entity) : null;
+
+      public object Subject => _simulations;
+
+      public void Select(ObjectBaseDTO objectBaseDTO)
+      {
+         _selection = objectBaseDTO;
+         ViewChanged();
+      }
+
+      public override bool CanClose => entityIsSelectableQuantity(_selection?.ObjectBase);
+   }
+}

--- a/src/MoBi.Presentation/Presenter/HierarchicalQuantitySelectionPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalQuantitySelectionPresenter.cs
@@ -53,11 +53,8 @@ namespace MoBi.Presentation.Presenter
       public void SelectPathFrom(IReadOnlyList<ISimulation> simulations)
       {
          _simulations = simulations;
-
          var simulationNodes = new List<ObjectBaseDTO>();
-
          simulationNodes.AddRange(_simulations.Select(x => _objectBaseMapper.MapFrom(x)));
-
          _view.Show(simulationNodes);
       }
 

--- a/src/MoBi.Presentation/Presenter/HierarchicalQuantitySelectionPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalQuantitySelectionPresenter.cs
@@ -36,7 +36,7 @@ namespace MoBi.Presentation.Presenter
       private readonly IEntityPathResolver _entityPathResolver;
       private IReadOnlyList<ISimulation> _simulations;
       private ObjectBaseDTO _selection;
-      private IViewItemContextMenuFactory _contextMenuFactory;
+      private readonly IViewItemContextMenuFactory _contextMenuFactory;
 
       public HierarchicalQuantitySelectionPresenter(IHierarchicalStructureView view,
          IMoBiContext context,

--- a/src/MoBi.Presentation/Presenter/HierarchicalSimulationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalSimulationPresenter.cs
@@ -29,7 +29,7 @@ namespace MoBi.Presentation.Presenter
       Func<IEnumerable<IParameter>> SimulationFavorites { get; set; }
    }
 
-   internal class HierarchicalSimulationPresenter : HierarchicalStructurePresenter, IHierarchicalSimulationPresenter
+   internal class HierarchicalSimulationPresenter : HierarchicalStructureEditPresenter, IHierarchicalSimulationPresenter
    {
       private IMoBiSimulation _simulation;
       private readonly ISimulationSettingsToObjectBaseDTOMapper _simulationSettingsMapper;

--- a/src/MoBi.Presentation/Presenter/HierarchicalSpatialStructurePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalSpatialStructurePresenter.cs
@@ -28,7 +28,7 @@ namespace MoBi.Presentation.Presenter
       void Refresh(IEntity entity);
    }
 
-   public class HierarchicalSpatialStructurePresenter : HierarchicalStructurePresenter, IHierarchicalSpatialStructurePresenter
+   public class HierarchicalSpatialStructurePresenter : HierarchicalStructureEditPresenter, IHierarchicalSpatialStructurePresenter
    {
       private SpatialStructure _spatialStructure;
       private readonly IViewItemContextMenuFactory _contextMenuFactory;

--- a/src/MoBi.Presentation/Presenter/HierarchicalStructureEditPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalStructureEditPresenter.cs
@@ -1,0 +1,52 @@
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Events;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Views;
+using OSPSuite.Presentation.Nodes;
+using ITreeNodeFactory = MoBi.Presentation.Nodes.ITreeNodeFactory;
+
+namespace MoBi.Presentation.Presenter
+{
+   public abstract class HierarchicalStructureEditPresenter : HierarchicalStructurePresenter
+   {
+
+      protected ITreeNode _favoritesNode;
+      protected ITreeNode _userDefinedNode;
+
+      protected HierarchicalStructureEditPresenter(
+         IHierarchicalStructureView view, 
+         IMoBiContext context,
+         IObjectBaseToObjectBaseDTOMapper objectBaseMapper, 
+         ITreeNodeFactory treeNodeFactory)
+         : base(view, context, objectBaseMapper)
+      {
+         _favoritesNode = treeNodeFactory.CreateForFavorites();
+         _userDefinedNode = treeNodeFactory.CreateForUserDefined();
+      }
+
+      public virtual void Select(ObjectBaseDTO objectBaseDTO)
+      {
+         if (objectBaseDTO == _favoritesNode.TagAsObject)
+            RaiseFavoritesSelectedEvent();
+
+         else if (objectBaseDTO == _userDefinedNode.TagAsObject)
+            RaiseUserDefinedSelectedEvent();
+
+         else
+            raiseEntitySelectedEvent(objectBaseDTO);
+      }
+
+      private void raiseEntitySelectedEvent(ObjectBaseDTO objectBaseDTO)
+      {
+         // First and second neighbor node selections should not trigger an EntitySelectedEvent
+         // because they are not a selectable entity
+         if(objectBaseDTO.ObjectBase != null)
+            _context.PublishEvent(new EntitySelectedEvent(objectBaseDTO.ObjectBase, this));
+      }
+
+      protected abstract void RaiseFavoritesSelectedEvent();
+
+      protected abstract void RaiseUserDefinedSelectedEvent();
+   }
+}

--- a/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
@@ -29,9 +29,9 @@ namespace MoBi.Presentation.Presenter
       protected IObjectBaseToObjectBaseDTOMapper _objectBaseMapper;
 
       protected HierarchicalStructurePresenter(
-         IHierarchicalStructureView view, 
-         IMoBiContext context, 
-         IObjectBaseToObjectBaseDTOMapper objectBaseMapper) 
+         IHierarchicalStructureView view,
+         IMoBiContext context,
+         IObjectBaseToObjectBaseDTOMapper objectBaseMapper)
          : base(view)
       {
          _context = context;
@@ -59,7 +59,6 @@ namespace MoBi.Presentation.Presenter
                return neighborsOf(neighborhood).Union(allChildrenDTO()).ToList();
             default:
                return allChildrenDTO();
-
          }
       }
 
@@ -73,9 +72,10 @@ namespace MoBi.Presentation.Presenter
       }
 
       /// <summary>
-      /// Creates an Id for neighbors in a neighborhood.
-      /// The Id must be distinct for each neighborhood and neighbor, so it cannot be just the <paramref name="neighborPath"/>, but must
-      /// include the id of the <paramref name="neighborhood"/>
+      ///    Creates an Id for neighbors in a neighborhood.
+      ///    The Id must be distinct for each neighborhood and neighbor, so it cannot be just the
+      ///    <paramref name="neighborPath" />, but must
+      ///    include the id of the <paramref name="neighborhood" />
       /// </summary>
       /// <returns>An Id that combines the two Ids of the neighborhood and neighbor</returns>
       private string createNeighborhoodId(NeighborhoodBuilder neighborhood, ObjectPath neighborPath)

--- a/src/MoBi.Presentation/Tasks/OutputSelectionsTask.cs
+++ b/src/MoBi.Presentation/Tasks/OutputSelectionsTask.cs
@@ -1,0 +1,150 @@
+﻿using System.Linq;
+using MoBi.Assets;
+using MoBi.Presentation.Presenter;
+using OSPSuite.Core.Commands;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Repositories;
+using OSPSuite.Core.Extensions;
+using OSPSuite.Core.Services;
+
+namespace MoBi.Presentation.Tasks
+{
+   public interface IOutputSelectionsTask
+   {
+      /// <summary>
+      /// Adds a new output selection to the <paramref name="simulationSettings"/>. The <paramref name="preSelectedQuantitySelection"/>
+      /// is preselected in the tree view
+      /// </summary>
+      void AddOutputSelection(SimulationSettings simulationSettings, QuantitySelection preSelectedQuantitySelection = null);
+
+      /// <summary>
+      /// Edit the <paramref name="selection"/> in the <paramref name="simulationSettings"/> using the interactive editor
+      /// </summary>
+      void EditOutputSelection(SimulationSettings simulationSettings, QuantitySelection selection);
+
+      /// <summary>
+      /// Removes the <paramref name="selection"/> from the <paramref name="simulationSettings"/>
+      /// </summary>
+      void RemoveOutputSelection(SimulationSettings simulationSettings, QuantitySelection selection);
+
+      /// <summary>
+      /// Updates the <paramref name="selection"/> with the <paramref name="newPath"/>
+      /// </summary>
+      void UpdateOutputSelection(SimulationSettings simulationSettings, QuantitySelection selection, string newPath);
+   }
+
+   public class OutputSelectionsTask : IOutputSelectionsTask
+   {
+      private readonly IOSPSuiteExecutionContext _context;
+      private readonly IMoBiApplicationController _applicationController;
+      private readonly ISimulationRepository _simulationRepository;
+      private readonly IDialogCreator _dialogCreator;
+
+      public OutputSelectionsTask(IOSPSuiteExecutionContext context, IMoBiApplicationController applicationController, ISimulationRepository simulationRepository, IDialogCreator dialogCreator)
+      {
+         _context = context;
+         _applicationController = applicationController;
+         _simulationRepository = simulationRepository;
+         _dialogCreator = dialogCreator;
+      }
+
+      public void AddOutputSelection(SimulationSettings simulationSettings, QuantitySelection preSelectedQuantitySelection = null)
+      {
+         var pathFromSimulations = selectPathFromSimulationsFor(AppConstants.Captions.AddDefaultCurveForNewSimulations, preSelectedQuantitySelection);
+         if(pathFromSimulations == null)
+            return;
+
+         if (!validateAndWarnNewPath(pathFromSimulations, simulationSettings))
+            return;
+
+         simulationSettings.OutputSelections.AddOutput(new QuantitySelection(pathFromSimulations, QuantityType.Undefined));
+         projectHasChanged();
+      }
+
+      private void showWarningMessage(ObjectPath pathFromSimulations)
+      {
+         _dialogCreator.MessageBoxInfo(AppConstants.Validation.ThePathIsAlreadySelectedAsAnOutput(pathFromSimulations));
+      }
+
+      private bool alreadyContainsPath(ObjectPath pathFromSimulations, SimulationSettings simulationSettings)
+      {
+         return simulationSettings.OutputSelections.Any(selection => Equals(selection.Path, pathFromSimulations.ToPathString()));
+      }
+
+      private void projectHasChanged()
+      {
+         _context.Project.HasChanged = true;
+      }
+
+      public void EditOutputSelection(SimulationSettings simulationSettings, QuantitySelection selection)
+      {
+         var newPath = selectPathFromSimulationsFor(AppConstants.Captions.ChangeDefaultCurveForNewSimulations, selection);
+
+         if (noChangesRequired(selection, newPath))
+            return;
+
+         if(validateAndUpdate(selection, newPath, simulationSettings))
+            projectHasChanged();
+      }
+
+      private static bool noChangesRequired(QuantitySelection selection, ObjectPath newPath)
+      {
+         return newPath == null || Equals(selection.Path, newPath.ToPathString());
+      }
+
+      private ObjectPath selectPathFromSimulationsFor(string caption, QuantitySelection preSelectedQuantity = null)
+      {
+         using (var modalPresenter = _applicationController.Start<IModalPresenter>())
+         {
+            modalPresenter.Text = caption;
+            var selectPathPresenter = _applicationController.Start<IHierarchicalQuantitySelectionPresenter>();
+            modalPresenter.Encapsulate(selectPathPresenter);
+            selectPathPresenter.SelectPathFrom(_simulationRepository.All().ToList());
+
+            if(preSelectedQuantity != null)
+               selectPathPresenter.SelectQuantityFromPath(new ObjectPath(preSelectedQuantity.Path.ToPathArray()));
+
+            if (modalPresenter.Show())
+               return selectPathPresenter.SelectedPath;
+         }
+
+         return null;
+      }
+
+      private bool validateAndWarnNewPath(ObjectPath selectedPath, SimulationSettings simulationSettings)
+      {
+         if (!alreadyContainsPath(selectedPath, simulationSettings)) 
+            return true;
+         
+         showWarningMessage(selectedPath);
+         return false;
+      }
+
+      public void UpdateOutputSelection(SimulationSettings simulationSettings, QuantitySelection selection, string newPath)
+      {
+         if (noChangesRequired(selection, new ObjectPath(newPath.ToPathArray())))
+            return;
+
+         if (!validateAndUpdate(selection, newPath, simulationSettings)) 
+            return;
+
+         projectHasChanged();
+      }
+
+      private bool validateAndUpdate(QuantitySelection selection, string newPath, SimulationSettings simulationSettings)
+      {
+         if (!validateAndWarnNewPath(new ObjectPath(newPath.ToPathArray()), simulationSettings))
+            return false;
+
+         selection.Path = newPath;
+         return true;
+      }
+
+      public void RemoveOutputSelection(SimulationSettings simulationSettings, QuantitySelection selection)
+      {
+         simulationSettings.OutputSelections.RemoveOutput(selection);
+         projectHasChanged();
+      }
+   }
+}

--- a/src/MoBi.Presentation/Tasks/OutputSelectionsTask.cs
+++ b/src/MoBi.Presentation/Tasks/OutputSelectionsTask.cs
@@ -41,7 +41,11 @@ namespace MoBi.Presentation.Tasks
       private readonly ISimulationRepository _simulationRepository;
       private readonly IDialogCreator _dialogCreator;
 
-      public OutputSelectionsTask(IOSPSuiteExecutionContext context, IMoBiApplicationController applicationController, ISimulationRepository simulationRepository, IDialogCreator dialogCreator)
+      public OutputSelectionsTask(
+         IOSPSuiteExecutionContext context, 
+         IMoBiApplicationController applicationController, 
+         ISimulationRepository simulationRepository, 
+         IDialogCreator dialogCreator)
       {
          _context = context;
          _applicationController = applicationController;
@@ -58,7 +62,8 @@ namespace MoBi.Presentation.Tasks
          if (!validateAndWarnNewPath(pathFromSimulations, simulationSettings))
             return;
 
-         simulationSettings.OutputSelections.AddOutput(new QuantitySelection(pathFromSimulations, QuantityType.Undefined));
+         // In the case of output selections, the quantity type is not important
+         simulationSettings.OutputSelections.AddOutput(new QuantitySelection(pathFromSimulations));
          projectHasChanged();
       }
 
@@ -103,7 +108,7 @@ namespace MoBi.Presentation.Tasks
             selectPathPresenter.SelectPathFrom(_simulationRepository.All().ToList());
 
             if(preSelectedQuantity != null)
-               selectPathPresenter.SelectQuantityFromPath(new ObjectPath(preSelectedQuantity.Path.ToPathArray()));
+               selectPathPresenter.SelectQuantityFromPath(preSelectedQuantity.Path.ToObjectPath());
 
             if (modalPresenter.Show())
                return selectPathPresenter.SelectedPath;
@@ -123,7 +128,7 @@ namespace MoBi.Presentation.Tasks
 
       public void UpdateOutputSelection(SimulationSettings simulationSettings, QuantitySelection selection, string newPath)
       {
-         if (noChangesRequired(selection, new ObjectPath(newPath.ToPathArray())))
+         if (noChangesRequired(selection, newPath.ToObjectPath()))
             return;
 
          if (!validateAndUpdate(selection, newPath, simulationSettings)) 
@@ -134,7 +139,7 @@ namespace MoBi.Presentation.Tasks
 
       private bool validateAndUpdate(QuantitySelection selection, string newPath, SimulationSettings simulationSettings)
       {
-         if (!validateAndWarnNewPath(new ObjectPath(newPath.ToPathArray()), simulationSettings))
+         if (!validateAndWarnNewPath(newPath.ToObjectPath(), simulationSettings))
             return false;
 
          selection.Path = newPath;

--- a/src/MoBi.Presentation/Tasks/SimulationCommitTask.cs
+++ b/src/MoBi.Presentation/Tasks/SimulationCommitTask.cs
@@ -156,7 +156,7 @@ namespace MoBi.Presentation.Tasks
       private IEnumerable<(ObjectPath quantityPath, TQuantity quantity)> changesFrom<TQuantity>(IMoBiSimulation simulation) where TQuantity : Quantity
       {
          var quantities = _entitiesInSimulationRetriever.EntitiesFrom<TQuantity>(simulation);
-         return simulation.OriginalQuantityValues.Select(x => (objectPath: _objectPathFactory.CreateObjectPathFrom(x.Path.ToPathArray()), quantity: quantities[x.Path])).Where(x => x.quantity != null);
+         return simulation.OriginalQuantityValues.Select(x => (objectPath: x.Path.ToObjectPath(), quantity: quantities[x.Path])).Where(x => x.quantity != null);
       }
 
       private IEnumerable<IMoBiCommand> createAddBuildingBlockCommands<TBuildingBlock, TPathAndValueEntity>(IMoBiSimulation simulation,

--- a/src/MoBi.Presentation/Views/IEditOutputSelectionsView.cs
+++ b/src/MoBi.Presentation/Views/IEditOutputSelectionsView.cs
@@ -1,0 +1,12 @@
+﻿using OSPSuite.Core.Domain;
+using System.Collections.Generic;
+using MoBi.Presentation.Presenter;
+using OSPSuite.Presentation.Views;
+
+namespace MoBi.Presentation.Views
+{
+   public interface IEditOutputSelectionsView : IView<IEditOutputSelectionsPresenter>
+   {
+      void BindTo(IEnumerable<QuantitySelection> allOutputs);
+   }
+}

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.259" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/Views/EditOutputSelectionsView.Designer.cs
+++ b/src/MoBi.UI/Views/EditOutputSelectionsView.Designer.cs
@@ -1,0 +1,127 @@
+﻿using OSPSuite.UI.Controls;
+
+namespace MoBi.UI.Views
+{
+   partial class EditOutputSelectionsView
+   {
+      /// <summary> 
+      /// Required designer variable.
+      /// </summary>
+      private System.ComponentModel.IContainer components = null;
+
+      /// <summary> 
+      /// Clean up any resources being used.
+      /// </summary>
+      /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+      protected override void Dispose(bool disposing)
+      {
+         if (disposing && (components != null))
+         {
+            components.Dispose();
+         }
+         _gridViewBinder.Dispose();
+         base.Dispose(disposing);
+      }
+
+      #region Component Designer generated code
+
+      /// <summary> 
+      /// Required method for Designer support - do not modify 
+      /// the contents of this method with the code editor.
+      /// </summary>
+      private void InitializeComponent()
+      {
+         this.layoutControl = new UxLayoutControl();
+         this.gridControl = new UxGridControl();
+         this.gridView = new UxGridView();
+         this.layoutControlGroup1 = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.layoutControlItem1 = new DevExpress.XtraLayout.LayoutControlItem();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
+         this.layoutControl.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.gridControl)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.gridView)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup1)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).BeginInit();
+         this.SuspendLayout();
+         // 
+         // layoutControl
+         // 
+         this.layoutControl.AllowCustomization = false;
+         this.layoutControl.Controls.Add(this.gridControl);
+         this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.layoutControl.Location = new System.Drawing.Point(0, 0);
+         this.layoutControl.Name = "layoutControl";
+         this.layoutControl.Root = this.layoutControlGroup1;
+         this.layoutControl.Size = new System.Drawing.Size(424, 392);
+         this.layoutControl.TabIndex = 0;
+         this.layoutControl.Text = "layoutControl1";
+         // 
+         // gridControl
+         // 
+         this.gridControl.Location = new System.Drawing.Point(2, 2);
+         this.gridControl.MainView = this.gridView;
+         this.gridControl.Name = "gridControl";
+         this.gridControl.Size = new System.Drawing.Size(420, 388);
+         this.gridControl.TabIndex = 4;
+         this.gridControl.ViewCollection.AddRange(new DevExpress.XtraGrid.Views.Base.BaseView[] {
+            this.gridView});
+         // 
+         // gridView
+         // 
+         this.gridView.AllowsFiltering = true;
+         this.gridView.EnableColumnContextMenu = true;
+         this.gridView.GridControl = this.gridControl;
+         this.gridView.MultiSelect = false;
+         this.gridView.Name = "gridView";
+         // 
+         // layoutControlGroup1
+         // 
+         this.layoutControlGroup1.CustomizationFormText = "layoutControlGroup1";
+         this.layoutControlGroup1.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
+         this.layoutControlGroup1.GroupBordersVisible = false;
+         this.layoutControlGroup1.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutControlItem1});
+         this.layoutControlGroup1.Location = new System.Drawing.Point(0, 0);
+         this.layoutControlGroup1.Name = "layoutControlGroup1";
+         this.layoutControlGroup1.Padding = new DevExpress.XtraLayout.Utils.Padding(0, 0, 0, 0);
+         this.layoutControlGroup1.Size = new System.Drawing.Size(424, 392);
+         this.layoutControlGroup1.TextVisible = false;
+         // 
+         // layoutControlItem1
+         // 
+         this.layoutControlItem1.Control = this.gridControl;
+         this.layoutControlItem1.CustomizationFormText = "layoutControlItem1";
+         this.layoutControlItem1.Location = new System.Drawing.Point(0, 0);
+         this.layoutControlItem1.Name = "layoutControlItem1";
+         this.layoutControlItem1.Size = new System.Drawing.Size(424, 392);
+         this.layoutControlItem1.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutControlItem1.TextVisible = false;
+         // 
+         // EditOutputSelectionsView
+         // 
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.Controls.Add(this.layoutControl);
+         this.Name = "EditOutputSelectionsView";
+         this.Size = new System.Drawing.Size(424, 392);
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
+         this.layoutControl.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.gridControl)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.gridView)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup1)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).EndInit();
+         this.ResumeLayout(false);
+
+      }
+
+      #endregion
+
+      private UxLayoutControl layoutControl;
+      private UxGridControl gridControl;
+      private UxGridView gridView;
+      private DevExpress.XtraLayout.LayoutControlGroup layoutControlGroup1;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlItem1;
+   }
+}

--- a/src/MoBi.UI/Views/EditOutputSelectionsView.cs
+++ b/src/MoBi.UI/Views/EditOutputSelectionsView.cs
@@ -1,0 +1,86 @@
+﻿using DevExpress.XtraEditors.Controls;
+using DevExpress.XtraEditors.Repository;
+using OSPSuite.Core.Domain;
+using OSPSuite.DataBinding.DevExpress.XtraGrid;
+using OSPSuite.UI.Controls;
+using OSPSuite.Utility.Exceptions;
+using System.Collections.Generic;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+using OSPSuite.Assets;
+using OSPSuite.DataBinding.DevExpress;
+using static OSPSuite.UI.UIConstants;
+using DevExpress.XtraGrid.Views.Base;
+using OSPSuite.DataBinding;
+using static OSPSuite.UI.UIConstants.Size;
+
+namespace MoBi.UI.Views
+{
+   public partial class EditOutputSelectionsView : BaseUserControl, IEditOutputSelectionsView
+   {
+      private readonly GridViewBinder<QuantitySelection> _gridViewBinder;
+      private readonly RepositoryItemButtonEdit _buttonRepository = new UxAddRemoveAndEditButtonRepository();
+      private IEditOutputSelectionsPresenter _presenter;
+
+      public EditOutputSelectionsView()
+      {
+         InitializeComponent();
+         _gridViewBinder = new GridViewBinder<QuantitySelection>(gridView);
+         gridView.AllowsFiltering = false;
+      }
+
+      public void AttachPresenter(IEditOutputSelectionsPresenter presenter)
+      {
+         _presenter = presenter;
+      }
+
+      public override void InitializeBinding()
+      {
+         _gridViewBinder.Bind(x => x.Path).WithOnValueUpdating((o,e) => OnEvent(() => updateOutputSelectionPath(e)));
+
+         _gridViewBinder.AddUnboundColumn()
+            .WithCaption(EMPTY_COLUMN)
+            .WithShowButton(ShowButtonModeEnum.ShowAlways)
+            .WithRepository(x => _buttonRepository)
+            .WithFixedWidth(EMBEDDED_BUTTON_WIDTH * 3);
+
+         _buttonRepository.ButtonClick += (o, e) => OnEvent(() => onButtonClick(e));
+      }
+
+      private void updateOutputSelectionPath(PropertyValueSetEventArgs<string> e)
+      {
+         _presenter.UpdateOutputSelection(_gridViewBinder.FocusedElement, e.NewValue);
+         _gridViewBinder.Rebind();
+      }
+
+      private void onButtonClick(ButtonPressedEventArgs eventArgs)
+      {
+         switch (eventArgs.Button.Kind)
+         {
+            case ButtonPredefines.Delete:
+               _presenter.RemoveOutputSelection(_gridViewBinder.FocusedElement);
+               break;
+            case ButtonPredefines.Plus:
+               _presenter.AddOutputSelection(_gridViewBinder.FocusedElement);
+               break;
+            case ButtonPredefines.Ellipsis:
+               _presenter.EditOutputSelection(_gridViewBinder.FocusedElement);
+               break;
+            default:
+               throw new OSPSuiteException("No action associated with that button type");
+         }
+         _gridViewBinder.Rebind();
+      }
+
+      public void BindTo(IEnumerable<QuantitySelection> allOutputs)
+      {
+         _gridViewBinder.BindToSource(allOutputs);
+      }
+
+      public override void InitializeResources()
+      {
+         base.InitializeResources();
+         Caption = Captions.OutputSelections;
+      }
+   }
+}

--- a/src/MoBi.UI/Views/HierarchicalStructureView.cs
+++ b/src/MoBi.UI/Views/HierarchicalStructureView.cs
@@ -51,8 +51,13 @@ namespace MoBi.UI.Views
          if (hitInfo.Node != null)
          {
             var treeNode = treeView.NodeFrom(hitInfo.Node);
-            OnEvent(() => _presenter.Select(treeNode.TagAsObject as ObjectBaseDTO));
+            OnEvent(() => selectionChanged(treeNode));
          }
+      }
+
+      private void selectionChanged(ITreeNode treeNode)
+      {
+         _presenter.Select(treeNode.TagAsObject as ObjectBaseDTO);
       }
 
       public void Refresh(ObjectBaseDTO objectToRefresh)
@@ -111,8 +116,10 @@ namespace MoBi.UI.Views
       public void Select(IWithId withId)
       {
          var nodeById = treeView.NodeById(withId.Id);
-         if (nodeById == null) return;
+         if (nodeById == null) 
+            return;
          treeView.SelectNode(nodeById);
+         selectionChanged(nodeById);
       }
 
       public void Clear()

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.259" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.257" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.259" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-nubVh" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.257" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.255" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-nubVh" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/Core/Service/OutputSelectionsTaskSpecs.cs
+++ b/tests/MoBi.Tests/Core/Service/OutputSelectionsTaskSpecs.cs
@@ -1,0 +1,398 @@
+﻿using System.Linq;
+using FakeItEasy;
+using MoBi.Presentation;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Tasks;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Commands;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Repositories;
+using OSPSuite.Core.Services;
+
+namespace MoBi.Core.Service
+{
+   public class concern_for_OutputSelectionsTask : ContextSpecification<OutputSelectionsTask>
+   {
+      protected IOSPSuiteExecutionContext _context;
+      protected ISimulationRepository _simulationRepository;
+      protected IMoBiApplicationController _applicationController;
+      protected IHierarchicalQuantitySelectionPresenter _quantitySelectionPresenter;
+      protected IModalPresenter _modalPresenter;
+      protected SimulationSettings _simulationSettings;
+      protected IDialogCreator _dialogCreator;
+
+      protected override void Context()
+      {
+         _context = A.Fake<IOSPSuiteExecutionContext>();
+         _dialogCreator = A.Fake<IDialogCreator>();
+         _applicationController = A.Fake<IMoBiApplicationController>();
+         _simulationRepository = A.Fake<ISimulationRepository>();
+         _modalPresenter = A.Fake<IModalPresenter>();
+         _quantitySelectionPresenter = A.Fake<IHierarchicalQuantitySelectionPresenter>();
+         _simulationSettings = new SimulationSettings();
+
+         sut = new OutputSelectionsTask(_context, _applicationController, _simulationRepository, _dialogCreator);
+
+         A.CallTo(() => _applicationController.Start<IModalPresenter>()).Returns(_modalPresenter);
+         A.CallTo(() => _applicationController.Start<IHierarchicalQuantitySelectionPresenter>()).Returns(_quantitySelectionPresenter);
+
+         SetupFakePresenterResponses();
+      }
+
+      protected virtual void SetupFakePresenterResponses()
+      {
+         A.CallTo(() => _modalPresenter.Show()).Returns(true);
+         A.CallTo(() => _quantitySelectionPresenter.SelectedPath).Returns(new ObjectPath("another|path"));
+      }
+   }
+
+   public class When_removing_an_output_selection_from_a_simulation_settings : concern_for_OutputSelectionsTask
+   {
+      private QuantitySelection _selection;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _selection = new QuantitySelection("test", QuantityType.Undefined);
+      }
+
+      protected override void Because()
+      {
+         sut.RemoveOutputSelection(_simulationSettings, _selection);
+      }
+
+      [Observation]
+      public void should_remove_the_selection_from_the_simulation_settings()
+      {
+         _simulationSettings.OutputSelections.AllOutputs.ShouldNotContain(_selection);
+      }
+
+      [Observation]
+      public void should_indicate_that_the_project_has_changed()
+      {
+         _context.Project.HasChanged.ShouldBeTrue();
+      }
+   }
+
+   public class When_canceling_the_edit_dialog_when_editing_a_output_selection : concern_for_OutputSelectionsTask
+   {
+      private QuantitySelection _selection;
+
+      protected override void Context()
+      {
+         base.Context();
+         _selection = new QuantitySelection("test", QuantityType.Undefined);
+         _simulationSettings.OutputSelections.AddOutput(_selection);
+      }
+
+      protected override void SetupFakePresenterResponses()
+      {
+         A.CallTo(() => _modalPresenter.Show()).Returns(false);
+      }
+
+      protected override void Because()
+      {
+         sut.EditOutputSelection(_simulationSettings, _selection);
+      }
+
+      [Observation]
+      public void should_not_update_the_selection_in_the_simulation_settings()
+      {
+         _selection.Path.ShouldBeEqualTo("test");
+      }
+
+      [Observation]
+      public void should_indicate_that_the_project_has_not_changed()
+      {
+         _context.Project.HasChanged.ShouldBeFalse();
+      }
+   }
+
+   public class When_canceling_the_edit_portion_of_adding_a_new_output_selection : concern_for_OutputSelectionsTask
+   {
+      protected override void SetupFakePresenterResponses()
+      {
+         A.CallTo(() => _modalPresenter.Show()).Returns(false);
+      }
+
+      protected override void Because()
+      {
+         sut.AddOutputSelection(_simulationSettings, null);
+      }
+
+      [Observation]
+      public void should_not_add_a_new_selection_to_the_simulation_settings()
+      {
+         _simulationSettings.OutputSelections.AllOutputs.Count().ShouldBeEqualTo(0);
+      }
+
+      [Observation]
+      public void should_indicate_that_the_project_has_not_changed()
+      {
+         _context.Project.HasChanged.ShouldBeFalse();
+      }
+   }
+
+   public class When_adding_an_output_selection_to_a_simulation_settings_and_the_path_already_exists_in_the_output_selections : concern_for_OutputSelectionsTask
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _simulationSettings.OutputSelections.AddOutput(new QuantitySelection("another|path", QuantityType.Undefined));
+      }
+
+      protected override void Because()
+      {
+         sut.AddOutputSelection(_simulationSettings);
+      }
+
+      [Observation]
+      public void the_user_should_be_warned()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>._)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_not_add_a_new_selection_to_the_simulation_settings()
+      {
+         _simulationSettings.OutputSelections.AllOutputs.Count().ShouldBeEqualTo(1);
+      }
+
+      [Observation]
+      public void should_indicate_that_the_project_has_not_changed()
+      {
+         _context.Project.HasChanged.ShouldBeFalse();
+      }
+   }
+
+   public class When_adding_an_output_selection_to_a_simulation_settings : concern_for_OutputSelectionsTask
+   {
+      protected override void Because()
+      {
+         sut.AddOutputSelection(_simulationSettings);
+      }
+
+      [Observation]
+      public void should_add_a_new_selection_to_the_simulation_settings()
+      {
+         _simulationSettings.OutputSelections.AllOutputs.Count().ShouldBeEqualTo(1);
+      }
+
+      [Observation]
+      public void should_indicate_that_the_project_has_changed()
+      {
+         _context.Project.HasChanged.ShouldBeTrue();
+      }
+   }
+
+   public class When_editing_an_output_selection_with_tree_browser_in_a_simulation_settings_and_the_path_is_already_selected : concern_for_OutputSelectionsTask
+   {
+      private QuantitySelection _selection;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _selection = new QuantitySelection("test", QuantityType.Undefined);
+         _simulationSettings.OutputSelections.AddOutput(_selection);
+         _simulationSettings.OutputSelections.AddOutput(new QuantitySelection("another|path", QuantityType.Undefined));
+      }
+
+      protected override void Because()
+      {
+         sut.EditOutputSelection(_simulationSettings, _selection);
+      }
+
+      [Observation]
+      public void the_user_should_be_warned()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>._)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_quantity_path_should_not_be_updated()
+      {
+         _selection.Path.ShouldBeEqualTo("test");
+      }
+
+      [Observation]
+      public void should_indicate_that_the_project_has_not_changed()
+      {
+         _context.Project.HasChanged.ShouldBeFalse();
+      }
+   }
+
+   public class When_editing_an_output_selection_with_tree_browser_in_a_simulation_settings_and_the_same_quantity_is_selected_and_not_changed : concern_for_OutputSelectionsTask
+   {
+      private QuantitySelection _selection;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _selection = new QuantitySelection("another|path", QuantityType.Undefined);
+         _simulationSettings.OutputSelections.AddOutput(_selection);
+         _simulationSettings.OutputSelections.AddOutput(new QuantitySelection("test", QuantityType.Undefined));
+      }
+
+      protected override void Because()
+      {
+         sut.EditOutputSelection(_simulationSettings, _selection);
+      }
+
+      [Observation]
+      public void the_user_should_not_be_warned()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>._)).MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void the_quantity_path_should_not_be_updated()
+      {
+         _selection.Path.ShouldBeEqualTo("another|path");
+      }
+
+      [Observation]
+      public void should_indicate_that_the_project_has_not_changed()
+      {
+         _context.Project.HasChanged.ShouldBeFalse();
+      }
+   }
+
+   public class When_editing_an_output_selection_with_tree_browser_in_a_simulation_settings : concern_for_OutputSelectionsTask
+   {
+      private QuantitySelection _selection;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _selection = new QuantitySelection("test", QuantityType.Undefined);
+         _simulationSettings.OutputSelections.AddOutput(_selection);
+      }
+
+      protected override void Because()
+      {
+         sut.EditOutputSelection(_simulationSettings, _selection);
+      }
+
+      [Observation]
+      public void the_quantity_path_should_be_updated()
+      {
+         _selection.Path.ShouldBeEqualTo("another|path");
+      }
+
+      [Observation]
+      public void should_indicate_that_the_project_has_changed()
+      {
+         _context.Project.HasChanged.ShouldBeTrue();
+      }
+   }
+
+   public class When_editing_an_output_selection_string_path_in_a_simulation_settings_where_there_is_no_change_made_to_the_path : concern_for_OutputSelectionsTask
+   {
+      private QuantitySelection _selection;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _selection = new QuantitySelection("test", QuantityType.Undefined);
+         _simulationSettings.OutputSelections.AddOutput(_selection);
+         _simulationSettings.OutputSelections.AddOutput(new QuantitySelection("another|path", QuantityType.Undefined));
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateOutputSelection(_simulationSettings, _selection, "test");
+      }
+
+      [Observation]
+      public void the_user_should_not_be_warned()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>._)).MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void the_quantity_path_should_not_be_updated()
+      {
+         _selection.Path.ShouldBeEqualTo("test");
+      }
+
+      [Observation]
+      public void should_indicate_that_the_project_has_not_changed()
+      {
+         _context.Project.HasChanged.ShouldBeFalse();
+      }
+   }
+
+   public class When_editing_an_output_selection_string_path_in_a_simulation_settings_where_there_is_a_duplicate_output_already_selected : concern_for_OutputSelectionsTask
+   {
+      private QuantitySelection _selection;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _selection = new QuantitySelection("test", QuantityType.Undefined);
+         _simulationSettings.OutputSelections.AddOutput(_selection);
+         _simulationSettings.OutputSelections.AddOutput(new QuantitySelection("another|path", QuantityType.Undefined));
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateOutputSelection(_simulationSettings, _selection, "another|path");
+      }
+
+      [Observation]
+      public void the_user_should_be_warned()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>._)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_quantity_path_should_not_be_updated()
+      {
+         _selection.Path.ShouldBeEqualTo("test");
+      }
+
+      [Observation]
+      public void should_indicate_that_the_project_has_not_changed()
+      {
+         _context.Project.HasChanged.ShouldBeFalse();
+      }
+   }
+
+   public class When_editing_an_output_selection_string_path_in_a_simulation_settings : concern_for_OutputSelectionsTask
+   {
+      private QuantitySelection _selection;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _selection = new QuantitySelection("test", QuantityType.Undefined);
+         _simulationSettings.OutputSelections.AddOutput(_selection);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateOutputSelection(_simulationSettings, _selection, "another|path");
+      }
+
+      [Observation]
+      public void the_quantity_path_should_be_updated()
+      {
+         _selection.Path.ShouldBeEqualTo("another|path");
+      }
+
+      [Observation]
+      public void should_indicate_that_the_project_has_changed()
+      {
+         _context.Project.HasChanged.ShouldBeTrue();
+      }
+   }
+}

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.257" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-nubVh" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.259" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/EditOutputSelectionsPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditOutputSelectionsPresenterSpecs.cs
@@ -1,0 +1,145 @@
+﻿using FakeItEasy;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Tasks;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+
+namespace MoBi.Presentation
+{
+   public class concern_for_EditOutputSelectionsPresenter : ContextSpecification<EditOutputSelectionsPresenter>
+   {
+      protected IEditOutputSelectionsView _view;
+      protected IOutputSelectionsTask _outputSelectionsTask;
+
+      protected override void Context()
+      {
+         _view = A.Fake<IEditOutputSelectionsView>();
+         _outputSelectionsTask = A.Fake<IOutputSelectionsTask>();
+         sut = new EditOutputSelectionsPresenter(_view, _outputSelectionsTask);
+      }
+   }
+
+   public class When_editing_output_selections : concern_for_EditOutputSelectionsPresenter
+   {
+      private SimulationSettings _simulationSettings;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulationSettings = new SimulationSettings();
+      }
+
+      protected override void Because()
+      {
+         sut.Edit(_simulationSettings);
+      }
+
+      [Observation]
+      public void should_bind_to_output_selections()
+      {
+         A.CallTo(() => _view.BindTo(_simulationSettings.OutputSelections.AllOutputs)).MustHaveHappened();
+      }
+   }
+
+   public class When_editing_output_selections_with_new_path_and_selection : concern_for_EditOutputSelectionsPresenter
+   {
+      private SimulationSettings _simulationSettings;
+      private QuantitySelection _selection;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulationSettings = new SimulationSettings();
+         _selection = new QuantitySelection("path", QuantityType.Undefined);
+         sut.Edit(_simulationSettings);
+      }
+
+      protected override void Because()
+      {
+         sut.EditOutputSelection(_selection);
+      }
+
+      [Observation]
+      public void should_edit_output_selection()
+      {
+         A.CallTo(() => _outputSelectionsTask.EditOutputSelection(_simulationSettings, _selection)).MustHaveHappened();
+      }
+   }
+
+   public class When_editing_output_selections_with_new_path : concern_for_EditOutputSelectionsPresenter
+   {
+      private SimulationSettings _simulationSettings;
+      private QuantitySelection _selection;
+      private string _newPath;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulationSettings = new SimulationSettings();
+         _selection = new QuantitySelection("path", QuantityType.Undefined);
+         _newPath = "newPath";
+         sut.Edit(_simulationSettings);
+      }
+
+      protected override void Because()
+      {
+         sut.UpdateOutputSelection(_selection, _newPath);
+      }
+
+      [Observation]
+      public void should_edit_output_selection()
+      {
+         A.CallTo(() => _outputSelectionsTask.UpdateOutputSelection(_simulationSettings, _selection, _newPath)).MustHaveHappened();
+      }
+   }
+
+   public class When_adding_output_selections_to_simulation_settings : concern_for_EditOutputSelectionsPresenter
+   {
+      private SimulationSettings _simulationSettings;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulationSettings = new SimulationSettings();
+         sut.Edit(_simulationSettings);
+      }
+
+      protected override void Because()
+      {
+         sut.AddOutputSelection(null);
+      }
+
+      [Observation]
+      public void should_add_output_selection_to_simulation_settings()
+      {
+         A.CallTo(() => _outputSelectionsTask.AddOutputSelection(_simulationSettings, null)).MustHaveHappened();
+      }
+   }
+
+   public class When_removing_output_selections_from_simulation_settings : concern_for_EditOutputSelectionsPresenter
+   {
+      private SimulationSettings _simulationSettings;
+      private QuantitySelection _selection;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulationSettings = new SimulationSettings();
+         _selection = new QuantitySelection("path", QuantityType.Undefined);
+         sut.Edit(_simulationSettings);
+      }
+
+      protected override void Because()
+      {
+         sut.RemoveOutputSelection(_selection);
+      }
+
+      [Observation]
+      public void should_remove_output_selection_from_simulation_settings()
+      {
+         A.CallTo(() => _outputSelectionsTask.RemoveOutputSelection(_simulationSettings, _selection)).MustHaveHappened();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/HierarchicalQuantitySelectionPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/HierarchicalQuantitySelectionPresenterSpecs.cs
@@ -1,0 +1,159 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using ISimulationPersistableUpdater = MoBi.Core.Services.ISimulationPersistableUpdater;
+
+namespace MoBi.Presentation
+{
+   public class concern_for_HierarchicalQuantitySelectionPresenter : ContextSpecification<HierarchicalQuantitySelectionPresenter>
+   {
+      protected IHierarchicalStructureView _view;
+      protected ISimulationPersistableUpdater _simulationPersistableUpdater;
+      protected IEntityPathResolver _entityPathResolver;
+      protected IObjectBaseToObjectBaseDTOMapper _objectBaseMapper;
+      protected IMoBiContext _context;
+      private IViewItemContextMenuFactory _contextMenuFactory;
+
+      protected override void Context()
+      {
+         _context = A.Fake<IMoBiContext>();
+         _objectBaseMapper = A.Fake<IObjectBaseToObjectBaseDTOMapper>();
+         _simulationPersistableUpdater = A.Fake<ISimulationPersistableUpdater>();
+         _entityPathResolver = A.Fake<IEntityPathResolver>();
+         _view = A.Fake<IHierarchicalStructureView>();
+         _contextMenuFactory = A.Fake<IViewItemContextMenuFactory>();
+         sut = new HierarchicalQuantitySelectionPresenter(_view, _context, _objectBaseMapper, _simulationPersistableUpdater, _entityPathResolver, _contextMenuFactory);
+      }
+   }
+
+   public class When_getting_child_objects_of_a_simulation : concern_for_HierarchicalQuantitySelectionPresenter
+   {
+      private ObjectBaseDTO _dto;
+      private IQuantity _quantity;
+
+      protected override void Context()
+      {
+         base.Context();
+         var moBiSimulation = new MoBiSimulation
+         {
+            Model = new Model
+            {
+               Root = new Container()
+            }
+         };
+
+         _dto = new ObjectBaseDTO(moBiSimulation);
+         _quantity = new Observer();
+         moBiSimulation.Model.Root.Add(_quantity);
+      }
+
+      protected override void Because()
+      {
+         sut.GetChildObjects(_dto, x => true);
+      }
+
+      [Observation]
+      public void the_simulation_persistable_updater_tests_if_entities_are_selectable()
+      {
+         A.CallTo(() => _simulationPersistableUpdater.QuantityIsSelectable(_quantity, true)).MustHaveHappened();
+      }
+   }
+
+   public class When_selecting_paths_from_simulations : concern_for_HierarchicalQuantitySelectionPresenter
+   {
+      private IReadOnlyList<ISimulation> _simulations;
+      private ISimulation _simulation1;
+      private ISimulation _simulation2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation1 = new MoBiSimulation();
+         _simulation2 = new MoBiSimulation();
+         _simulations = new List<ISimulation> { _simulation1, _simulation2 };
+
+         A.CallTo(() => _objectBaseMapper.MapFrom(_simulation1)).Returns(new ObjectBaseDTO(_simulation1));
+         A.CallTo(() => _objectBaseMapper.MapFrom(_simulation2)).Returns(new ObjectBaseDTO(_simulation2));
+      }
+
+      protected override void Because()
+      {
+         sut.SelectPathFrom(_simulations);
+      }
+
+      [Observation]
+      public void should_show_simulations()
+      {
+         A.CallTo(() => _view.Show(A<IReadOnlyList<ObjectBaseDTO>>.That.Matches(x => hasAllSimulations(x)))).MustHaveHappened();
+      }
+
+      private bool hasAllSimulations(IReadOnlyList<ObjectBaseDTO> objectBaseDTOs)
+      {
+         return objectBaseDTOs.Count == 2 && objectBaseDTOs.Any(x => Equals(x.ObjectBase, _simulation1)) && objectBaseDTOs.Any(x => Equals(x.ObjectBase, _simulation2));
+      }
+   }
+
+   public class When_pre_selecting_an_entity_by_path : concern_for_HierarchicalQuantitySelectionPresenter
+   {
+      private Observer _quantity;
+
+      protected override void Context()
+      {
+         base.Context();
+         base.Context();
+         var organismContainer = new Container();
+         var moBiSimulation = new MoBiSimulation
+         {
+            Model = new Model
+            {
+               Root = new Container
+               {
+                  organismContainer.WithName("Organism")
+               }.WithName("Simulation")
+            }
+         };
+
+         A.CallTo(() => _objectBaseMapper.MapFrom(moBiSimulation)).Returns(new ObjectBaseDTO(moBiSimulation));
+
+         _quantity = new Observer().WithName("Observer");
+         organismContainer.Add(_quantity);
+         sut.SelectPathFrom(new[] { moBiSimulation });
+
+         A.CallTo(() => _simulationPersistableUpdater.QuantityIsSelectable(_quantity, true)).Returns(true);
+         A.CallTo(() => _view.Select(_quantity)).Invokes(x => sut.Select(new ObjectBaseDTO(x.Arguments.Get<IWithId>(0) as IObjectBase)));
+      }
+
+      protected override void Because()
+      {
+         sut.SelectQuantityFromPath(new ObjectPath("Organism", "Observer"));
+      }
+
+      [Observation]
+      public void the_presenter_should_be_able_to_close_with_selection()
+      {
+         sut.CanClose.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void the_selected_path_of_the_presenter_is_set()
+      {
+         sut.SelectedPath.Equals(new ObjectPath("Organism", "Observer"));
+      }
+
+      [Observation]
+      public void the_view_should_select_the_entity()
+      {
+         A.CallTo(() => _view.Select(_quantity)).MustHaveHappened();
+      }
+   }
+}

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.257" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.257" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.257" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.259" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.259" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.255" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.255" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-nubVh" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-nubVh" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1163 

# Description
Allow users to edit/add/remove selections from the default project settings. In v11 you added/removed/updated these settings by committing from a simulation. We'll add that in #1206. 

This allows users to directly edit the paths in their default simulation settings using a tree browser, or by hand editing the path.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

In the simulation settings / output selections tab this grid view has new buttons added to each row
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/acc20559-3008-4e54-87e4-4e591f15f9eb)

- You can type in the path column to make changes
- If I want to remove, that is straightforward the row disappears.

- If I edit a row, or I use the +button in a specific row, the tree selection appears with all simulations from the project. For paths that can be resolved in any simulation, the focused element will be pre-selected.

![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/3a9a21b7-d99a-43d4-91ab-6cfd2ca1b74c)

- Non-quantity selections prevent user from clicking 'OK'
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/839d9b5d-998e-4863-8f15-5af854adff9a)

- Trying to duplicate a selection, either through adding or editing, a dialog informs the user and prevents the output being added or updated.
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/20845126-59c6-48cb-9ccb-691de62cda7c)




# Questions (if appropriate):