### PR TITLE
Fixes #1218 "Refresh from source" for Initial Conditions

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1585,6 +1585,7 @@ namespace MoBi.Assets
          public static readonly string SelectOrganAndMolecules = "Select an organ and molecules";
          public static readonly string SelectSpatialStructure = "Select a spatial structure";
          public static readonly string ExtendDescription = "<b>The building block will be extended with new values for selected <i>molecules</i> in all physical containers in the selected <i>spatial structure</i></b>";
+         public static readonly string RefreshDescription = "<b>The building block values will be refreshed for selected <i>molecules</i> in all physical containers in the selected <i>spatial structure</i></b>";
          public static readonly string AddExpressionDescription = "<b>The building block will be extended with expression parameter values for selected <i>molecules</i> in the selected <i>organ</i> </b>";
          public static readonly string AddDefaultCurveForNewSimulations = "Add default curve for new simulations";
          public static readonly string ChangeDefaultCurveForNewSimulations = "Change default curve for new simulations";

--- a/src/MoBi.Core/Services/MoleculeResolver.cs
+++ b/src/MoBi.Core/Services/MoleculeResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
@@ -7,6 +8,7 @@ namespace MoBi.Core.Services
    public interface IMoleculeResolver
    {
       MoleculeBuilder Resolve(ObjectPath containerPath, string moleculeName, SpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock);
+      MoleculeBuilder Resolve(ObjectPath containerPath, string moleculeName, SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules);
    }
 
    public class MoleculeResolver : IMoleculeResolver
@@ -18,17 +20,14 @@ namespace MoBi.Core.Services
             .FirstOrDefault(container => container != null && (container.Mode == ContainerMode.Physical)) != null;
       }
 
-      private bool canResolveMolecule(MoleculeBuildingBlock moleculeBuildingBlock, string moleculeName)
-      {
-         return moleculeBuildingBlock[moleculeName] != null;
-      }
-
       public MoleculeBuilder Resolve(ObjectPath containerPath, string moleculeName, SpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock)
       {
-         if (!canResolveMolecule(moleculeBuildingBlock, moleculeName) || !canResolvePhysicalContainer(containerPath, spatialStructure))
-            return null;
+         return Resolve(containerPath, moleculeName, spatialStructure, moleculeBuildingBlock.ToList());
+      }
 
-         return moleculeBuildingBlock[moleculeName];
+      public MoleculeBuilder Resolve(ObjectPath containerPath, string moleculeName, SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules)
+      {
+         return !canResolvePhysicalContainer(containerPath, spatialStructure) ? null : molecules.FindByName(moleculeName);
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/ExpressionProfileInitialConditionsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ExpressionProfileInitialConditionsPresenter.cs
@@ -27,9 +27,10 @@ namespace MoBi.Presentation.Presenter
          IMoBiContext context,
          IDeleteStartValuePresenter deleteStartValuePresenter,
          IFormulaToValueFormulaDTOMapper formulaToValueFormulaDTOMapper,
-         IDimensionFactory dimensionFactory, 
+         IDimensionFactory dimensionFactory,
          IInitialConditionsDistributedInExpressionProfilePresenter distributedParameterPresenter,
-         IExpressionProfileBuildingBlockToExpressionProfileBuildingBlockDTOMapper buildingBlockMapper) : 
+         IExpressionProfileBuildingBlockToExpressionProfileBuildingBlockDTOMapper buildingBlockMapper, 
+         IRefreshInitialConditionsPresenter refreshInitialConditionsPresenter) : 
          base(view, 
             startValueMapper, 
             initialConditionsTask, 
@@ -38,6 +39,7 @@ namespace MoBi.Presentation.Presenter
             deleteStartValuePresenter, 
             formulaToValueFormulaDTOMapper, 
             dimensionFactory, 
+            refreshInitialConditionsPresenter,
             isPresentSelectionPresenter, 
             negativeStartValuesAllowedSelectionPresenter, distributedParameterPresenter)
       {
@@ -50,9 +52,6 @@ namespace MoBi.Presentation.Presenter
          DisablePathColumns();
       }
 
-      protected override IReadOnlyList<InitialConditionDTO> ValueDTOsFor(ExpressionProfileBuildingBlock buildingBlock)
-      {
-         return _buildingBlockMapper.MapFrom(buildingBlock).InitialConditionDTOs;
-      }
+      protected override IReadOnlyList<InitialConditionDTO> ValueDTOsFor(ExpressionProfileBuildingBlock buildingBlock) => _buildingBlockMapper.MapFrom(buildingBlock).InitialConditionDTOs;
    }
 }

