### PR TITLE
Fixes #1291 Cannot change value of a distributed parameter

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -261,6 +261,8 @@ namespace MoBi.Assets
          public static readonly string RemoveTrackedQuantityChanges = "Remove tracked quantity changes";
          public static readonly string AddedMultipleBuildingBlocksFromFile = "Added multiple building blocks from file";
 
+         public static string ConvertDistributedPathAndValueEntityToConstantValue(string type, string path) => $"Convert distributed {type} '{path}' to constant value";
+
          public static string UpdateSimulationSettingsInSimulation(string simulationName) => $"Update simulation settings in simulation {simulationName}";
 
 

--- a/src/MoBi.Presentation/Presenter/ExpressionDistributedPathAndValueEntityPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ExpressionDistributedPathAndValueEntityPresenter.cs
@@ -15,9 +15,8 @@ namespace MoBi.Presentation.Presenter
       DistributedPathAndValueEntityPresenter<IExpressionDistributedPathAndValueEntityView, IExpressionDistributedPathAndValueEntityPresenter, ExpressionParameterDTO, ExpressionParameter, ExpressionProfileBuildingBlock>,
       IExpressionDistributedPathAndValueEntityPresenter
    {
-      public ExpressionDistributedPathAndValueEntityPresenter(IExpressionDistributedPathAndValueEntityView view, 
-         IInteractionTasksForExpressionProfileBuildingBlock interactionTasksForExpressionProfile) : 
-         base(view, interactionTasksForExpressionProfile)
+      public ExpressionDistributedPathAndValueEntityPresenter(IExpressionDistributedPathAndValueEntityView view, IInteractionTasksForExpressionProfileBuildingBlock interactionTasks) : 
+         base(view, interactionTasks)
       {
       }
    }

--- a/src/MoBi.Presentation/Presenter/ExpressionProfileBuildingBlockPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ExpressionProfileBuildingBlockPresenter.cs
@@ -1,5 +1,4 @@
-﻿using MoBi.Core.Domain.Model;
-using MoBi.Presentation.DTO;
+﻿using MoBi.Presentation.DTO;
 using MoBi.Presentation.Extensions;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Tasks.Interaction;

--- a/src/MoBi.Presentation/Presenter/IndividualBuildingBlockPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/IndividualBuildingBlockPresenter.cs
@@ -1,5 +1,4 @@
-﻿using MoBi.Core.Domain.Model;
-using MoBi.Presentation.DTO;
+﻿using MoBi.Presentation.DTO;
 using MoBi.Presentation.Extensions;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Tasks.Interaction;

--- a/src/MoBi.Presentation/Presenter/InitialConditionsDistributedPathAndValueEntityPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/InitialConditionsDistributedPathAndValueEntityPresenter.cs
@@ -15,7 +15,7 @@ namespace MoBi.Presentation.Presenter
       DistributedPathAndValueEntityPresenter<IInitialConditionsDistributedPathAndValueEntityView, IInitialConditionsDistributedPathAndValueEntityPresenter, InitialConditionDTO, InitialCondition, InitialConditionsBuildingBlock>,
       IInitialConditionsDistributedPathAndValueEntityPresenter
    {
-      public InitialConditionsDistributedPathAndValueEntityPresenter(IInitialConditionsDistributedPathAndValueEntityView view, IInitialConditionsTask<InitialConditionsBuildingBlock> interactionTasks) : base(view, interactionTasks)
+      public InitialConditionsDistributedPathAndValueEntityPresenter(IInitialConditionsDistributedPathAndValueEntityView view, IInitialConditionsTask<InitialConditionsBuildingBlock> initialConditionsTask) : base(view, initialConditionsTask)
       {
       }
    }
@@ -29,7 +29,7 @@ namespace MoBi.Presentation.Presenter
       DistributedPathAndValueEntityPresenter<IInitialConditionsDistributedInExpressionProfileView, IInitialConditionsDistributedInExpressionProfilePresenter, InitialConditionDTO, InitialCondition, ExpressionProfileBuildingBlock>,
       IInitialConditionsDistributedInExpressionProfilePresenter
    {
-      public InitialConditionsDistributedInExpressionProfilePresenter(IInitialConditionsDistributedInExpressionProfileView view, IInitialConditionsTask<ExpressionProfileBuildingBlock> interactionTasks) : base(view, interactionTasks)
+      public InitialConditionsDistributedInExpressionProfilePresenter(IInitialConditionsDistributedInExpressionProfileView view, IInitialConditionsTask<ExpressionProfileBuildingBlock> initialConditionsTask) : base(view, initialConditionsTask)
       {
       }
    }

--- a/src/MoBi.Presentation/Presenter/ParameterValueDistributedPathAndValueEntityPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ParameterValueDistributedPathAndValueEntityPresenter.cs
@@ -16,7 +16,7 @@ namespace MoBi.Presentation.Presenter
       DistributedPathAndValueEntityPresenter<IParameterValueDistributedPathAndValueEntityView, IParameterValueDistributedPathAndValueEntityPresenter, ParameterValueDTO, ParameterValue, ParameterValuesBuildingBlock>,
       IParameterValueDistributedPathAndValueEntityPresenter
    {
-      public ParameterValueDistributedPathAndValueEntityPresenter(IParameterValueDistributedPathAndValueEntityView view, IParameterValuesTask interactionTasks) : base(view, interactionTasks)
+      public ParameterValueDistributedPathAndValueEntityPresenter(IParameterValueDistributedPathAndValueEntityView view, IParameterValuesTask parameterValuesTask) : base(view, parameterValuesTask)
       {
       }
    }

--- a/src/MoBi.Presentation/Presenter/PathAndValueBuildingBlockPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/PathAndValueBuildingBlockPresenter.cs
@@ -12,6 +12,7 @@ using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Presentation.DTO;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Views;
+using OSPSuite.Utility.Events;
 
 namespace MoBi.Presentation.Presenter
 {
@@ -40,8 +41,20 @@ namespace MoBi.Presentation.Presenter
          _distributedPathAndValuePresenter = distributedPathAndValuePresenter;
          _subPresenterManager.Add(_distributedPathAndValuePresenter);
          _view.AddDistributedParameterView(_distributedPathAndValuePresenter.BaseView);
+         _distributedPathAndValuePresenter.ParameterModified += UpdateEntityFor;
       }
