### PR TITLE
Fixes #1258 Load simulation twice does not work properly?

### DIFF
--- a/src/MoBi.Presentation/Tasks/ModuleLoader.cs
+++ b/src/MoBi.Presentation/Tasks/ModuleLoader.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
+using MoBi.Core.Domain.Services;
 using MoBi.Core.Helper;
 using MoBi.Presentation.Tasks.Interaction;
 using OSPSuite.Core.Commands.Core;
@@ -25,13 +26,19 @@ namespace MoBi.Presentation.Tasks
       private readonly IInteractionTasksForExpressionProfileBuildingBlock _expressionTask;
       private readonly IInteractionTasksForIndividualBuildingBlock _individualTask;
       private readonly IInteractionTaskContext _interactionTaskContext;
+      private readonly ICloneManagerForSimulation _cloneManager;
 
-      public ModuleLoader(IInteractionTasksForModule moduleTask, IInteractionTasksForExpressionProfileBuildingBlock expressionTask, IInteractionTasksForIndividualBuildingBlock individualTask, IInteractionTaskContext interactionTaskContext)
+      public ModuleLoader(IInteractionTasksForModule moduleTask, 
+         IInteractionTasksForExpressionProfileBuildingBlock expressionTask, 
+         IInteractionTasksForIndividualBuildingBlock individualTask, 
+         IInteractionTaskContext interactionTaskContext,
+         ICloneManagerForSimulation cloneManager)
       {
          _moduleTask = moduleTask;
          _expressionTask = expressionTask;
          _individualTask = individualTask;
          _interactionTaskContext = interactionTaskContext;
+         _cloneManager = cloneManager;
       }
 
       public IMoBiCommand LoadModule(MoBiProject project)
@@ -55,7 +62,10 @@ namespace MoBi.Presentation.Tasks
 
       private IMoBiCommand addFromSimulationTransfer(MoBiProject project, string filename)
       {
-         var configuration = _interactionTaskContext.InteractionTask.LoadTransfer<SimulationTransfer>(filename).Simulation.Configuration;
+         var simulation = _interactionTaskContext.InteractionTask.LoadTransfer<SimulationTransfer>(filename).Simulation;
+
+         // Clone the simulation configuration so that any loaded objects will have unique Ids.
+         var configuration = _cloneManager.CloneSimulationConfiguration(simulation.Configuration);
 
          var macroCommand = new MoBiMacroCommand
          {


### PR DESCRIPTION
Fixes #1258

# Description
Due to not cloning the incoming simulation transfer, the module was loaded twice with the same Id

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):