--- a/src/MoBi.Presentation/Presenter/InitialConditionsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/InitialConditionsPresenter.cs
@@ -27,6 +27,7 @@ namespace MoBi.Presentation.Presenter
          IInitialConditionsView view,
          IInitialConditionToInitialConditionDTOMapper startValueMapper,
          IMoleculeIsPresentSelectionPresenter isPresentSelectionPresenter,
+         IRefreshInitialConditionsPresenter refreshInitialConditionsPresenter,
          IMoleculeNegativeValuesAllowedSelectionPresenter negativeStartValuesAllowedSelectionPresenter,
          IInitialConditionsTask<InitialConditionsBuildingBlock> initialConditionsTask,
          IInitialConditionsCreator msvCreator,
@@ -36,14 +37,11 @@ namespace MoBi.Presentation.Presenter
          IDimensionFactory dimensionFactory,
          IInitialConditionsDistributedPathAndValueEntityPresenter distributedParameterPresenter,
          IInitialConditionsBuildingBlockToInitialConditionsBuildingBlockDTOMapper buildingBlockMapper)
-         : base(view, startValueMapper, initialConditionsTask, msvCreator, context, deleteStartValuePresenter, formulaToValueFormulaDTOMapper, dimensionFactory, isPresentSelectionPresenter, negativeStartValuesAllowedSelectionPresenter, distributedParameterPresenter)
+         : base(view, startValueMapper, initialConditionsTask, msvCreator, context, deleteStartValuePresenter, formulaToValueFormulaDTOMapper, dimensionFactory, refreshInitialConditionsPresenter, isPresentSelectionPresenter, negativeStartValuesAllowedSelectionPresenter, distributedParameterPresenter)
       {
          _buildingBlockMapper = buildingBlockMapper;
       }
 
-      protected override IReadOnlyList<InitialConditionDTO> ValueDTOsFor(InitialConditionsBuildingBlock buildingBlock)
-      {
-         return _buildingBlockMapper.MapFrom(buildingBlock).ParameterDTOs;
-      }
+      protected override IReadOnlyList<InitialConditionDTO> ValueDTOsFor(InitialConditionsBuildingBlock buildingBlock) => _buildingBlockMapper.MapFrom(buildingBlock).ParameterDTOs;
    }
 }

--- a/src/MoBi.Presentation/Presenter/RefreshInitialConditionsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/RefreshInitialConditionsPresenter.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using MoBi.Assets;
+using MoBi.Presentation.Views;
+
+namespace MoBi.Presentation.Presenter
+{
+   public interface IRefreshInitialConditionsPresenter : IApplyToSelectionPresenter
+   {
+   }
+
+   public class RefreshInitialConditionsPresenter : ApplyToSelectionPresenter, IRefreshInitialConditionsPresenter
+   {
+      public RefreshInitialConditionsPresenter(IApplyToSelectionView view)
+         : base(view, SelectOption.RefreshAll, AppConstants.Captions.RefreshValues)
+      {
+      }
+
+      public override IEnumerable<SelectOption> AvailableSelectOptions => new[] { SelectOption.RefreshAll, SelectOption.RefreshSelected };
+   }
+}

--- a/src/MoBi.Presentation/Presenter/SelectBuildingBlocksForExtendPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectBuildingBlocksForExtendPresenter.cs
@@ -17,6 +17,7 @@ namespace MoBi.Presentation.Presenter
       IReadOnlyList<MoBiSpatialStructure> AllSpatialStructures { get; }
 
       void SelectBuildingBlocksForExtend(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure);
+      void SelectBuildingBlocksForRefresh(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure);
       SpatialStructure SelectedSpatialStructure { get; }
       IReadOnlyList<MoleculeBuilder> SelectedMolecules { get; }
    }
@@ -45,8 +46,13 @@ namespace MoBi.Presentation.Presenter
 
       private void moleculeSelectionStatusChanged(object sender, EventArgs e) => _view.MoleculeSelectionChanged();
 