-      
+
+      public override void ReleaseFrom(IEventPublisher eventPublisher)
+      {
+         base.ReleaseFrom(eventPublisher);
+         _distributedPathAndValuePresenter.ParameterModified -= UpdateEntityFor;
+      }
+
+      protected void UpdateEntityFor(ObjectPath objectPath)
+      {
+         _view.RefreshForUpdatedEntity();
+      }
+
       public override object Subject => _buildingBlock;
 
       public override void Edit(TBuildingBlock buildngBlock)

--- a/src/MoBi.Presentation/Tasks/Interaction/InitialConditionsTask.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InitialConditionsTask.cs
@@ -55,8 +55,9 @@ namespace MoBi.Presentation.Tasks.Interaction
          IInitialConditionPathTask initialConditionPathTask,
          IReactionDimensionRetriever dimensionRetriever,
          IInitialConditionsCreator initialConditionsCreator, 
-         IMoleculeResolver moleculeResolver) : 
-         base(interactionTaskContext, editTask, extendManager, cloneManagerForBuildingBlock, moBiFormulaTask, spatialStructureFactory, dtoMapper, initialConditionPathTask)
+         IMoleculeResolver moleculeResolver, 
+         IParameterFactory parameterFactory) : 
+         base(interactionTaskContext, editTask, extendManager, cloneManagerForBuildingBlock, moBiFormulaTask, spatialStructureFactory, dtoMapper, initialConditionPathTask, parameterFactory)
       {
          _dimensionRetriever = dimensionRetriever;
          _initialConditionsCreator = initialConditionsCreator;

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExpressionProfileBuildingBlock.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExpressionProfileBuildingBlock.cs
@@ -32,8 +32,9 @@ namespace MoBi.Presentation.Tasks.Interaction
          IEditTasksForExpressionProfileBuildingBlock editTask, 
          IMoBiFormulaTask formulaTask, 
          IPKSimStarter pkSimStarter, 
-         IContainerTask containerTask) :
-         base(interactionTaskContext, editTask, formulaTask)
+         IContainerTask containerTask, 
+         IParameterFactory parameterFactory) :
+         base(interactionTaskContext, editTask, formulaTask, parameterFactory)
       {
          _editTaskForExpressionProfileBuildingBlock = editTask;
          _pkSimStarter = pkSimStarter;

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExtendablePathAndValueEntity.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExtendablePathAndValueEntity.cs
@@ -37,8 +37,9 @@ namespace MoBi.Presentation.Tasks.Interaction
       protected InteractionTasksForExtendablePathAndValueEntity(IInteractionTaskContext interactionTaskContext, IEditTasksForBuildingBlock<TBuildingBlock> editTask,
          IExtendPathAndValuesManager<TPathAndValueEntity> extendManager, ICloneManagerForBuildingBlock cloneManagerForBuildingBlock,
          IMoBiFormulaTask moBiFormulaTask, ISpatialStructureFactory spatialStructureFactory, IMapper<ImportedQuantityDTO, TPathAndValueEntity> dtoToQuantityToParameterValueMapper,
-         IPathAndValueEntityPathTask<ILookupBuildingBlock<TPathAndValueEntity>, TPathAndValueEntity> entityPathTask)
-         : base(interactionTaskContext, editTask, moBiFormulaTask)
+         IPathAndValueEntityPathTask<ILookupBuildingBlock<TPathAndValueEntity>, TPathAndValueEntity> entityPathTask,
+         IParameterFactory parameterFactory)
+         : base(interactionTaskContext, editTask, moBiFormulaTask, parameterFactory)
       {
          _extendManager = extendManager;
          _cloneManagerForBuildingBlock = cloneManagerForBuildingBlock;

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForIndividualBuildingBlock.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForIndividualBuildingBlock.cs
@@ -2,6 +2,7 @@
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
 using MoBi.Presentation.Tasks.Edit;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 
 namespace MoBi.Presentation.Tasks.Interaction
@@ -14,7 +15,11 @@ namespace MoBi.Presentation.Tasks.Interaction
 
    public class InteractionTasksForIndividualBuildingBlock : InteractionTasksForProjectPathAndValueEntityBuildingBlocks<IndividualBuildingBlock, IndividualParameter>, IInteractionTasksForIndividualBuildingBlock
    {
-      public InteractionTasksForIndividualBuildingBlock(IInteractionTaskContext interactionTaskContext, IEditTasksForIndividualBuildingBlock editTask, IMoBiFormulaTask moBiFormulaTask) : base(interactionTaskContext, editTask, moBiFormulaTask)
+      public InteractionTasksForIndividualBuildingBlock(IInteractionTaskContext interactionTaskContext, 
+         IEditTasksForIndividualBuildingBlock editTask, 
+         IMoBiFormulaTask moBiFormulaTask, 
+         IParameterFactory parameterFactory) : 
+         base(interactionTaskContext, editTask, moBiFormulaTask, parameterFactory)
       {
       }
 

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForProjectPathAndValueEntityBuildingBlocks.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForProjectPathAndValueEntityBuildingBlocks.cs
@@ -19,7 +19,10 @@ namespace MoBi.Presentation.Tasks.Interaction
       where TParameter : PathAndValueEntity 
       where TBuildingBlock : class, ILookupBuildingBlock<TParameter>
    {
-      protected InteractionTasksForProjectPathAndValueEntityBuildingBlocks(IInteractionTaskContext interactionTaskContext, IEditTasksForBuildingBlock<TBuildingBlock> editTask, IMoBiFormulaTask moBiFormulaTask) : base(interactionTaskContext, editTask, moBiFormulaTask)
+      protected InteractionTasksForProjectPathAndValueEntityBuildingBlocks(IInteractionTaskContext interactionTaskContext, 
+         IEditTasksForBuildingBlock<TBuildingBlock> editTask, 
+         IMoBiFormulaTask moBiFormulaTask,
+         IParameterFactory parameterFactory) : base(interactionTaskContext, editTask, moBiFormulaTask, parameterFactory)
       {
       }
 

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForProjectPathAndValueEntityBuildingBlocks.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForProjectPathAndValueEntityBuildingBlocks.cs
@@ -17,7 +17,7 @@ namespace MoBi.Presentation.Tasks.Interaction
       InteractionTasksForPathAndValueEntity<MoBiProject, TBuildingBlock, TParameter>,
       IInteractionTasksForProjectPathAndValueEntityBuildingBlocks<TBuildingBlock, TParameter>
       where TParameter : PathAndValueEntity 
-      where TBuildingBlock : class, IBuildingBlock<TParameter>
+      where TBuildingBlock : class, ILookupBuildingBlock<TParameter>
    {
       protected InteractionTasksForProjectPathAndValueEntityBuildingBlocks(IInteractionTaskContext interactionTaskContext, IEditTasksForBuildingBlock<TBuildingBlock> editTask, IMoBiFormulaTask moBiFormulaTask) : base(interactionTaskContext, editTask, moBiFormulaTask)
       {

--- a/src/MoBi.Presentation/Tasks/Interaction/ParameterValuesTask.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/ParameterValuesTask.cs
@@ -35,8 +35,9 @@ namespace MoBi.Presentation.Tasks.Interaction
          IMoBiFormulaTask moBiFormulaTask,
          IMoBiSpatialStructureFactory spatialStructureFactory,
          IParameterValuePathTask parameterValuePathTask,
-         IParameterValuesCreator parameterValuesCreator)
-         : base(interactionTaskContext, editTask, parameterValuesExtendManager, cloneManagerForBuildingBlock, moBiFormulaTask, spatialStructureFactory, dtoToQuantityToParameterValueMapper, parameterValuePathTask)
+         IParameterValuesCreator parameterValuesCreator, 
+         IParameterFactory parameterFactory)
+         : base(interactionTaskContext, editTask, parameterValuesExtendManager, cloneManagerForBuildingBlock, moBiFormulaTask, spatialStructureFactory, dtoToQuantityToParameterValueMapper, parameterValuePathTask, parameterFactory)
       {
          _parameterValuesCreator = parameterValuesCreator;
       }

--- a/src/MoBi.Presentation/Views/IPathAndValueEntitiesView.cs
+++ b/src/MoBi.Presentation/Views/IPathAndValueEntitiesView.cs
@@ -6,6 +6,7 @@ namespace MoBi.Presentation.Views
    public interface IPathAndValueEntitiesView : IView
    {
       void AddDistributedParameterView(IView view);
+      void RefreshForUpdatedEntity();
    }
 
    public interface IPathAndValueEntitiesView<TStartValueDTO> : IPathAndValueEntitiesView

--- a/src/MoBi.UI/Views/BasePathAndValueEntityView.cs
+++ b/src/MoBi.UI/Views/BasePathAndValueEntityView.cs
@@ -222,6 +222,12 @@ namespace MoBi.UI.Views
          _popupControl.FillWith(view);
       }
 
+      public void RefreshForUpdatedEntity()
+      {
+         gridView.CloseEditor();
+         gridView.ShowEditor();
+      }
+
       public void HideValueOriginColumn()
       {
          _valueOriginBinder.ValueOriginColumn.AsHidden().WithShowInColumnChooser(true);

--- a/src/MoBi.UI/Views/DistributedPathAndValueEntityView.Designer.cs
+++ b/src/MoBi.UI/Views/DistributedPathAndValueEntityView.Designer.cs
@@ -39,10 +39,13 @@ namespace MoBi.UI.Views
          this.gridControl = new OSPSuite.UI.Controls.UxGridControl();
          this.gridView = new OSPSuite.UI.Controls.UxGridView();
          this.uxLayoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.lblDistributionType = new DevExpress.XtraEditors.LabelControl();
          this.Root = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutControlItem1 = new DevExpress.XtraLayout.LayoutControlItem();
-         this.lblDistributionType = new DevExpress.XtraEditors.LabelControl();
          this.layoutControlItem2 = new DevExpress.XtraLayout.LayoutControlItem();
+         this.emptySpaceItem1 = new DevExpress.XtraLayout.EmptySpaceItem();
+         this.convertToSimpleParameterButton = new OSPSuite.UI.Controls.UxSimpleButton();
+         this.convertButtonLayoutItem = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.gridControl)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.gridView)).BeginInit();
@@ -51,6 +54,8 @@ namespace MoBi.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.Root)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem2)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem1)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.convertButtonLayoutItem)).BeginInit();
          this.SuspendLayout();
          // 
          // gridControl
