### PR TITLE
#1257 Cancel renaming should also cancel loading exp profiles and individuals

### DIFF
--- a/src/MoBi.Presentation/Tasks/ModuleLoader.cs
+++ b/src/MoBi.Presentation/Tasks/ModuleLoader.cs
@@ -5,6 +5,7 @@ using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Helper;
 using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Serialization.Exchange;
@@ -67,9 +68,10 @@ namespace MoBi.Presentation.Tasks
          var individual = configuration.Individual;
          var expressions = configuration.ExpressionProfiles;
 
-         macroCommand.Add(_moduleTask.AddTo(modules, project));
+         var commandToAdd = _moduleTask.AddTo(modules, project);
+         macroCommand.Add(commandToAdd);
 
-         if (!addAdditionalBuildingBlocksConfirmed(individual, expressions))
+         if (commandToAdd.IsEmpty() || !addAdditionalBuildingBlocksConfirmed(individual, expressions))
             return macroCommand;
 
          macroCommand.Add(_individualTask.AddTo(new[] { individual }, project));


### PR DESCRIPTION
Fixes #1257

# Description
Formerly, if the module rename was canceled during import, the empty command was added to the macrocommand, but it was not tested to check if the follow-up commands for expression or individual import should be attempted.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):