-      public void SelectBuildingBlocksForExtend(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure)
+      public void SelectBuildingBlocksForRefresh(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure) => selectBuildingBlocks(defaultMolecules, defaultSpatialStructure, AppConstants.Captions.RefreshDescription);
+
+      public void SelectBuildingBlocksForExtend(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure) => selectBuildingBlocks(defaultMolecules, defaultSpatialStructure, AppConstants.Captions.ExtendDescription);
+
+      private void selectBuildingBlocks(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure, string descriptionText)
       {
+         _view.SetDescriptionText(descriptionText);
          _view.Caption = AppConstants.Captions.SelectSpatialStructureAndMolecules;
          _dto = _mapper.MapFrom(defaultSpatialStructure ?? AllSpatialStructures.FirstOrDefault());
          _selectMoleculesPresenter.SelectMolecules(defaultMolecules);

--- a/src/MoBi.Presentation/Tasks/Interaction/StartValuesTask.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/StartValuesTask.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MoBi.Assets;
@@ -282,7 +283,13 @@ namespace MoBi.Presentation.Tasks.Interaction
          return new AddBuildingBlockToModuleCommand<TBuildingBlock>(itemToAdd, parent);
       }
 
-      private (SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules) selectBuildingBlocksForExtend(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure)
+      private (SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules) selectBuildingBlocksForExtend(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure) => 
+         selectBuildingBlocks(x => x.SelectBuildingBlocksForExtend(defaultMolecules, defaultSpatialStructure));
+      
+      protected (SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules) SelectBuildingBlocksForRefresh(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure) =>
+         selectBuildingBlocks(x => x.SelectBuildingBlocksForRefresh(defaultMolecules, defaultSpatialStructure));
+
+      private (SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules) selectBuildingBlocks(Action<ISelectSpatialStructureAndMoleculesPresenter> actionToSelectBuildingBlocks)
       {
          var moleculeBlockCollection = _interactionTaskContext.BuildingBlockRepository.MoleculeBlockCollection;
          var spatialStructureCollection = _interactionTaskContext.BuildingBlockRepository.SpatialStructureCollection;
@@ -299,7 +306,7 @@ namespace MoBi.Presentation.Tasks.Interaction
 
          using (var selectorPresenter = Context.Resolve<ISelectSpatialStructureAndMoleculesPresenter>())
          {
-            selectorPresenter.SelectBuildingBlocksForExtend(defaultMolecules, defaultSpatialStructure);
+            actionToSelectBuildingBlocks(selectorPresenter);
             return (selectorPresenter.SelectedSpatialStructure, selectorPresenter.SelectedMolecules);
          }
       }

--- a/src/MoBi.Presentation/Views/IInitialConditionsView.cs
+++ b/src/MoBi.Presentation/Views/IInitialConditionsView.cs
@@ -8,6 +8,7 @@ namespace MoBi.Presentation.Views
    {
       void AddIsPresentSelectionView(IView view);
       void AddNegativeValuesAllowedSelectionView(IView view);
+      void AddRefreshSelectionView(IView view);
       void HideIsPresentColumn();
    }
 }

--- a/src/MoBi.Presentation/Views/ISelectSpatialStructureAndMoleculesView.cs
+++ b/src/MoBi.Presentation/Views/ISelectSpatialStructureAndMoleculesView.cs
@@ -9,5 +9,6 @@ namespace MoBi.Presentation.Views
       void Show(SelectSpatialStructureDTO dto);
       void AddMoleculeSelectionView(IView view);
       void MoleculeSelectionChanged();
+      void SetDescriptionText(string description);
    }
 }

--- a/src/MoBi.UI/Views/BasePathAndValueEntityView.Designer.cs
+++ b/src/MoBi.UI/Views/BasePathAndValueEntityView.Designer.cs
@@ -38,6 +38,7 @@ namespace MoBi.UI.Views
          this.gridControl = new OSPSuite.UI.Controls.UxGridControl();
          this.gridView = new MoBi.UI.Views.UxGridView();
          this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.panelRefresh = new DevExpress.XtraEditors.PanelControl();
          this.panelDeleteStartValues = new DevExpress.XtraEditors.PanelControl();
          this.panelIsPresent = new DevExpress.XtraEditors.PanelControl();
          this.panelNegativeValuesAllowed = new DevExpress.XtraEditors.PanelControl();
@@ -48,11 +49,13 @@ namespace MoBi.UI.Views
          this.layoutItemIsPresent = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemNegativeValuesAllowed = new DevExpress.XtraLayout.LayoutControlItem();
          this.emptySpaceItem = new DevExpress.XtraLayout.EmptySpaceItem();
+         this.layoutItemRefresh = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.gridControl)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.gridView)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
          this.layoutControl.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.panelRefresh)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelDeleteStartValues)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelIsPresent)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelNegativeValuesAllowed)).BeginInit();
@@ -63,6 +66,7 @@ namespace MoBi.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemIsPresent)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemNegativeValuesAllowed)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemRefresh)).BeginInit();
          this.SuspendLayout();
          // 
          // gridControl