@@ -58,7 +63,7 @@ namespace MoBi.UI.Views
          this.gridControl.Location = new System.Drawing.Point(2, 19);
          this.gridControl.MainView = this.gridView;
          this.gridControl.Name = "gridControl";
-         this.gridControl.Size = new System.Drawing.Size(429, 206);
+         this.gridControl.Size = new System.Drawing.Size(429, 180);
          this.gridControl.TabIndex = 0;
          this.gridControl.ViewCollection.AddRange(new DevExpress.XtraGrid.Views.Base.BaseView[] {
             this.gridView});
@@ -80,36 +85,17 @@ namespace MoBi.UI.Views
          // uxLayoutControl
          // 
          this.uxLayoutControl.AllowCustomization = false;
+         this.uxLayoutControl.Controls.Add(this.convertToSimpleParameterButton);
          this.uxLayoutControl.Controls.Add(this.lblDistributionType);
          this.uxLayoutControl.Controls.Add(this.gridControl);
          this.uxLayoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
          this.uxLayoutControl.Location = new System.Drawing.Point(0, 0);
          this.uxLayoutControl.Name = "uxLayoutControl";
+         this.uxLayoutControl.OptionsCustomizationForm.DesignTimeCustomizationFormPositionAndSize = new System.Drawing.Rectangle(1432, 216, 650, 400);
          this.uxLayoutControl.Root = this.Root;
          this.uxLayoutControl.Size = new System.Drawing.Size(433, 227);
          this.uxLayoutControl.TabIndex = 1;
          this.uxLayoutControl.Text = "uxLayoutControl";
-         // 
-         // Root
-         // 
-         this.Root.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
-         this.Root.GroupBordersVisible = false;
-         this.Root.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
-            this.layoutControlItem1,
-            this.layoutControlItem2});
-         this.Root.Name = "Root";
-         this.Root.Padding = new DevExpress.XtraLayout.Utils.Padding(0, 0, 0, 0);
-         this.Root.Size = new System.Drawing.Size(433, 227);
-         this.Root.TextVisible = false;
-         // 
-         // layoutControlItem1
-         // 
-         this.layoutControlItem1.Control = this.gridControl;
-         this.layoutControlItem1.Location = new System.Drawing.Point(0, 17);
-         this.layoutControlItem1.Name = "layoutControlItem1";
-         this.layoutControlItem1.Size = new System.Drawing.Size(433, 210);
-         this.layoutControlItem1.TextSize = new System.Drawing.Size(0, 0);
-         this.layoutControlItem1.TextVisible = false;
          // 
          // lblDistributionType
          // 
@@ -120,6 +106,29 @@ namespace MoBi.UI.Views
          this.lblDistributionType.TabIndex = 4;
          this.lblDistributionType.Text = "lblDistributionType";
          // 
