### PR TITLE
Fixes #1261 Clone simulation - weird "Rename" dialogue

### DIFF
--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTask.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTask.cs
@@ -28,7 +28,7 @@ namespace MoBi.Presentation.Tasks.Interaction
       string AskForFileToSave(string title, string filter, string directoryKey, string defaultName);
       string AskForFolder(string title, string directoryKey);
       T LoadTransfer<T>(string filePath);
-      string PromptForNewName(IObjectBase objectBase, IEnumerable<string> forbiddenNames);
+      string PromptForNewName<T>(T objectBase, IEnumerable<string> forbiddenNames) where T : IObjectBase;
    }
 
    public class InteractionTask : IInteractionTask
@@ -123,6 +123,6 @@ namespace MoBi.Presentation.Tasks.Interaction
 
       public bool CorrectName<T>(T objectBase, IEnumerable<string> forbiddenNames) where T : IObjectBase => _nameCorrector.CorrectName(forbiddenNames, objectBase);
 
-      public string PromptForNewName(IObjectBase objectBase, IEnumerable<string> forbiddenNames) => _nameCorrector.PromptForCorrectName(forbiddenNames.ToList(), objectBase);
+      public string PromptForNewName<T>(T objectBase, IEnumerable<string> forbiddenNames) where T : IObjectBase => _nameCorrector.PromptForCorrectName(forbiddenNames.ToList(), objectBase);
    }
 }

--- a/tests/MoBi.Tests/Presentation/InteractionTasksForSimulationSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/InteractionTasksForSimulationSpecs.cs
@@ -109,7 +109,7 @@ namespace MoBi.Presentation
             Configuration = new SimulationConfiguration()
          };
 
-         A.CallTo(() => _interactionTaskContext.InteractionTask.PromptForNewName(A<IObjectBase>._, A<IEnumerable<string>>._)).Returns("new name");
+         A.CallTo(() => _interactionTaskContext.InteractionTask.PromptForNewName(A<IMoBiSimulation>._, A<IEnumerable<string>>._)).Returns("new name");
          A.CallTo(() => _cloneManager.CloneSimulation(_originalSimulation)).Returns(_clonedSimulation);
          A.CallTo(() => _interactionTaskContext.Context.CurrentProject).Returns(_moBiProject);
       }


### PR DESCRIPTION
Fixes #1261

# Description
Formerly this clone for simulation would decode the object type as IObjectBase which would then use "i object base" in the prompt. This changes the type argument in the interaction task so the object type can be decoded properly

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):