@@ -91,6 +95,7 @@ namespace MoBi.UI.Views
          // layoutControl
          // 
          this.layoutControl.AllowCustomization = false;
+         this.layoutControl.Controls.Add(this.panelRefresh);
          this.layoutControl.Controls.Add(this.panelDeleteStartValues);
          this.layoutControl.Controls.Add(this.panelIsPresent);
          this.layoutControl.Controls.Add(this.gridControl);
@@ -103,6 +108,13 @@ namespace MoBi.UI.Views
          this.layoutControl.Size = new System.Drawing.Size(1627, 558);
          this.layoutControl.TabIndex = 1;
          this.layoutControl.Text = "layoutControl1";
+         // 
+         // panelRefresh
+         // 
+         this.panelRefresh.Location = new System.Drawing.Point(391, 39);
+         this.panelRefresh.Name = "panelRefresh";
+         this.panelRefresh.Size = new System.Drawing.Size(373, 21);
+         this.panelRefresh.TabIndex = 9;
          // 
          // panelDeleteStartValues
          // 
@@ -155,7 +167,8 @@ namespace MoBi.UI.Views
             this.layoutItemDelete,
             this.layoutItemIsPresent,
             this.layoutItemNegativeValuesAllowed,
-            this.emptySpaceItem});
+            this.emptySpaceItem,
+            this.layoutItemRefresh});
          this.layoutGroupPanel.Location = new System.Drawing.Point(0, 0);
          this.layoutGroupPanel.Name = "layoutGroupPanel";
          this.layoutGroupPanel.Size = new System.Drawing.Size(1627, 74);
@@ -181,7 +194,7 @@ namespace MoBi.UI.Views
          this.layoutItemIsPresent.MaxSize = new System.Drawing.Size(377, 25);
          this.layoutItemIsPresent.MinSize = new System.Drawing.Size(377, 25);
          this.layoutItemIsPresent.Name = "layoutItemIsPresent";
-         this.layoutItemIsPresent.Size = new System.Drawing.Size(754, 25);
+         this.layoutItemIsPresent.Size = new System.Drawing.Size(377, 25);
          this.layoutItemIsPresent.SizeConstraintsType = DevExpress.XtraLayout.SizeConstraintsType.Custom;
          this.layoutItemIsPresent.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemIsPresent.TextVisible = false;
@@ -208,6 +221,18 @@ namespace MoBi.UI.Views
          this.emptySpaceItem.Size = new System.Drawing.Size(849, 50);
          this.emptySpaceItem.TextSize = new System.Drawing.Size(0, 0);
          // 
+         // layoutItemRefresh
+         // 
+         this.layoutItemRefresh.Control = this.panelRefresh;
+         this.layoutItemRefresh.Location = new System.Drawing.Point(377, 25);
+         this.layoutItemRefresh.MaxSize = new System.Drawing.Size(377, 25);
+         this.layoutItemRefresh.MinSize = new System.Drawing.Size(377, 25);
+         this.layoutItemRefresh.Name = "layoutItemRefresh";
+         this.layoutItemRefresh.Size = new System.Drawing.Size(377, 25);
+         this.layoutItemRefresh.SizeConstraintsType = DevExpress.XtraLayout.SizeConstraintsType.Custom;
+         this.layoutItemRefresh.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutItemRefresh.TextVisible = false;
+         // 
          // BasePathAndValueEntityView
          // 
          this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -220,6 +245,7 @@ namespace MoBi.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.gridView)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
          this.layoutControl.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.panelRefresh)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelDeleteStartValues)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelIsPresent)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelNegativeValuesAllowed)).EndInit();
@@ -230,6 +256,7 @@ namespace MoBi.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemIsPresent)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemNegativeValuesAllowed)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemRefresh)).EndInit();
          this.ResumeLayout(false);
 
       }
@@ -248,5 +275,7 @@ namespace MoBi.UI.Views
       private DevExpress.XtraLayout.LayoutControlItem layoutItemNegativeValuesAllowed;
       private DevExpress.XtraLayout.EmptySpaceItem emptySpaceItem;
       protected UxGridControl gridControl;
+      protected DevExpress.XtraEditors.PanelControl panelRefresh;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemRefresh;
    }
 }

--- a/src/MoBi.UI/Views/InitialConditionsView.cs
+++ b/src/MoBi.UI/Views/InitialConditionsView.cs
@@ -61,20 +61,11 @@ namespace MoBi.UI.Views
 
       public override string NameColumnCaption => AppConstants.Captions.MoleculeName;
 