+         // Root
+         // 
+         this.Root.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
+         this.Root.GroupBordersVisible = false;
+         this.Root.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutControlItem1,
+            this.layoutControlItem2,
+            this.emptySpaceItem1,
+            this.convertButtonLayoutItem});
+         this.Root.Name = "Root";
+         this.Root.Padding = new DevExpress.XtraLayout.Utils.Padding(0, 0, 0, 0);
+         this.Root.Size = new System.Drawing.Size(433, 227);
+         this.Root.TextVisible = false;
+         // 
+         // layoutControlItem1
+         // 
+         this.layoutControlItem1.Control = this.gridControl;
+         this.layoutControlItem1.Location = new System.Drawing.Point(0, 17);
+         this.layoutControlItem1.Name = "layoutControlItem1";
+         this.layoutControlItem1.Size = new System.Drawing.Size(433, 184);
+         this.layoutControlItem1.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutControlItem1.TextVisible = false;
+         // 
          // layoutControlItem2
          // 
          this.layoutControlItem2.Control = this.lblDistributionType;
@@ -128,6 +137,34 @@ namespace MoBi.UI.Views
          this.layoutControlItem2.Size = new System.Drawing.Size(433, 17);
          this.layoutControlItem2.TextSize = new System.Drawing.Size(0, 0);
          this.layoutControlItem2.TextVisible = false;
+         // 
+         // emptySpaceItem1
+         // 
+         this.emptySpaceItem1.AllowHotTrack = false;
+         this.emptySpaceItem1.Location = new System.Drawing.Point(0, 201);
+         this.emptySpaceItem1.Name = "emptySpaceItem1";
+         this.emptySpaceItem1.Size = new System.Drawing.Size(216, 26);
+         this.emptySpaceItem1.TextSize = new System.Drawing.Size(0, 0);
+         // 
+         // convertToSimpleParameterButton
+         // 
+         this.convertToSimpleParameterButton.Location = new System.Drawing.Point(218, 203);
+         this.convertToSimpleParameterButton.Manager = null;
+         this.convertToSimpleParameterButton.Name = "convertToSimpleParameterButton";
+         this.convertToSimpleParameterButton.Shortcut = System.Windows.Forms.Keys.None;
+         this.convertToSimpleParameterButton.Size = new System.Drawing.Size(213, 22);
+         this.convertToSimpleParameterButton.StyleController = this.uxLayoutControl;
+         this.convertToSimpleParameterButton.TabIndex = 5;
+         this.convertToSimpleParameterButton.Text = "convertToSimpleParameterButton";
+         // 
+         // convertButtonLayoutItem
+         // 
+         this.convertButtonLayoutItem.Control = this.convertToSimpleParameterButton;
+         this.convertButtonLayoutItem.Location = new System.Drawing.Point(216, 201);
+         this.convertButtonLayoutItem.Name = "convertButtonLayoutItem";
+         this.convertButtonLayoutItem.Size = new System.Drawing.Size(217, 26);
+         this.convertButtonLayoutItem.TextSize = new System.Drawing.Size(0, 0);
+         this.convertButtonLayoutItem.TextVisible = false;
          // 
          // DistributedPathAndValueEntityView
          // 
@@ -144,6 +181,8 @@ namespace MoBi.UI.Views
          ((System.ComponentModel.ISupportInitialize)(this.Root)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem2)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem1)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.convertButtonLayoutItem)).EndInit();
          this.ResumeLayout(false);
 
       }
@@ -157,5 +196,8 @@ namespace MoBi.UI.Views
       private DevExpress.XtraLayout.LayoutControlGroup Root;
       private DevExpress.XtraLayout.LayoutControlItem layoutControlItem1;
       private DevExpress.XtraLayout.LayoutControlItem layoutControlItem2;
+      private UxSimpleButton convertToSimpleParameterButton;
+      private DevExpress.XtraLayout.EmptySpaceItem emptySpaceItem1;
+      private DevExpress.XtraLayout.LayoutControlItem convertButtonLayoutItem;
    }
 }

--- a/src/MoBi.UI/Views/DistributedPathAndValueEntityView.cs
+++ b/src/MoBi.UI/Views/DistributedPathAndValueEntityView.cs
@@ -1,29 +1,34 @@
-﻿using DevExpress.XtraEditors;
-using MoBi.Presentation.DTO;
+﻿using MoBi.Presentation.DTO;
 using MoBi.Presentation.Presenter;
+using OSPSuite.Assets;
 using OSPSuite.Core.Domain.Builder;
-using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.DataBinding.DevExpress.XtraGrid;
 using OSPSuite.UI.Controls;
