### PR TITLE
Fixes #1307 Automatically create a building block "IC" when creating a new Molecules BB

### DIFF
--- a/src/MoBi.Presentation/DTO/ModuleContentDTO.cs
+++ b/src/MoBi.Presentation/DTO/ModuleContentDTO.cs
@@ -10,7 +10,19 @@ namespace MoBi.Presentation.DTO
       public bool WithPassiveTransport { get; set; }
       public bool WithMolecule { get; set; }
       public bool WithObserver { get; set; }
-      public virtual bool WithInitialConditions { get; set; }
+
+      private bool _withInitialConditions;
+
+      public virtual bool WithInitialConditions
+      {
+         get => _withInitialConditions;
+         set
+         {
+            _withInitialConditions = value;
+            OnPropertyChanged(nameof(WithInitialConditions));
+         }
+      }
+
       public virtual bool WithParameterValues { get; set; }
 
       public bool CanSelectReaction { get; set; } = true;

--- a/src/MoBi.Presentation/DTO/ModuleContentDTO.cs
+++ b/src/MoBi.Presentation/DTO/ModuleContentDTO.cs
@@ -16,11 +16,7 @@ namespace MoBi.Presentation.DTO
       public virtual bool WithInitialConditions
       {
          get => _withInitialConditions;
-         set
-         {
-            _withInitialConditions = value;
-            OnPropertyChanged(nameof(WithInitialConditions));
-         }
+         set => SetProperty(ref _withInitialConditions, value);
       }
 
       public virtual bool WithParameterValues { get; set; }

