### PR TITLE
Fixes #1322 UX improvements when refreshing initial conditions

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1587,7 +1587,7 @@ namespace MoBi.Assets
          public static readonly string SelectOrganAndMolecules = "Select an organ and molecules";
          public static readonly string SelectSpatialStructure = "Select a spatial structure";
          public static readonly string ExtendDescription = "<b>The building block will be extended with new values for selected <i>molecules</i> in all physical containers in the selected <i>spatial structure</i></b>";
-         public static readonly string RefreshDescription = "<b>The building block values will be refreshed for selected <i>molecules</i> in all physical containers in the selected <i>spatial structure</i></b>";
+         public static readonly string RefreshDescription = "<b>The initial conditions will be refreshed from the selected <i>molecules</i></b>";
          public static readonly string AddExpressionDescription = "<b>The building block will be extended with expression parameter values for selected <i>molecules</i> in the selected <i>organ</i> </b>";
          public static readonly string AddDefaultCurveForNewSimulations = "Add default curve for new simulations";
          public static readonly string ChangeDefaultCurveForNewSimulations = "Change default curve for new simulations";

--- a/src/MoBi.Presentation/Mappers/SelectMoleculesDTOMapper.cs
+++ b/src/MoBi.Presentation/Mappers/SelectMoleculesDTOMapper.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using Antlr.Runtime.Misc;
+﻿using System;
+using System.Collections.Generic;
 using MoBi.Presentation.DTO;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Utility;

--- a/src/MoBi.Presentation/Presenter/SelectMoleculePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectMoleculePresenter.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-using Antlr.Runtime.Misc;
 using MoBi.Core.Domain.Repository;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExtendablePathAndValueEntity.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExtendablePathAndValueEntity.cs
@@ -285,8 +285,8 @@ namespace MoBi.Presentation.Tasks.Interaction
       private (SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules) selectBuildingBlocksForExtend(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure) => 
          selectBuildingBlocks(x => x.SelectBuildingBlocksForExtend(defaultMolecules, defaultSpatialStructure));
       
-      protected (SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules) SelectBuildingBlocksForRefresh(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure) =>
-         selectBuildingBlocks(x => x.SelectBuildingBlocksForRefresh(defaultMolecules, defaultSpatialStructure));
+      protected (SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules) SelectBuildingBlocksForRefresh(MoleculeBuildingBlock defaultMolecules, SpatialStructure defaultSpatialStructure, IReadOnlyList<string> selectableBuilders) =>
+         selectBuildingBlocks(x => x.SelectMoleculesForRefresh(defaultMolecules, selectableBuilders));
 
       private (SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules) selectBuildingBlocks(Action<ISelectSpatialStructureAndMoleculesPresenter> actionToSelectBuildingBlocks)
       {

--- a/src/MoBi.Presentation/Views/ISelectSpatialStructureAndMoleculesView.cs
+++ b/src/MoBi.Presentation/Views/ISelectSpatialStructureAndMoleculesView.cs
@@ -6,9 +6,10 @@ namespace MoBi.Presentation.Views
 {
    public interface ISelectSpatialStructureAndMoleculesView : IModalView<ISelectSpatialStructureAndMoleculesPresenter>
    {
-      void Show(SelectSpatialStructureDTO dto);
+      void ShowSpatialStructureSelection(SelectSpatialStructureDTO dto);
       void AddMoleculeSelectionView(IView view);
       void MoleculeSelectionChanged();
       void SetDescriptionText(string description);
+      void HideSpatialStructureSelection();
    }
 }

--- a/src/MoBi.UI/Views/SelectSpatialStructureAndMoleculesView.cs
+++ b/src/MoBi.UI/Views/SelectSpatialStructureAndMoleculesView.cs
@@ -1,4 +1,5 @@
 ﻿using DevExpress.Utils;
+using DevExpress.XtraLayout.Utils;
 using MoBi.Assets;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Presenter;
@@ -27,6 +28,11 @@ namespace MoBi.UI.Views
 
       public void SetDescriptionText(string description) => descriptionLabel.Text = description;
 
+      public void HideSpatialStructureSelection()
+      {
+         layoutControlItemSpatialStructure.Visibility = LayoutVisibility.Never;
+      }
+
       public void AttachPresenter(ISelectSpatialStructureAndMoleculesPresenter presenter) => _presenter = presenter;
 
       public override void InitializeBinding()
@@ -50,7 +56,7 @@ namespace MoBi.UI.Views
          Text = AppConstants.Captions.NewWindow(ObjectTypes.MoleculeBuildingBlock);
       }
 