+using OSPSuite.UI.Extensions;
 using OSPSuite.Utility.Format;
 
 namespace MoBi.UI.Views
 {
-   public abstract partial class DistributedPathAndValueEntityView<TPresenter, TPathAndValueEntity, TPathAndValueDTO, TBuildingBlock> : BaseUserControl 
+   public abstract partial class DistributedPathAndValueEntityView<TPresenter, TPathAndValueEntity, TPathAndValueDTO, TBuildingBlock> : BaseUserControl
       where TPresenter : IDistributedPathAndValueEntityPresenter<TPathAndValueDTO, TBuildingBlock>
       where TPathAndValueDTO : PathAndValueEntityDTO<TPathAndValueEntity, TPathAndValueDTO> where TPathAndValueEntity : PathAndValueEntity
    {
       private GridViewBinder<TPathAndValueDTO> _gridViewBinder;
       private ScreenBinder<TPathAndValueDTO> _screenBinder;
-      private readonly UxComboBoxUnit<TPathAndValueDTO> _unitControl;
       private TPresenter _presenter;
 
       protected DistributedPathAndValueEntityView()
       {
          InitializeComponent();
-         _unitControl = new UxComboBoxUnit<TPathAndValueDTO>(gridControl);
+      }
+
+      public override void InitializeResources()
+      {
+         base.InitializeResources();
+         convertToSimpleParameterButton.Text = Captions.Edit;
+         convertButtonLayoutItem.AdjustButtonSize();
       }
 
       public override void InitializeBinding()
@@ -31,45 +36,21 @@ namespace MoBi.UI.Views
          _screenBinder = new ScreenBinder<TPathAndValueDTO>();
          _gridViewBinder = new GridViewBinder<TPathAndValueDTO>(gridView);
          _gridViewBinder.AutoBind(x => x.Name).AsReadOnly();
-         _gridViewBinder.Bind(x => x.Value).
-            WithEditorConfiguration(configureRepository).
-            WithFormat(RepositoryFormatter).
-            WithOnValueUpdating(setValue);
-         gridView.HiddenEditor += (o, e) => hideEditor();
+         _gridViewBinder.Bind(x => x.Value).WithFormat(RepositoryFormatter).AsReadOnly();
 
-         _unitControl.ParameterUnitSet += (o, e) => OnEvent(() => setUnit(o,e));
          gridView.OptionsCustomization.AllowGroup = false;
          gridView.OptionsView.ShowGroupPanel = false;
 
          _screenBinder.Bind(x => x.DistributionType).To(lblDistributionType);
+
+         convertToSimpleParameterButton.Click += (o, e) => OnEvent(convertToSimpleParameter);
       }
 
-      private void setValue(TPathAndValueDTO dto, PropertyValueSetEventArgs<double?> arg2)
-      {
-         _presenter.SetParameterValue(dto, arg2.NewValue);
-      }
+      private void convertToSimpleParameter() => _presenter.ConvertToConstantFormula();
 
-      private void setUnit(TPathAndValueDTO distributionSubParameterDTO, Unit unit)
-      {
-         _presenter.SetParameterUnit(distributionSubParameterDTO, unit);
-      }
-
-      private void hideEditor()
-      {
-         _unitControl.Hide();
-      }
-
-      protected IFormatter<double?> RepositoryFormatter(TPathAndValueDTO distributionSubParameterDTO)
-      {
-         return FormatterFor(distributionSubParameterDTO);
-      }
+      protected IFormatter<double?> RepositoryFormatter(TPathAndValueDTO distributionSubParameterDTO) => FormatterFor(distributionSubParameterDTO);
 
       protected abstract IFormatter<double?> FormatterFor(TPathAndValueDTO dto);
-
-      private void configureRepository(BaseEdit activeEditor, TPathAndValueDTO pathAndValueDTO)
-      {
-         _unitControl.UpdateUnitsFor(activeEditor, pathAndValueDTO);
-      }
 
       public void BindTo(TPathAndValueDTO dto)
       {
@@ -83,9 +64,6 @@ namespace MoBi.UI.Views
          _screenBinder.Dispose();
       }
 
-      public void AttachPresenter(TPresenter presenter)
-      {
-         _presenter = presenter;
-      }
+      public void AttachPresenter(TPresenter presenter) => _presenter = presenter;
    }
 }

--- a/src/MoBi.UI/Views/ExpressionProfileBuildingBlockView.cs
+++ b/src/MoBi.UI/Views/ExpressionProfileBuildingBlockView.cs
@@ -223,5 +223,11 @@ namespace MoBi.UI.Views
       {
          _popupControl.FillWith(view);
       }
+
+      public void RefreshForUpdatedEntity()
+      {
+         gridView.CloseEditor();
+         gridView.ShowEditor();
+      }
    }
 }

--- a/src/MoBi.UI/Views/IndividualBuildingBlockView.cs
+++ b/src/MoBi.UI/Views/IndividualBuildingBlockView.cs
@@ -51,6 +51,7 @@ namespace MoBi.UI.Views
          _unitControl = new UxComboBoxUnit<IndividualParameterDTO>(gridControl);
          gridGroup.Text = Parameters;
          _repositoryItemPopupContainerEdit.PopupControl = _popupControl;
+
          _repositoryItemPopupContainerEdit.QueryDisplayText += (o, e) => OnEvent(queryText, e);
       }
 
@@ -194,6 +195,12 @@ namespace MoBi.UI.Views
          createNameValuePairs(buildingBlockDTO);
          _gridViewBinder.BindToSource(buildingBlockDTO.Parameters);
          initColumnVisibility();
+      }
+
+      public void RefreshForUpdatedEntity()
+      {
+         gridView.CloseEditor();
+         gridView.ShowEditor();
       }
 
       public void AddDistributedParameterView(IView view)

--- a/tests/MoBi.Tests/Core/Commands/SetParameterValueWithUnitCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/SetParameterValueWithUnitCommandSpecs.cs
@@ -5,6 +5,7 @@ using OSPSuite.BDDHelper.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Services;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.UnitSystem;
 
 
@@ -19,35 +20,40 @@ namespace MoBi.Core.Commands
       protected double _oldValue=1.1;
       protected Unit _oldUnit;
       protected ParameterValuesBuildingBlock _buildingBlock;
+      protected IMoBiContext _context;
+      protected IBuildingBlockVersionUpdater _buildingBlockVersionUpdater;
 
       protected override void Context()
       {
          _psv = new ParameterValue{ Value = _oldValue, Dimension = _dimension};
          _dimension = A.Fake<IDimension>();
          _newUnit = new Unit("Neu",2,0);
-         _buildingBlock = A.Fake<ParameterValuesBuildingBlock>();
-         _buildingBlock.Version = 1;
+         _context = A.Fake<IMoBiContext>();
+         _buildingBlockVersionUpdater = A.Fake<IBuildingBlockVersionUpdater>();
+         _buildingBlock = new ParameterValuesBuildingBlock
+         {
+            Version = 1
+         };
          A.CallTo(() => _dimension.Unit("Neu")).Returns(_newUnit);
          _oldUnit = new Unit("Old",1,0);
          _psv.DisplayUnit = _oldUnit;
          _psv.Dimension = _dimension;
+
          A.CallTo(() => _dimension.BaseUnitValueToUnitValue(_oldUnit,_oldValue)).Returns(_oldValue);
          A.CallTo(() => _dimension.UnitValueToBaseUnitValue(_newUnit,_newValue)).Returns(_newValue);
-         sut = new PathAndValueEntityValueOrUnitChangedCommand<ParameterValue, ParameterValuesBuildingBlock>(_psv, _newValue, _newUnit, _buildingBlock);
+         A.CallTo(() => _context.Resolve<IBuildingBlockVersionUpdater>()).Returns(_buildingBlockVersionUpdater);
+         A.CallTo(() => _context.Get<ParameterValuesBuildingBlock>(_buildingBlock.Id)).Returns(_buildingBlock);
+         
+         _buildingBlock.Add(_psv);
       }
    }
 
-   public class executing_a_set_parameter_value_with_unit_command : concern_for_SetParameterValueWithUnitCommandSpecs
+   public class When_executing_a_set_parameter_value_with_unit_command : concern_for_SetParameterValueWithUnitCommandSpecs
    {
-      private IMoBiContext _context;
-      private IBuildingBlockVersionUpdater _buildingBlockVersionUpdater;
-
       protected override void Context()
       {
          base.Context();
-         _context = A.Fake<IMoBiContext>();
-         _buildingBlockVersionUpdater= A.Fake<IBuildingBlockVersionUpdater>();
-         A.CallTo(() => _context.Resolve<IBuildingBlockVersionUpdater>()).Returns(_buildingBlockVersionUpdater);
+         sut = new PathAndValueEntityValueOrUnitChangedCommand<ParameterValue, ParameterValuesBuildingBlock>(_psv, _newValue, _newUnit, _buildingBlock);
       }
 
       protected override void Because()
@@ -63,10 +69,51 @@ namespace MoBi.Core.Commands
       }
 
       [Observation]
