### PR TITLE
Fixes #1285 Neighborhoods are not exported for compartments

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.Core/Domain/Model/MoBiSpatialStructure.cs
+++ b/src/MoBi.Core/Domain/Model/MoBiSpatialStructure.cs
@@ -28,8 +28,7 @@ namespace MoBi.Core.Domain.Model
             if (parentContainer?.ParentPath == null)
                return absolutePath;
 
-            absolutePath.AddAtFront(parentContainer.ParentPath);
-            return absolutePath;
+            return absolutePath.AndAddAtFront(parentContainer.ParentPath);
          }
 
          //Returns all possible physical containers that can be taken into consideration

--- a/src/MoBi.Core/Domain/Model/MoBiSpatialStructure.cs
+++ b/src/MoBi.Core/Domain/Model/MoBiSpatialStructure.cs
@@ -28,7 +28,8 @@ namespace MoBi.Core.Domain.Model
             if (parentContainer?.ParentPath == null)
                return absolutePath;
 
-            return absolutePath.AndAddAtFront(parentContainer.ParentPath);
+            absolutePath.AddAtFront(parentContainer.ParentPath);
+            return absolutePath;
          }
 
          //Returns all possible physical containers that can be taken into consideration

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.274" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.274" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.265" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.274" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/Core/Mapper/ParameterListToSimulationParameterDataTableMapperSpecs.cs
+++ b/tests/MoBi.Tests/Core/Mapper/ParameterListToSimulationParameterDataTableMapperSpecs.cs
@@ -15,7 +15,7 @@ namespace MoBi.Core.Mapper
 {
    public abstract class concern_for_ParameterListToSimulationParameterDataTableMapper : ContextSpecification<ParameterListToSimulationParameterDataTableMapper>
    {
-      protected IMoBiSimulation _simultion;
+      protected IMoBiSimulation _simulation;
       protected DataTable _result;
 
       protected override void Context()
@@ -25,12 +25,12 @@ namespace MoBi.Core.Mapper
                new ObjectPathFactory(
                   new AliasCreator())));
 
-         _simultion = A.Fake<IMoBiSimulation>();
+         _simulation = A.Fake<IMoBiSimulation>();
       }
 
       protected override void Because()
       {
-         _result = sut.MapFrom(_simultion.Model.Root.GetAllChildren<IParameter>());
+         _result = sut.MapFrom(_simulation.Model.Root.GetAllChildren<IParameter>());
       }
    }
 
@@ -39,7 +39,7 @@ namespace MoBi.Core.Mapper
       protected override void Context()
       {
          base.Context();
-         A.CallTo(() => _simultion.Model.Root.GetAllChildren<IParameter>()).Returns(generateParameters());
+         A.CallTo(() => _simulation.Model.Root.GetAllChildren<IParameter>()).Returns(generateParameters());
       }
 
       [Observation]
@@ -76,7 +76,7 @@ namespace MoBi.Core.Mapper
                DisplayUnit = DimensionFactoryForSpecs.Factory.Dimension(DimensionFactoryForSpecs.DimensionNames.Mass).DefaultUnit,
                Description = "description"
             },
-            new Parameter()
+            new Parameter().WithName("aParameter")
          };
       }
    }

--- a/tests/MoBi.Tests/Core/MoBiSpatialStructureSpecs.cs
+++ b/tests/MoBi.Tests/Core/MoBiSpatialStructureSpecs.cs
@@ -113,20 +113,18 @@ namespace MoBi.Core
       private IObjectPathFactory _objectPathFactory;
       private IReadOnlyList<NeighborhoodBuilder> _result;
       private NeighborhoodBuilder _neighborhood;
-      private Container _subContainer;
 
       protected override void Context()
       {
          base.Context();
          _objectPathFactory = new ObjectPathFactoryForSpecs();
-         _container = new Container().WithName("Muscle").WithMode(ContainerMode.Logical);
-         _subContainer = new Container().WithName("Interstitial").WithMode(ContainerMode.Physical).Under(_container);
-         _container.ParentPath = new ObjectPath("Organism");
+         _container = new Container().WithName("Interstitial").WithMode(ContainerMode.Physical);
+         _container.ParentPath = new ObjectPath("Organism", "Bone");
 
          _neighborhood = new NeighborhoodBuilder
          {
             //mae the neighborhood reference a sub container instead of the root container
-            FirstNeighborPath = _objectPathFactory.CreateAbsoluteObjectPath(_subContainer).AndAddAtFront("Organism"),
+            FirstNeighborPath = _objectPathFactory.CreateAbsoluteObjectPath(_container).AndAddAtFront("Bone").AndAddAtFront("Organism"),
             SecondNeighborPath = new ObjectPath("A", "PATH"),
             Name = "_neighborhoodBetweenCont2AndUnknown"
          };

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.274" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/ObjectPathCreatorSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ObjectPathCreatorSpecs.cs
@@ -1,4 +1,5 @@
-﻿using FakeItEasy;
+﻿using DevExpress.Utils.Extensions;
+using FakeItEasy;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.UnitSystem;
 using MoBi.Presentation.DTO;
@@ -137,7 +138,7 @@ namespace MoBi.Presentation
          var parentContainer = new Container().WithName(_parentName);
          rootContainer.Add(parentContainer);
          parentContainer.Add(_moleculeProperties);
-         _refObject = new Parameter();
+         _refObject = new Parameter().WithName("refObject");
          rootContainer.Add(_refObject);
       }
 

--- a/tests/MoBi.Tests/Presentation/Tasks/InitialConditionsTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InitialConditionsTaskSpecs.cs
@@ -338,7 +338,7 @@ namespace MoBi.Presentation.Tasks
       [Observation]
       public void should_not_affect_start_value_path()
       {
-         _startValue.Path.PathAsString.ShouldBeEqualTo("A|B|");
+         _startValue.Path.PathAsString.ShouldBeEqualTo("A|B");
       }
    }
 

--- a/tests/MoBi.Tests/Presentation/Tasks/ParameterValuesTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/ParameterValuesTaskSpecs.cs
@@ -246,7 +246,7 @@ namespace MoBi.Presentation.Tasks
       [Observation]
       public void should_not_affect_start_value_path()
       {
-         _startValue.Path.PathAsString.ShouldBeEqualTo("A|B|");
+         _startValue.Path.PathAsString.ShouldBeEqualTo("A|B");
       }
    }
 

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.265" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.265" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.274" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1285

# Description
We were using the wrong overload to append paths together. The extension method first converts the object path to string, then appends the whole string into one element of the object path. So, ```Bone|Intracellular``` was not two elements, but one. 

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):