-      public void HideIsPresentColumn()
-      {
-         _isPresentColumn.AsHidden().WithShowInColumnChooser(true);
-      }
+      public void HideIsPresentColumn() => _isPresentColumn.AsHidden().WithShowInColumnChooser(true);
 
-      private void onSetIsPresent(InitialConditionDTO dto, bool isPresent)
-      {
-         InitialConditionPresenter.SetIsPresent(dto, isPresent);
-      }
+      private void onSetIsPresent(InitialConditionDTO dto, bool isPresent) => InitialConditionPresenter.SetIsPresent(dto, isPresent);
 
-      private void onSetNegativeValueAllowed(InitialConditionDTO dto, bool negativeValuesAllowed)
-      {
-         InitialConditionPresenter.SetNegativeValuesAllowed(dto, negativeValuesAllowed);
-      }
+      private void onSetNegativeValueAllowed(InitialConditionDTO dto, bool negativeValuesAllowed) => InitialConditionPresenter.SetNegativeValuesAllowed(dto, negativeValuesAllowed);
 
       private void setParameterUnit(InitialConditionDTO initialCondition, Unit unit)
       {
@@ -87,20 +78,13 @@ namespace MoBi.UI.Views
 
       public IBuildingBlockWithInitialConditionsPresenter InitialConditionPresenter => _presenter.DowncastTo<IBuildingBlockWithInitialConditionsPresenter>();
 
-      public void AddIsPresentSelectionView(IView view)
-      {
-         panelIsPresent.FillWith(view);
-      }
+      public void AddRefreshSelectionView(IView view) => panelRefresh.FillWith(view);
 
-      public void AddNegativeValuesAllowedSelectionView(IView view)
-      {
-         panelNegativeValuesAllowed.FillWith(view);
-      }
+      public void AddIsPresentSelectionView(IView view) => panelIsPresent.FillWith(view);
 
-      public void AttachPresenter(IBuildingBlockWithInitialConditionsPresenter presenter)
-      {
-         _presenter = presenter;
-      }
+      public void AddNegativeValuesAllowedSelectionView(IView view) => panelNegativeValuesAllowed.FillWith(view);
+
+      public void AttachPresenter(IBuildingBlockWithInitialConditionsPresenter presenter) => _presenter = presenter;
 
       public override ApplicationIcon ApplicationIcon => ApplicationIcons.InitialConditions;
    }

--- a/src/MoBi.UI/Views/SelectSpatialStructureAndMoleculesView.cs
+++ b/src/MoBi.UI/Views/SelectSpatialStructureAndMoleculesView.cs
@@ -23,13 +23,11 @@ namespace MoBi.UI.Views
          InitializeComponent();
 
          descriptionLabel.AsDescription();
-         descriptionLabel.Text = AppConstants.Captions.ExtendDescription;
       }
 
-      public void AttachPresenter(ISelectSpatialStructureAndMoleculesPresenter presenter)
-      {
-         _presenter = presenter;
-      }
+      public void SetDescriptionText(string description) => descriptionLabel.Text = description;
+
+      public void AttachPresenter(ISelectSpatialStructureAndMoleculesPresenter presenter) => _presenter = presenter;
 
       public override void InitializeBinding()
       {
@@ -52,26 +50,14 @@ namespace MoBi.UI.Views
          Text = AppConstants.Captions.NewWindow(ObjectTypes.MoleculeBuildingBlock);
       }
 
-      public void Show(SelectSpatialStructureDTO dto)
-      {
-         _screenBinder.BindToSource(dto);
-      }
+      public void Show(SelectSpatialStructureDTO dto) => _screenBinder.BindToSource(dto);
 
-      public void AddMoleculeSelectionView(IView view)
-      {
-         moleculeSelectionPanel.FillWith(view);
-      }
+      public void AddMoleculeSelectionView(IView view) => moleculeSelectionPanel.FillWith(view);
 
-      public void MoleculeSelectionChanged()
-      {
-         SetOkButtonEnable();
-      }
+      public void MoleculeSelectionChanged() => SetOkButtonEnable();
 
       public override bool HasError => !_presenter.CanClose || base.HasError || _screenBinder.HasError;
 
-      private void disposeBinders()
-      {
-         _screenBinder.Dispose();
-      }
+      private void disposeBinders() => _screenBinder.Dispose();
    }
 }


### PR DESCRIPTION
Fixes #1218

# Description
Bringing back the previous functionality of refreshing initial conditions from a spatial structure and molecules.

Previously, we always refreshed from the template building blocks, but here the user has to choose what molecules and spatial structure to base their refresh from. That follows the pattern of ```Extend```.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):