-      public void should_have_set_parameter_start_values_building_block_to_chnaged()
+      public void should_have_set_parameter_start_values_building_block_to_changed()
       {
          A.CallTo(() => _buildingBlockVersionUpdater.UpdateBuildingBlockVersion(_buildingBlock, true)).MustHaveHappened();
       }
    }
 
+   public class When_reverting_to_distributed_from_constant_formula : concern_for_SetParameterValueWithUnitCommandSpecs
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _psv.DistributionType = DistributionType.Normal;
+         sut = new PathAndValueEntityValueOrUnitChangedCommand<ParameterValue, ParameterValuesBuildingBlock>(_psv, _newValue, _newUnit, _buildingBlock);
+      }
+
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_context);
+      }
+
+      [Observation]
+      public void should_change_the_parameter_to_be_distributed()
+      {
+         _psv.DistributionType.ShouldBeEqualTo(DistributionType.Normal);
+      }
+   }
+
+   public class When_converting_a_distributed_path_and_value_entity: concern_for_SetParameterValueWithUnitCommandSpecs
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _psv.DistributionType = DistributionType.Normal;
+         sut = new PathAndValueEntityValueOrUnitChangedCommand<ParameterValue, ParameterValuesBuildingBlock>(_psv, _newValue, _newUnit, _buildingBlock);
+      }
+
+      protected override void Because()
+      {
+         sut.Execute(_context);
+      }
+
+      [Observation]
+      public void should_change_the_parameter_to_be_non_distributed()
+      {
+         _psv.DistributionType.ShouldBeEqualTo(null);
+      }
+   }
 }	

--- a/tests/MoBi.Tests/Presentation/IndividualDistributedPathAndValueEntityPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/IndividualDistributedPathAndValueEntityPresenterSpecs.cs
@@ -6,16 +6,14 @@ using MoBi.Presentation.Tasks.Interaction;
 using MoBi.Presentation.Views;
 using OSPSuite.BDDHelper;
 using OSPSuite.Core.Commands.Core;
-using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
-using OSPSuite.Core.Domain.UnitSystem;
 
 namespace MoBi.Presentation
 {
    public class concern_for_IndividualDistributedPathAndValueEntityPresenter : ContextSpecification<IndividualDistributedPathAndValueEntityPresenter>
    {
-      protected IInteractionTasksForIndividualBuildingBlock _interactionTasks;
       protected IIndividualDistributedPathAndValueEntityView _view;
+      private IInteractionTasksForIndividualBuildingBlock _interactionTasks;
 
       protected override void Context()
       {
@@ -23,64 +21,6 @@ namespace MoBi.Presentation
          _interactionTasks = A.Fake<IInteractionTasksForIndividualBuildingBlock>();
          sut = new IndividualDistributedPathAndValueEntityPresenter(_view, _interactionTasks);
          sut.InitializeWith(A.Fake<ICommandCollector>());
-      }
-   }
-
-   public class When_changing_a_distributed_sub_parameter_unit : concern_for_IndividualDistributedPathAndValueEntityPresenter
-   {
-      private IndividualParameterDTO _dto;
-      private IndividualBuildingBlock _buildingBlock;
-      private IndividualParameterDTO _subParameter;
-      private Unit _newUnit;
-
-      protected override void Context()
-      {
-         base.Context();
-         _buildingBlock = new IndividualBuildingBlock();
-         _subParameter = new IndividualParameterDTO(new IndividualParameter().WithName(Constants.Distribution.MEAN));
-         _dto = new IndividualParameterDTO(new IndividualParameter());
-         _dto.AddSubParameter(_subParameter);
-         _newUnit = new Unit("new unit", 1.0, 0.0);
-         sut.Edit(_dto, _buildingBlock);
-      }
-
-      protected override void Because()
-      {
-         sut.SetParameterUnit(_subParameter, _newUnit);
-      }
-
-      [Observation]
-      public void should_use_the_interaction_task_to_raise_the_commands()
-      {
-         A.CallTo(() => _interactionTasks.SetUnit(_buildingBlock, _subParameter.PathWithValueObject, _newUnit)).MustHaveHappened();
-      }
-   }
-
-   public class When_changing_a_distributed_sub_parameter_value : concern_for_IndividualDistributedPathAndValueEntityPresenter
-   {
-      private IndividualParameterDTO _dto;
-      private IndividualBuildingBlock _buildingBlock;
-      private IndividualParameterDTO _subParameter;
-
-      protected override void Context()
-      {
-         base.Context();
-         _buildingBlock = new IndividualBuildingBlock();
-         _subParameter = new IndividualParameterDTO(new IndividualParameter().WithName(Constants.Distribution.MEAN));
-         _dto = new IndividualParameterDTO(new IndividualParameter());
-         _dto.AddSubParameter(_subParameter);
-         sut.Edit(_dto, _buildingBlock);
-      }
-
-      protected override void Because()
-      {
-         sut.SetParameterValue(_subParameter, 1.0);
-      }
-
-      [Observation]
-      public void should_use_the_interaction_task_to_raise_the_commands()
-      {
-         A.CallTo(() => _interactionTasks.SetValue(_buildingBlock, 1.0, _subParameter.PathWithValueObject)).MustHaveHappened();
       }
    }
 }

--- a/tests/MoBi.Tests/Presentation/Tasks/InitialConditionsTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InitialConditionsTaskSpecs.cs
@@ -37,6 +37,7 @@ namespace MoBi.Presentation.Tasks
       protected IReactionDimensionRetriever _reactionDimensionRetriever;
       protected IMoleculeResolver _moleculeResolver;
       protected IInteractionTasksForMoleculeBuilder _moleculeBuilderTask;
