### PR TITLE
Fixes #1323 Formula duplicated when updating IC BB

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.278" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.278" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.278" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.278" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.278" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Tasks/ObservedDataTask.cs
+++ b/src/MoBi.Presentation/Tasks/ObservedDataTask.cs
@@ -57,7 +57,8 @@ namespace MoBi.Presentation.Tasks
          IContainerTask containerTask,
          IObjectTypeResolver objectTypeResolver,
          IBuildingBlockRepository buildingBlockRepository,
-         IObjectBaseNamingTask namingTask) : base(dialogCreator, context, dataRepositoryTask, containerTask, objectTypeResolver)
+         IObjectBaseNamingTask namingTask,
+         IConfirmationManager confirmationManager) : base(dialogCreator, context, dataRepositoryTask, containerTask, objectTypeResolver, confirmationManager)
       {
          _dataImporter = dataImporter;
          _interactionTask = interactionTask;

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.278" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,13 +71,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.278" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.277" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.278" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.278" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/Tasks/ObservedDataTasksSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/ObservedDataTasksSpecs.cs
@@ -35,6 +35,7 @@ namespace MoBi.Presentation.Tasks
       private IObjectTypeResolver _objectTypeResolver;
       private IBuildingBlockRepository _buildingBlockRepository;
       protected IObjectBaseNamingTask _namingTask;
+      private IConfirmationManager _confirmationManager;
 
       protected override void Context()
       {
@@ -49,7 +50,8 @@ namespace MoBi.Presentation.Tasks
          _objectTypeResolver = A.Fake<IObjectTypeResolver>();
          _buildingBlockRepository = A.Fake<IBuildingBlockRepository>();
          _namingTask = A.Fake<IObjectBaseNamingTask>();
-         sut = new ObservedDataTask(_dataImporter, _context, _dialogCreator, _interactionTask, _dataRepositoryTask, _containerTask, _objectTypeResolver, _buildingBlockRepository, _namingTask);
+         _confirmationManager = A.Fake<IConfirmationManager>();
+         sut = new ObservedDataTask(_dataImporter, _context, _dialogCreator, _interactionTask, _dataRepositoryTask, _containerTask, _objectTypeResolver, _buildingBlockRepository, _namingTask, _confirmationManager);
 
          _project = DomainHelperForSpecs.NewProject();
          A.CallTo(() => _context.Project).Returns(_project);

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.277" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.277" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.278" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.278" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1323 

# Description
The change checks for usages of a formula in the context of an initial conditions refresh. If all usages of the formula will be replaced with a new formula, then remove the existing formula from the building block cache and add the new formula.

If not all are replaced, the both have to be retained. In that case, the formula being added needs to be renamed if the name is the same as one already present in the formula cache.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):