### PR TITLE
Fixes #1271 layout not working in simulation diagram view

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.262" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.262" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.262" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.265" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.262" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.265" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.262" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/BaseDiagram/MoBiBaseDiagramPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/BaseDiagram/MoBiBaseDiagramPresenter.cs
@@ -19,6 +19,7 @@ using OSPSuite.Presentation.Views;
 using OSPSuite.Utility.Container;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
+using IContainer = OSPSuite.Core.Domain.IContainer;
 
 namespace MoBi.Presentation.Presenter.BaseDiagram
 {
@@ -190,6 +191,16 @@ namespace MoBi.Presentation.Presenter.BaseDiagram
          finally
          {
             _view.EndUpdate();
+         }
+      }
+
+      protected void ApplyLayoutFromTemplate(string templateFile)
+      {
+         foreach (var topContainerNode in DiagramModel.GetDirectChildren<IContainerNode>())
+         {
+            var topContainer = _context.Get<IContainer>(topContainerNode.Id);
+            if (topContainer != null && topContainer.ContainerType == ContainerType.Organism)
+               ApplyLayoutTemplate(topContainerNode, templateFile, false);
          }
       }
 

--- a/src/MoBi.Presentation/Presenter/SpaceDiagram/SpatialStructureDiagramPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SpaceDiagram/SpatialStructureDiagramPresenter.cs
@@ -61,27 +61,17 @@ namespace MoBi.Presentation.Presenter.SpaceDiagram
 
          if (!DiagramModel.IsLayouted)
          {
-            applyLayoutFromTemplate();
+            var organismTemplateFile = _configuration.SpaceOrganismBaseTemplate;
+            if (File.Exists(_configuration.SpaceOrganismUserTemplate))
+               organismTemplateFile = _configuration.SpaceOrganismUserTemplate;
+
+            ApplyLayoutFromTemplate(organismTemplateFile);
          }
 
          Refresh();
 
          //to avoid scrollbar error
          ResetViewSize();
-      }
-
-      private void applyLayoutFromTemplate()
-      {
-         string organismTemplateFile = _configuration.SpaceOrganismBaseTemplate;
-         if (File.Exists(_configuration.SpaceOrganismUserTemplate))
-            organismTemplateFile = _configuration.SpaceOrganismUserTemplate;
-
-         foreach (var topContainerNode in DiagramModel.GetDirectChildren<IContainerNode>())
-         {
-            var topContainer = _context.Get<IContainer>(topContainerNode.Id);
-            if (topContainer != null && topContainer.ContainerType == ContainerType.Organism)
-               ApplyLayoutTemplate(topContainerNode, organismTemplateFile, false);
-         }
       }
 
       private IContainer firstTopContainerWithNode(MoBiSpatialStructure spatialStructure)

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.262" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.262" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.262" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.265" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/IntegrationTests/ContextForIntegration.cs
+++ b/tests/MoBi.Tests/IntegrationTests/ContextForIntegration.cs
@@ -79,6 +79,7 @@ namespace MoBi.IntegrationTests
             container.RegisterImplementationOf(A.Fake<IContainerBaseLayouter>());
             container.RegisterImplementationOf(A.Fake<ILayerLayouter>());
             container.RegisterImplementationOf(A.Fake<IEntityValidationTask>());
+            container.RegisterImplementationOf(A.Fake<IDiagramLayoutTask>());
 
             container.Register<IDiagramModelToXmlMapper, DiagramModelToXmlMapperForSpecs>();
             container.Register<IMoBiConfiguration, MoBiConfiguration>(LifeStyle.Singleton);

--- a/tests/MoBi.Tests/IntegrationTests/CoreRegisterSpecs.cs
+++ b/tests/MoBi.Tests/IntegrationTests/CoreRegisterSpecs.cs
@@ -19,12 +19,12 @@ namespace MoBi.IntegrationTests
       public void should_be_able_to_find_a_diff_builder_for_a_simulation()
       {
          var diffBuilderRepository = IoC.Resolve<IDiffBuilderRepository>();
-         var simuationDiffBuilder = diffBuilderRepository.BuilderFor(new MoBiSimulation());
-         simuationDiffBuilder.ShouldBeAnInstanceOf<MoBiSimulationDiffBuilder>();
+         var simulationDiffBuilder = diffBuilderRepository.BuilderFor(new MoBiSimulation());
+         simulationDiffBuilder.ShouldBeAnInstanceOf<MoBiSimulationDiffBuilder>();
       }
 
       [Observation]
-      public void should_be_able_to_find_a_base_presenter_for_a_simulation_diamgram_manager()
+      public void should_be_able_to_find_a_base_presenter_for_a_simulation_diagram_manager()
       {
          var presenter = IoC.Resolve<IBaseDiagramPresenter<IMoBiSimulation>>();
          presenter.ShouldNotBeNull();

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.262" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.265" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.262" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.262" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.265" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1271

# Description
Removed the diagram copy strategy where a simulation diagram layout was copied from the building block diagrams. That's because there are multiple spatial structures and reaction building blocks that had to be considered as templates. In the end, there's not a good way to apply varying diagram layouts to the simulation. Instead, the simulation is laid out from default templates.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):