+      protected IParameterFactory _parameterFactory;
 
       protected override void Context()
       {
@@ -48,12 +49,13 @@ namespace MoBi.Presentation.Tasks
          {
             Module = new Module()
          };
+         _parameterFactory = A.Fake<IParameterFactory>();
          _reactionDimensionRetriever = A.Fake<IReactionDimensionRetriever>();
          _moleculeResolver = A.Fake<IMoleculeResolver>();
          _moleculeBuilderTask = A.Fake<IInteractionTasksForMoleculeBuilder>();
 
          sut = new InitialConditionsTask<InitialConditionsBuildingBlock>(_context, _editTask, A.Fake<IInitialConditionsBuildingBlockExtendManager>(), _cloneManagerForBuildingBlock, A.Fake<IMoBiFormulaTask>(), A.Fake<IMoBiSpatialStructureFactory>(),
-            new ImportedQuantityToInitialConditionMapper(_initialConditionsCreator), new InitialConditionPathTask(A.Fake<IFormulaTask>(), _context.Context), _reactionDimensionRetriever, _initialConditionsCreator, _moleculeResolver);
+            new ImportedQuantityToInitialConditionMapper(_initialConditionsCreator), new InitialConditionPathTask(A.Fake<IFormulaTask>(), _context.Context), _reactionDimensionRetriever, _initialConditionsCreator, _moleculeResolver, _parameterFactory);
       }
    }
 

--- a/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForExpressionProfileBuildingBlockSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForExpressionProfileBuildingBlockSpecs.cs
@@ -29,6 +29,7 @@ namespace MoBi.Presentation.Tasks
       protected IFormula _formula;
       protected IPKSimStarter _pkSimStarter;
       private IContainerTask _containerTask;