-      public void Show(SelectSpatialStructureDTO dto) => _screenBinder.BindToSource(dto);
+      public void ShowSpatialStructureSelection(SelectSpatialStructureDTO dto) => _screenBinder.BindToSource(dto);
 
       public void AddMoleculeSelectionView(IView view) => moleculeSelectionPanel.FillWith(view);
 

--- a/tests/MoBi.Tests/Presentation/SelectOrganAndProteinsPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectOrganAndProteinsPresenterSpecs.cs
@@ -1,4 +1,4 @@
-﻿using Antlr.Runtime.Misc;
+﻿using System;
 using FakeItEasy;
 using FluentNHibernate.Utils;
 using MoBi.Core.Domain.Model;

--- a/tests/MoBi.Tests/Presentation/SelectSpatialStructureAndMoleculesPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectSpatialStructureAndMoleculesPresenterSpecs.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using FakeItEasy;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Repository;
@@ -116,6 +117,41 @@ namespace MoBi.Presentation
       public void the_selected_spatial_structure_is_still_set()
       {
          sut.SelectedSpatialStructure.ShouldBeNull();
+      }
+   }
+
+   public class When_selecting_molecules_only_for_refresh : concern_for_SelectSpatialStructureAndMoleculesPresenter
+   {
+      private MoleculeBuilder _molecule1;
+      private MoleculeBuilder _molecule2;
+
+      protected override void Context()
+      {
+         base.Context();
+         _molecule1 = new MoleculeBuilder { Name = "Molecule1"};
+         _molecule2 = new MoleculeBuilder { Name = "Molecule2"};
+      }
+
+      protected override void Because()
+      {
+         sut.SelectMoleculesForRefresh(null, new List<string> {_molecule1.Name});
+      }
+
+      [Observation]
+      public void the_view_should_not_show_the_spatial_structure_selection()
+      {
+         A.CallTo(() => _view.HideSpatialStructureSelection()).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_selectable_molecules_should_not_include_molecules_not_in_the_list()
+      {
+         A.CallTo(() => _selectMoleculesPresenter.SelectMolecules(null, A<Func<MoleculeBuilder, bool>>.That.Matches(x => includesOnlyMolecule1(x)))).MustHaveHappened();
+      }
+
+      private bool includesOnlyMolecule1(Func<MoleculeBuilder, bool> canSelect)
+      {
+         return canSelect(_molecule1) && !canSelect(_molecule2);
       }
    }
 }

--- a/tests/MoBi.Tests/Presentation/Tasks/InitialConditionsTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InitialConditionsTaskSpecs.cs
@@ -7,7 +7,6 @@ using MoBi.Core.Domain.Builder;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
 using MoBi.Core.Exceptions;
-using MoBi.Core.Services;
 using MoBi.Helpers;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;
@@ -35,7 +34,6 @@ namespace MoBi.Presentation.Tasks
       private IEditTasksForBuildingBlock<InitialConditionsBuildingBlock> _editTask;
       protected IInteractionTaskContext _context;
       protected IReactionDimensionRetriever _reactionDimensionRetriever;
-      protected IMoleculeResolver _moleculeResolver;
       protected IInteractionTasksForMoleculeBuilder _moleculeBuilderTask;
       protected IParameterFactory _parameterFactory;
 
