### PR TITLE
Fixes #1299 Show a warning when converting to extension module

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1931,6 +1931,11 @@ namespace MoBi.Assets
             sb.AppendLine(allNames.ToString("\n - "));
             return sb.ToString();
          }
+
+         public static string TheModuleWillBeConvertedFromPKSimToExtensionModule(string moduleName)
+         {
+            return $"The PK-Sim module '{moduleName}' will be converted to an extension module";
+         }
       }
 
       public static class Validation

--- a/src/MoBi.Core/Services/BuildingBlockVersionUpdater.cs
+++ b/src/MoBi.Core/Services/BuildingBlockVersionUpdater.cs
@@ -1,8 +1,10 @@
 ﻿using System.Linq;
+using MoBi.Assets;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Services;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
 
@@ -18,11 +20,13 @@ namespace MoBi.Core.Services
    {
       private readonly IMoBiProjectRetriever _projectRetriever;
       private readonly IEventPublisher _eventPublisher;
+      private readonly IDialogCreator _dialogCreator;
 
-      public BuildingBlockVersionUpdater(IMoBiProjectRetriever projectRetriever, IEventPublisher eventPublisher)
+      public BuildingBlockVersionUpdater(IMoBiProjectRetriever projectRetriever, IEventPublisher eventPublisher, IDialogCreator dialogCreator)
       {
          _projectRetriever = projectRetriever;
          _eventPublisher = eventPublisher;
+         _dialogCreator = dialogCreator;
       }
 
       public void UpdateBuildingBlockVersion(IBuildingBlock buildingBlock, uint newVersion)
@@ -30,9 +34,22 @@ namespace MoBi.Core.Services
          if (buildingBlock == null)
             return;
 
+         if (shouldShowModuleConversionWarning(buildingBlock))
+            showModuleConversionWarning(buildingBlock);
+
          buildingBlock.Version = newVersion;
          publishSimulationStatusChangedEvents(buildingBlock);
          publishModuleStatusChangedEvents(buildingBlock);
+      }
+
+      private void showModuleConversionWarning(IBuildingBlock buildingBlock)
+      {
+         _dialogCreator.MessageBoxInfo(AppConstants.Captions.TheModuleWillBeConvertedFromPKSimToExtensionModule(buildingBlock.Module.Name));
+      }
+
+      private bool shouldShowModuleConversionWarning(IBuildingBlock buildingBlock)
+      {
+         return buildingBlock.Module != null && buildingBlock.Module.IsPKSimModule;
       }
 
       private void publishModuleStatusChangedEvents(IBuildingBlock buildingBlock)


### PR DESCRIPTION
Fixes #1299

# Description
When making any change in a PK-Sim module when the version will be updated, show a dialog to inform the user that the module will not be a PK-Sim module anymore

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/b3c54790-7739-4aac-8b13-e0ba8cdc9f33)


# Questions (if appropriate):