+      private IParameterFactory _parameterFactory;
 
       protected override void Context()
       {
@@ -37,8 +38,9 @@ namespace MoBi.Presentation.Tasks
          _interactionTaskContext = A.Fake<IInteractionTaskContext>();
          _pkSimStarter = A.Fake<IPKSimStarter>();
          _containerTask = new ContainerTask(A.Fake<IObjectBaseFactory>(), A.Fake<IEntityPathResolver>(), A.Fake<IObjectPathFactory>());
+         _parameterFactory = A.Fake<IParameterFactory>();
 
-         sut = new InteractionTasksForExpressionProfileBuildingBlock(_interactionTaskContext, _editTask, _formulaTask, _pkSimStarter, _containerTask);
+         sut = new InteractionTasksForExpressionProfileBuildingBlock(_interactionTaskContext, _editTask, _formulaTask, _pkSimStarter, _containerTask, _parameterFactory);
 
          _formula = new ExplicitFormula("y=mx+b");
          _expressionParameter = GetExpressionParameter();

--- a/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForIndividualBuildingBlockSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForIndividualBuildingBlockSpecs.cs
@@ -1,0 +1,115 @@
+﻿using System.Collections.Generic;
+using FakeItEasy;
+using MoBi.Core.Domain.Extensions;
+using MoBi.Core.Domain.Services;
+using MoBi.Presentation.Tasks.Edit;
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Utility.Extensions;
+
+namespace MoBi.Presentation.Tasks
+{
+   internal class concern_for_InteractionTasksForIndividualBuildingBlock : ContextSpecification<InteractionTasksForIndividualBuildingBlock>
+   {
+      protected IInteractionTaskContext _interactionTaskContext;
+      protected IEditTasksForIndividualBuildingBlock _editTasksForIndividualBuildingBlock;
+      protected IMoBiFormulaTask _moBiFormulaTask;
+
+      protected override void Context()
+      {
+         _interactionTaskContext = A.Fake<IInteractionTaskContext>();
+         _editTasksForIndividualBuildingBlock = A.Fake<IEditTasksForIndividualBuildingBlock>();
+         _moBiFormulaTask = A.Fake<IMoBiFormulaTask>();
+         sut = new InteractionTasksForIndividualBuildingBlock(_interactionTaskContext, _editTasksForIndividualBuildingBlock, _moBiFormulaTask);
+      }
+   }
+
+   internal class When_converting_a_distributed_individual_parameter_to_constant_formula : concern_for_InteractionTasksForIndividualBuildingBlock
+   {
+      private IndividualParameter _individualParameter;
+      private IndividualBuildingBlock _individualBuildingBlock;
+      private List<IndividualParameter> _subParameters;
+
+      protected override void Context()
+      {
+         base.Context();
+         _individualParameter = new IndividualParameter
+         {
+            DistributionType = DistributionType.Normal
+         };
+
+         _individualBuildingBlock = new IndividualBuildingBlock();
+
+         _subParameters = new List<IndividualParameter>
+         {
+            new IndividualParameter{Value = 3.0}.WithName(Constants.Distribution.MEAN),
+            new IndividualParameter().WithName(Constants.Distribution.PERCENTILE)
+         };
+
+         _individualBuildingBlock.AddRange(_subParameters);
+      }
+
+      protected override void Because()
+      {
+         sut.ConvertDistributedParameterToConstantParameter(_individualParameter, _individualBuildingBlock, _subParameters);
+      }
+
+      [Observation]
+      public void sub_parameters_should_be_removed_from_the_building_block()
+      {
+         _subParameters.Each(x => _individualBuildingBlock.ShouldNotContain(x));
+      }
+
+      [Observation]
+      public void should_set_the_value_of_the_parameter_to_the_mean()
+      {
+         _individualParameter.Value.ShouldBeEqualTo(3.0);
+      }
+   }
+
+   internal class When_converting_a_distributed_individual_parameter_to_constant_formula_and_the_mean_is_not_found : concern_for_InteractionTasksForIndividualBuildingBlock
+   {
+      private IndividualParameter _individualParameter;
+      private IndividualBuildingBlock _individualBuildingBlock;
+      private List<IndividualParameter> _subParameters;
+
+      protected override void Context()
+      {
+         base.Context();
+         _individualParameter = new IndividualParameter
+         {
+            DistributionType = DistributionType.Normal
+         };
+
+         _individualBuildingBlock = new IndividualBuildingBlock();
+
+         _subParameters = new List<IndividualParameter>
+         {
+            new IndividualParameter().WithName(Constants.Distribution.PERCENTILE)
+         };
+
+         _individualBuildingBlock.AddRange(_subParameters);
+      }
+
+      protected override void Because()
+      {
+         sut.ConvertDistributedParameterToConstantParameter(_individualParameter, _individualBuildingBlock, _subParameters);
+      }
+
+      [Observation]
+      public void should_not_clear_the_distribution_type()
+      {
+         _individualParameter.DistributionType.ShouldBeEqualTo(DistributionType.Normal);
+      }
+
+      [Observation]
+      public void sub_parameters_should_not_be_removed_from_the_building_block()
+      {
+         _subParameters.Each(x => _individualBuildingBlock.ShouldContain(x));
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForIndividualBuildingBlockSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForIndividualBuildingBlockSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using FakeItEasy;
+using FakeItEasy.Core;
 using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Services;
 using MoBi.Presentation.Tasks.Edit;
@@ -9,6 +10,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation.Tasks
@@ -18,13 +20,29 @@ namespace MoBi.Presentation.Tasks
       protected IInteractionTaskContext _interactionTaskContext;
       protected IEditTasksForIndividualBuildingBlock _editTasksForIndividualBuildingBlock;
       protected IMoBiFormulaTask _moBiFormulaTask;
+      protected IParameterFactory _parameterFactory;
 
       protected override void Context()
       {
          _interactionTaskContext = A.Fake<IInteractionTaskContext>();
          _editTasksForIndividualBuildingBlock = A.Fake<IEditTasksForIndividualBuildingBlock>();
          _moBiFormulaTask = A.Fake<IMoBiFormulaTask>();
-         sut = new InteractionTasksForIndividualBuildingBlock(_interactionTaskContext, _editTasksForIndividualBuildingBlock, _moBiFormulaTask);
+         _parameterFactory = A.Fake<IParameterFactory>();
+         sut = new InteractionTasksForIndividualBuildingBlock(_interactionTaskContext, _editTasksForIndividualBuildingBlock, _moBiFormulaTask, _parameterFactory);
+         A.CallTo(() => _parameterFactory.CreateDistributedParameter(A<string>._, A<DistributionType>._, A<double?>._, A<IDimension>._, A<string>._, A<Unit>._)).ReturnsLazily(newDistributedParameterFrom);
+         A.CallTo(() => _parameterFactory.CreateParameter(A<string>._,A<double?>._, A<IDimension>._, A<string>._, A<IFormula>._, A<Unit>._)).ReturnsLazily(newParameterFrom);
+      }
+
+      private IParameter newParameterFrom(IFakeObjectCall fakeObjectCall)
+      {
+         return new Parameter().WithName(fakeObjectCall.GetArgument<string>(0));
+      }
+
+      private IParameter newDistributedParameterFrom(IFakeObjectCall fakeObjectCall)
+      {
+         // We can just use 3 here as we are not creating real distributed formulas that will be calculated
+         var distributedParameter = new DistributedParameter().WithName(fakeObjectCall.GetArgument<string>(0)).WithValue(3);
+         return distributedParameter;
       }
    }
 
@@ -68,48 +86,6 @@ namespace MoBi.Presentation.Tasks
       public void should_set_the_value_of_the_parameter_to_the_mean()
       {
          _individualParameter.Value.ShouldBeEqualTo(3.0);
-      }
-   }
-
-   internal class When_converting_a_distributed_individual_parameter_to_constant_formula_and_the_mean_is_not_found : concern_for_InteractionTasksForIndividualBuildingBlock
-   {
-      private IndividualParameter _individualParameter;
-      private IndividualBuildingBlock _individualBuildingBlock;
-      private List<IndividualParameter> _subParameters;
-
-      protected override void Context()
-      {
-         base.Context();
-         _individualParameter = new IndividualParameter
-         {
-            DistributionType = DistributionType.Normal
-         };
-
-         _individualBuildingBlock = new IndividualBuildingBlock();
-
-         _subParameters = new List<IndividualParameter>
-         {
-            new IndividualParameter().WithName(Constants.Distribution.PERCENTILE)
-         };
-
-         _individualBuildingBlock.AddRange(_subParameters);
-      }
-
-      protected override void Because()
-      {
-         sut.ConvertDistributedParameterToConstantParameter(_individualParameter, _individualBuildingBlock, _subParameters);
-      }
-
-      [Observation]
-      public void should_not_clear_the_distribution_type()
-      {
-         _individualParameter.DistributionType.ShouldBeEqualTo(DistributionType.Normal);
-      }
-
-      [Observation]
-      public void sub_parameters_should_not_be_removed_from_the_building_block()
-      {
-         _subParameters.Each(x => _individualBuildingBlock.ShouldContain(x));
       }
    }
 }

--- a/tests/MoBi.Tests/Presentation/Tasks/ParameterValuesTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/ParameterValuesTaskSpecs.cs
@@ -20,7 +20,6 @@ using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
-using OSPSuite.Core.Services;
 
 namespace MoBi.Presentation.Tasks
 {

--- a/tests/MoBi.Tests/Presentation/Tasks/ParameterValuesTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/ParameterValuesTaskSpecs.cs
@@ -31,6 +31,7 @@ namespace MoBi.Presentation.Tasks
       protected IInteractionTaskContext _context;
       private IEditTasksForBuildingBlock<ParameterValuesBuildingBlock> _editTasks;
       protected IParameterResolver _parameterResolver;
+      private IParameterFactory _parameterFactory;
 
       protected override void Context()
       {
@@ -40,11 +41,11 @@ namespace MoBi.Presentation.Tasks
          _cloneManagerForBuildingBlock = A.Fake<ICloneManagerForBuildingBlock>();
          _parameterValueBuildingBlock = new ParameterValuesBuildingBlock();
          _parameterResolver = A.Fake<IParameterResolver>();
-
+         _parameterFactory = A.Fake<IParameterFactory>();
          sut = new ParameterValuesTask(_context, _editTasks,
             _cloneManagerForBuildingBlock,
             new ImportedQuantityToParameterValueMapper(_parameterValuesCreator), A.Fake<IParameterValueBuildingBlockExtendManager>(),
-            A.Fake<IMoBiFormulaTask>(), A.Fake<IMoBiSpatialStructureFactory>(), new ParameterValuePathTask(A.Fake<IFormulaTask>(), _context.Context), _parameterValuesCreator);
+            A.Fake<IMoBiFormulaTask>(), A.Fake<IMoBiSpatialStructureFactory>(), new ParameterValuePathTask(A.Fake<IFormulaTask>(), _context.Context), _parameterValuesCreator, _parameterFactory);
       }
    }
 


### PR DESCRIPTION
Fixes #1291

# Description
Changing a distributed parameter will now update the parameter so that it no longer has a distribution type or any sub-parameters in the building block.

The value of the parameter will come from the `MEAN` Subparameter.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

When you view a distributed Individual Parameter
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/b524398e-fea5-4c4b-9ea7-4e3c6fdbcbe7)

Click the edit button converts the parameter to a constant value parameter with the value set to whatever the `MEAN` was before. It also removes sub-parameters from the building block.

![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/491a28d1-65ac-43df-9ceb-047f0466b3b7)
This is immediate after pressing edit. You can type a new number.

# Questions (if appropriate):