@@ -51,11 +49,10 @@ namespace MoBi.Presentation.Tasks
          };
          _parameterFactory = A.Fake<IParameterFactory>();
          _reactionDimensionRetriever = A.Fake<IReactionDimensionRetriever>();
-         _moleculeResolver = A.Fake<IMoleculeResolver>();
          _moleculeBuilderTask = A.Fake<IInteractionTasksForMoleculeBuilder>();
 
          sut = new InitialConditionsTask<InitialConditionsBuildingBlock>(_context, _editTask, A.Fake<IInitialConditionsBuildingBlockExtendManager>(), _cloneManagerForBuildingBlock, A.Fake<IMoBiFormulaTask>(), A.Fake<IMoBiSpatialStructureFactory>(),
-            new ImportedQuantityToInitialConditionMapper(_initialConditionsCreator), new InitialConditionPathTask(A.Fake<IFormulaTask>(), _context.Context), _reactionDimensionRetriever, _initialConditionsCreator, _moleculeResolver, _parameterFactory);
+            new ImportedQuantityToInitialConditionMapper(_initialConditionsCreator), new InitialConditionPathTask(A.Fake<IFormulaTask>(), _context.Context), _reactionDimensionRetriever, _initialConditionsCreator, _parameterFactory);
       }
    }
 
@@ -557,7 +554,6 @@ namespace MoBi.Presentation.Tasks
          moleculeBuildingBlock.Add(molecule);
          var nanStartValue = new InitialCondition { Formula = new ConstantFormula(double.NaN), Name = molecule.Name, Value = double.NaN, Dimension = Constants.Dimension.NO_DIMENSION };
          _initialConditionsBuildingBlock.Add(nanStartValue);
-         A.CallTo(_moleculeResolver).WithReturnType<MoleculeBuilder>().Returns(molecule);
       }
 
       protected override void Because()
@@ -586,7 +582,6 @@ namespace MoBi.Presentation.Tasks
          var startValue = new InitialCondition { Name = builder.Name, Value = 45, Dimension = Constants.Dimension.NO_DIMENSION, Formula = null };
          _initialConditionsBuildingBlock.Add(startValue);
          A.CallTo(() => _cloneManagerForBuildingBlock.Clone(builder.DefaultStartFormula, _initialConditionsBuildingBlock.FormulaCache)).Returns(new ExplicitFormula("M/V"));
-         A.CallTo(_moleculeResolver).WithReturnType<MoleculeBuilder>().Returns(builder);
       }
 
       protected override void Because()
@@ -616,7 +611,6 @@ namespace MoBi.Presentation.Tasks
          moleculeBuildingBlock.Add(molecule);
          var nanStartValue = new InitialCondition { Name = molecule.Name, Value = null, Dimension = Constants.Dimension.NO_DIMENSION };
          _initialConditionsBuildingBlock.Add(nanStartValue);
-         A.CallTo(_moleculeResolver).WithReturnType<MoleculeBuilder>().Returns(molecule);
       }
 
       protected override void Because()
@@ -648,7 +642,6 @@ namespace MoBi.Presentation.Tasks
          _nullStartValue = new InitialCondition { Name = molecule.Name, Value = 1, Dimension = Constants.Dimension.NO_DIMENSION };
          _initialConditionsBuildingBlock.Add(_nullStartValue);
          A.CallTo(_context.Context).WithReturnType<MoleculeBuildingBlock>().Returns(moleculeBuildingBlock);
-         A.CallTo(_moleculeResolver).WithReturnType<MoleculeBuilder>().Returns(molecule);
       }
 
       protected override void Because()


### PR DESCRIPTION
Fixes #1322

# Description
See the linked issue. We want to hide the spatial structure selection when extending initial conditions because it is not relevant. We also want only to show the molecules that were selected for refresh in the initial conditions building block.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/f2a5bcd8-19fe-4c84-96fe-dbc7ad819e89)

# Questions (if appropriate):