### PR TITLE
Fixes #1290 When loading an organ, individual parameters are not created

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.277" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.277" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
@@ -11,6 +11,8 @@ using MoBi.Presentation.Tasks.Interaction;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Core.Domain.Mappers;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Extensions;
 using OSPSuite.Utility.Extensions;
@@ -40,17 +42,23 @@ namespace MoBi.Presentation.Tasks.Edit
       private readonly IObjectPathFactory _objectPathFactory;
       private readonly ICloneManagerForBuildingBlock _cloneManager;
       private readonly IPathAndValueEntityToParameterValueMapper _pathAndValueEntityToParameterValueMapper;
+      private readonly IFormulaFactory _formulaFactory;
+      private readonly IIndividualParameterToParameterMapper _individualParameterToParameterMapper;
 
       public EditTaskForContainer(IInteractionTaskContext interactionTaskContext,
          IMoBiSpatialStructureFactory spatialStructureFactory,
          IObjectPathFactory objectPathFactory,
          ICloneManagerForBuildingBlock cloneManager,
-         IPathAndValueEntityToParameterValueMapper pathAndValueEntityToParameterValueMapper) : base(interactionTaskContext)
+         IPathAndValueEntityToParameterValueMapper pathAndValueEntityToParameterValueMapper,
+         IFormulaFactory formulaFactory,
+         IIndividualParameterToParameterMapper individualParameterToParameterMapper) : base(interactionTaskContext)
       {
          _spatialStructureFactory = spatialStructureFactory;
          _objectPathFactory = objectPathFactory;
          _cloneManager = cloneManager;
          _pathAndValueEntityToParameterValueMapper = pathAndValueEntityToParameterValueMapper;
+         _formulaFactory = formulaFactory;
+         _individualParameterToParameterMapper = individualParameterToParameterMapper;
       }
 
       protected override IEnumerable<string> GetUnallowedNames(IContainer container, IEnumerable<IObjectBase> existingObjectsInParent)
@@ -86,6 +94,66 @@ namespace MoBi.Presentation.Tasks.Edit
          exportContainer(container, fileName);
       }
 
+      private void addIndividualParametersToContainers(IndividualBuildingBlock individual, IContainer container)
+      {
+         if (individual == null || !individual.Any())
+            return;
+
+         var allSubContainers = container.GetAllContainersAndSelf<IContainer>();
+         allSubContainers.Each(subContainer =>
+         {
+            var subContainerPath = container.ParentPath.Concat(_objectPathFactory.CreateAbsoluteObjectPath(subContainer));
+            addIndividualParametersToContainer(individual, subContainer, new ObjectPath(subContainerPath));
+         });
+      }
+
+      private void addIndividualParametersToContainer(IndividualBuildingBlock individual, IContainer container, ObjectPath containerPath)
+      {
+         var individualParametersToExport = individual.Where(individualParameter => individualParameter.ContainerPath.StartsWith(containerPath)).ToList();
+
+         // Ensure that the distributed parameters are added to the container first. After all distributed parameters are added, then the other parameters can be added.
+         individualParametersToExport.Where(x => x.DistributionType != null).Each(x => addIndividualParameterToContainer(x, container, containerPath));
+         individualParametersToExport.Where(x => x.DistributionType == null).Each(x => addIndividualParameterToContainer(x, container, containerPath));
+      }
+
+      private void addIndividualParameterToContainer(IndividualParameter individualParameter, IContainer container, string containerPath)
+      {
+         var targetContainer = findTargetContainer(individualParameter.ContainerPath, container, containerPath);
+         // The target container for this parameter is not found - skip
+         if (targetContainer == null)
+            return;
+
+         var parameterToAdd = createParameter(individualParameter);
+         var existingParameter = targetContainer.FindByName(parameterToAdd.Name);
+
+         if (existingParameter != null)
+            targetContainer.RemoveChild(existingParameter);
+
+         targetContainer.Add(parameterToAdd);
+      }
+
+      private IParameter createParameter(IndividualParameter individualParameter)
+      {
+         var parameterToAdd = _individualParameterToParameterMapper.MapFrom(individualParameter);
+
+         if (individualParameter.Formula != null)
+            parameterToAdd.Formula = individualParameter.Formula;
+         if (individualParameter.Value.HasValue)
+            parameterToAdd.Formula = _formulaFactory.ConstantFormula(individualParameter.Value.Value, individualParameter.Dimension);
+
+         return parameterToAdd;
+      }
+
+      private IContainer findTargetContainer(string individualParameterContainerPath, IContainer container, string containerPath)
+      {
+         if (individualParameterContainerPath == containerPath)
+            return container;
+
+         // if the individualParameterContainerPath is pointing to a sub-container, then search for a child container with the relative path
+         var relativePath = individualParameterContainerPath.Substring(containerPath.Length + 1).ToPathArray();
+         return container.EntityAt<IContainer>(relativePath);
+      }
+
       private void exportContainer(IContainer container, string fileName, IndividualBuildingBlock individual = null, IReadOnlyList<ExpressionProfileBuildingBlock> expressionProfileBuildingBlocks = null)
       {
          var tmpSpatialStructure = (MoBiSpatialStructure)_spatialStructureFactory.Create();
@@ -98,9 +166,9 @@ namespace MoBi.Presentation.Tasks.Edit
 
          var entitiesToExport = new List<PathAndValueEntity>();
 
-         entitiesToExport.AddRange(pathAndValueEntitiesForContainer(individual, clonedEntity));
+         addIndividualParametersToContainers(individual, clonedEntity);
 
-         if(expressionProfileBuildingBlocks != null)
+         if (expressionProfileBuildingBlocks != null)
             entitiesToExport.AddRange(expressionProfileBuildingBlocks.SelectMany(x => pathAndValueEntitiesForContainer(x, clonedEntity, x.MoleculeName)));
 
          var existingSpatialStructure = _interactionTaskContext.Active<MoBiSpatialStructure>();

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.274" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.277" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.277" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/Tasks/EditTaskForContainerSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/EditTaskForContainerSpecs.cs
@@ -1,6 +1,4 @@
 ﻿using System.Linq;
-using DevExpress.Utils.Extensions;
-using DevExpress.XtraCharts;
 using FakeItEasy;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Builder;

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.274" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.274" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.277" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1290

# Description
This brings back code that exports ```IndividualParameters``` in the container itself when exporting a container with individual and expression. ```ExpressionParameters``` are still exported as ```ParameterValues```

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):