--- a/src/MoBi.Presentation/Presenter/AddBuildingBlocksToModulePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/AddBuildingBlocksToModulePresenter.cs
@@ -6,22 +6,23 @@ using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Views;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
-using OSPSuite.Presentation.Presenters;
 
 namespace MoBi.Presentation.Presenter
 {
-   public interface IAddBuildingBlocksToModulePresenter : IDisposablePresenter
+   public interface IAddBuildingBlocksToModulePresenter : IAddContentToModulePresenter
    {
       IReadOnlyList<IBuildingBlock> AddBuildingBlocksToModule(Module module);
       IReadOnlyList<IBuildingBlock> AddInitialConditionsToModule(Module module);
       IReadOnlyList<IBuildingBlock> AddParameterValuesToModule(Module module);
    }
 
-   public class AddBuildingBlocksToModulePresenter : AbstractDisposablePresenter<IAddBuildingBlocksToModuleView, IAddBuildingBlocksToModulePresenter>,
+   public class AddBuildingBlocksToModulePresenter : AddContentToModulePresenter<IAddBuildingBlocksToModuleView, IAddBuildingBlocksToModulePresenter>,
       IAddBuildingBlocksToModulePresenter
    {
       private readonly IAddBuildingBlocksToModuleDTOToBuildingBlocksListMapper _addBuildingBlocksToModuleDTOToBuildingBlocksListMapper;
       private readonly IModuleToAddBuildingBlocksToModuleDTOMapper _moduleToAddBuildingBlocksToModuleDTOMapper;
+      private AddBuildingBlocksToModuleDTO _addBuildingBlocksToModuleDTO;
+      private Module _module;
 
       public AddBuildingBlocksToModulePresenter(IAddBuildingBlocksToModuleView view,
          IAddBuildingBlocksToModuleDTOToBuildingBlocksListMapper addBuildingBlocksToModuleDTOToBuildingBlocksListMapper, 
@@ -33,6 +34,7 @@ namespace MoBi.Presentation.Presenter
 
       public IReadOnlyList<IBuildingBlock> AddBuildingBlocksToModule(Module module)
       {
+         _module = module;
          return addBuildingBlocksToModule(module);
       }
 
@@ -40,16 +42,16 @@ namespace MoBi.Presentation.Presenter
       {
          _view.Caption = AppConstants.Captions.AddBuildingBlocksToModule(module.Name);
 
-         var addBuildingBlocksToModuleDTO = _moduleToAddBuildingBlocksToModuleDTOMapper.MapFrom(module);
-         configureDTOAction?.Invoke(addBuildingBlocksToModuleDTO);
+         _addBuildingBlocksToModuleDTO = _moduleToAddBuildingBlocksToModuleDTOMapper.MapFrom(module);
+         configureDTOAction?.Invoke(_addBuildingBlocksToModuleDTO);
 
-         _view.BindTo(addBuildingBlocksToModuleDTO);
+         _view.BindTo(_addBuildingBlocksToModuleDTO);
          _view.Display();
 
          if (_view.Canceled)
             return new List<IBuildingBlock>();
 
-         return _addBuildingBlocksToModuleDTOToBuildingBlocksListMapper.MapFrom(addBuildingBlocksToModuleDTO);
+         return _addBuildingBlocksToModuleDTOToBuildingBlocksListMapper.MapFrom(_addBuildingBlocksToModuleDTO);
       }
 
       public IReadOnlyList<IBuildingBlock> AddParameterValuesToModule(Module module)
@@ -61,5 +63,8 @@ namespace MoBi.Presentation.Presenter
       {
          return addBuildingBlocksToModule(module, dto => dto.AllowOnlyInitialConditions = true);
       }
+
+      protected override Module Module => _module;
+      protected override ModuleContentDTO ContentDTO => _addBuildingBlocksToModuleDTO;
    }
 }

--- a/src/MoBi.Presentation/Presenter/AddContentToModulePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/AddContentToModulePresenter.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Views;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.Presenters;
+
+namespace MoBi.Presentation.Presenter
+{
+   public interface IAddContentToModulePresenter : IDisposablePresenter
+   {
+      void AddMoleculesSelectionChanged(bool moleculesSelected);
+   }
+
+   public abstract class AddContentToModulePresenter<TView, TPresenter> : AbstractDisposablePresenter<TView, TPresenter>, IAddContentToModulePresenter where TView : IAddContentToModuleView<TPresenter> where TPresenter : IAddContentToModulePresenter
+   {
+      protected AddContentToModulePresenter(TView view) : base(view)
+      {
+      }
+
+      protected abstract Module Module { get; }
+      protected abstract ModuleContentDTO ContentDTO { get; }
+
+      public void AddMoleculesSelectionChanged(bool moleculesSelected)
+      {
+         if (!moleculesSelected || Module.InitialConditionsCollection.Any())
+            return;
+
+         ContentDTO.WithInitialConditions = true;
+         _view.ShowInitialConditionsName();
+      }
+   }
+}

--- a/src/MoBi.Presentation/Presenter/CreateModulePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/CreateModulePresenter.cs
@@ -4,20 +4,21 @@ using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Views;
 using OSPSuite.Core.Domain;
-using OSPSuite.Presentation.Presenters;
 
 namespace MoBi.Presentation.Presenter
 {
   
-   public interface ICreateModulePresenter : IDisposablePresenter
+   public interface ICreateModulePresenter : IAddContentToModulePresenter
    {
       Module CreateModule();
    }
 
-   public class CreateModulePresenter : AbstractDisposablePresenter<ICreateModuleView, ICreateModulePresenter>, ICreateModulePresenter
+   public class CreateModulePresenter : AddContentToModulePresenter<ICreateModuleView, ICreateModulePresenter>, ICreateModulePresenter
    {
       private readonly IMoBiContext _context;
       private readonly ICreateModuleDTOToModuleMapper _createModuleDTOToModuleMapper;
+      private Module _module;
+      private ModuleContentDTO _createModuleDTO;
 
       public CreateModulePresenter(ICreateModuleView view, IMoBiContext context, ICreateModuleDTOToModuleMapper createModuleDTOToModuleMapper) : base(view)
       {
@@ -27,15 +28,18 @@ namespace MoBi.Presentation.Presenter
 
       public Module CreateModule()
       {
-         var module = _context.Create<Module>();
-         _view.Caption = AppConstants.Captions.NewWindow(_context.TypeFor(module));
+         _module = _context.Create<Module>();
+         _view.Caption = AppConstants.Captions.NewWindow(_context.TypeFor(_module));
 
-         var createModuleDTO = new ModuleContentDTO();
-         createModuleDTO.AddUsedNames(_context.CurrentProject.Modules.AllNames());
-         _view.BindTo(createModuleDTO);
+         _createModuleDTO = new ModuleContentDTO();
+         _createModuleDTO.AddUsedNames(_context.CurrentProject.Modules.AllNames());
+         _view.BindTo(_createModuleDTO);
          _view.Display();
          
-         return _view.Canceled ? null : _createModuleDTOToModuleMapper.MapFrom(createModuleDTO);
+         return _view.Canceled ? null : _createModuleDTOToModuleMapper.MapFrom(_createModuleDTO);
       }
+
+      protected override Module Module => _module;
+      protected override ModuleContentDTO ContentDTO => _createModuleDTO;
    }
 }

--- a/src/MoBi.Presentation/Views/IAddBuildingBlocksToModuleView.cs
+++ b/src/MoBi.Presentation/Views/IAddBuildingBlocksToModuleView.cs
@@ -4,7 +4,12 @@ using OSPSuite.Presentation.Views;
 
 namespace MoBi.Presentation.Views
 {
-   public interface IAddBuildingBlocksToModuleView : IModalView<IAddBuildingBlocksToModulePresenter>
+   public interface IAddContentToModuleView<TPresenter> : IModalView<TPresenter> where TPresenter : IAddContentToModulePresenter
+   {
+      void ShowInitialConditionsName();
+   }
+
+   public interface IAddBuildingBlocksToModuleView : IAddContentToModuleView<IAddBuildingBlocksToModulePresenter>
    {
       void BindTo(AddBuildingBlocksToModuleDTO moduleContentDTO);
    }

--- a/src/MoBi.Presentation/Views/ICreateModuleView.cs
+++ b/src/MoBi.Presentation/Views/ICreateModuleView.cs
@@ -4,7 +4,7 @@ using OSPSuite.Presentation.Views;
 
 namespace MoBi.Presentation.Views
 {
-   public interface ICreateModuleView : IModalView<ICreateModulePresenter>   
+   public interface ICreateModuleView : IAddContentToModuleView<ICreateModulePresenter>   
    {
       void BindTo(ModuleContentDTO createModuleDTO);
    }

--- a/src/MoBi.UI/Views/AddBuildingBlocksToModuleView.cs
+++ b/src/MoBi.UI/Views/AddBuildingBlocksToModuleView.cs
@@ -11,7 +11,7 @@ using OSPSuite.Utility.Extensions;
 
 namespace MoBi.UI.Views
 {
-   public class AddBuildingBlocksToModuleView : BaseModuleContentView<AddBuildingBlocksToModuleDTO>,
+   public class AddBuildingBlocksToModuleView : AddContentToModuleView<AddBuildingBlocksToModuleDTO, IAddBuildingBlocksToModulePresenter>,
       IAddBuildingBlocksToModuleView
    {
       public override void InitializeResources()
@@ -36,13 +36,9 @@ namespace MoBi.UI.Views
             adjustViewForOnlyParameterValues();
       }
 
-      protected override void StartValueCheckChanged(bool enabled, LayoutControlItem namingLayoutControlItem)
+      protected override void ShowOrHideNamingItem(LayoutControlItem namingLayoutControlItem, bool show)
       {
-         namingLayoutControlItem.Visibility = LayoutVisibilityConvertor.FromBoolean(enabled);
-      }
-
-      public void AttachPresenter(IAddBuildingBlocksToModulePresenter presenter)
-      {
+         namingLayoutControlItem.Visibility = LayoutVisibilityConvertor.FromBoolean(show);
       }
 
       public void adjustViewForOnlyParameterValues()
@@ -83,11 +79,9 @@ namespace MoBi.UI.Views
       }
    }
 
-   public class CreateModuleView : BaseModuleContentView<ModuleContentDTO>, ICreateModuleView
+   public class CreateModuleView : AddContentToModuleView<ModuleContentDTO, ICreateModulePresenter>, ICreateModuleView
    {
-      public void AttachPresenter(ICreateModulePresenter presenter)
-      {
-      }
+
    }
 
    public class CloneBuildingBlocksToModuleView : BaseModuleContentView<CloneBuildingBlocksToModuleDTO>,

--- a/src/MoBi.UI/Views/AddContentToModuleView.cs
+++ b/src/MoBi.UI/Views/AddContentToModuleView.cs
@@ -1,0 +1,32 @@
+﻿using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+
+namespace MoBi.UI.Views
+{
+   public abstract class AddContentToModuleView<TDTO, TPresenter> : BaseModuleContentView<TDTO>, IAddContentToModuleView<TPresenter> where TDTO : ModuleContentDTO where TPresenter : IAddContentToModulePresenter
+   {
+      protected TPresenter _presenter;
+
+      public void AttachPresenter(TPresenter presenter)
+      {
+         _presenter = presenter;
+      }
+
+      public void ShowInitialConditionsName()
+      {
+         ShowOrHideNamingItem(initialConditionsNameItem, true);
+      }
+
+      public override void InitializeResources()
+      {
+         base.InitializeResources();
+         cbMolecules.CheckedChanged += (o, e) => OnEvent(moleculesChanged);
+      }
+
+      private void moleculesChanged()
+      {
+         _presenter.AddMoleculesSelectionChanged(cbMolecules.Checked);
+      }
+   }
+}

--- a/src/MoBi.UI/Views/BaseModuleContentView.cs
+++ b/src/MoBi.UI/Views/BaseModuleContentView.cs
@@ -44,8 +44,8 @@ namespace MoBi.UI.Views
          initialConditionsNameItem.Text = AppConstants.Captions.Name.FormatForLabel();
          parameterValuesNameItem.Text = AppConstants.Captions.Name.FormatForLabel();
 
-         StartValueCheckChanged(cbInitialConditions.Checked, initialConditionsNameItem);
-         StartValueCheckChanged(cbParameterValues.Checked, parameterValuesNameItem);
+         ShowOrHideNamingItem(initialConditionsNameItem, show: cbInitialConditions.Checked);
+         ShowOrHideNamingItem(parameterValuesNameItem, show: cbParameterValues.Checked);
       }
 
       protected void ShowStartValueNameControls()
@@ -69,13 +69,13 @@ namespace MoBi.UI.Views
          _screenBinder.Bind(dto => dto.WithObserver).To(cbObservers);
          _screenBinder.Bind(dto => dto.WithPassiveTransport).To(cbPassiveTransports);
          _screenBinder.Bind(dto => dto.WithReaction).To(cbReactions);
-         _screenBinder.Bind(dto => dto.WithParameterValues).To(cbParameterValues).OnValueUpdated += (o, e) => OnEvent(() => StartValueCheckChanged(e, parameterValuesNameItem));
-         _screenBinder.Bind(dto => dto.WithInitialConditions).To(cbInitialConditions).OnValueUpdated += (o, e) => OnEvent(() => StartValueCheckChanged(e, initialConditionsNameItem));
+         _screenBinder.Bind(dto => dto.WithParameterValues).To(cbParameterValues).OnValueUpdated += (o, newValue) => OnEvent(() => ShowOrHideNamingItem(parameterValuesNameItem, show: newValue));
+         _screenBinder.Bind(dto => dto.WithInitialConditions).To(cbInitialConditions).OnValueUpdated += (o, newValue) => OnEvent(() => ShowOrHideNamingItem(initialConditionsNameItem, show: newValue));
 
          RegisterValidationFor(_screenBinder);
       }
 
-      protected virtual void StartValueCheckChanged(bool enabled, LayoutControlItem namingLayoutControlItem)
+      protected virtual void ShowOrHideNamingItem(LayoutControlItem namingLayoutControlItem, bool show)
       {
          namingLayoutControlItem.Visibility = LayoutVisibility.Never;
       }

--- a/tests/MoBi.Tests/Presentation/AddBuildingBlocksToModulePresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/AddBuildingBlocksToModulePresenterSpecs.cs
@@ -19,7 +19,7 @@ namespace MoBi.Presentation
       protected MoBiProject _project;
       protected Module _existingModule;
       protected IReadOnlyList<IBuildingBlock> _listOfNewBuildingBlocks;
-      private IModuleToAddBuildingBlocksToModuleDTOMapper _moduleToDTOMapper;
+      protected IModuleToAddBuildingBlocksToModuleDTOMapper _moduleToDTOMapper;
 
       protected override void Context()
       {
@@ -35,6 +35,67 @@ namespace MoBi.Presentation
             new ReactionBuildingBlock()
          };
          sut = new AddBuildingBlocksToModulePresenter(_view, _dtoToBuildingBlocksMapper, _moduleToDTOMapper);
+      }
+   }
+
+   public class When_adding_molecules_to_a_building_block_with_initial_conditions : concern_for_AddBuildingBlocksToModulePresenter
+   {
+      private AddBuildingBlocksToModuleDTO _dto;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dto = new AddBuildingBlocksToModuleDTO(_existingModule);
+         _existingModule.Add(new InitialConditionsBuildingBlock());
+         A.CallTo(() => _moduleToDTOMapper.MapFrom(_existingModule)).Returns(_dto);
+         sut.AddBuildingBlocksToModule(_existingModule);
+      }
+
+      protected override void Because()
+      {
+         sut.AddMoleculesSelectionChanged(true);
+      }
+
+      [Observation]
+      public void the_building_module_dto_should_not_be_updated()
+      {
+         _dto.WithInitialConditions.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void the_view_should_not_be_updated_to_show_the_initial_condition_naming()
+      {
+         A.CallTo(() => _view.ShowInitialConditionsName()).MustNotHaveHappened();
+      }
+   }
+
+   public class When_adding_molecules_to_a_building_block_without_initial_conditions : concern_for_AddBuildingBlocksToModulePresenter
+   {
+      private AddBuildingBlocksToModuleDTO _dto;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dto = new AddBuildingBlocksToModuleDTO(_existingModule);
+         A.CallTo(() => _moduleToDTOMapper.MapFrom(_existingModule)).Returns(_dto);
+         sut.AddBuildingBlocksToModule(_existingModule);
+      }
+
+      protected override void Because()
+      {
+         sut.AddMoleculesSelectionChanged(true);
+      }
+
+      [Observation]
+      public void the_module_dto_should_be_updated()
+      {
+         _dto.WithInitialConditions.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void the_view_should_be_updated_to_show_the_initial_condition_naming()
+      {
+         A.CallTo(() => _view.ShowInitialConditionsName()).MustHaveHappened();
       }
    }
 

--- a/tests/MoBi.Tests/Presentation/CreateModulePresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/CreateModulePresenterSpecs.cs
@@ -8,13 +8,14 @@ using MoBi.Presentation.Views;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
 
 namespace MoBi.Presentation
 {
    public class concern_for_CreateModulePresenter : ContextSpecification<CreateModulePresenter>
    {
       protected ICreateModuleDTOToModuleMapper _mapper;
-      private IMoBiContext _context;
+      protected IMoBiContext _context;
       protected ICreateModuleView _view;
       protected MoBiProject _project;
 


### PR DESCRIPTION
Fixes #1307

# Description
When the user selects the molecules checkbox when creating a module, or when adding molecules to an existing module the checkbox for initial conditions will be automatically selected

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):