### PR TITLE
Fixes #1269 When importing containers with additional parameter values, allow user to select target for parameter values

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -260,6 +260,7 @@ namespace MoBi.Assets
          public static readonly string UpdateProjectDefaultSimulationSettings = "Update project default simulation settings";
          public static readonly string RemoveTrackedQuantityChanges = "Remove tracked quantity changes";
          public static readonly string AddedMultipleBuildingBlocksFromFile = "Added multiple building blocks from file";
+         public static readonly string AddOrReplaceCommand = "Add or replace";
 
          public static string ConvertDistributedPathAndValueEntityToConstantValue(string type, string path) => $"Convert distributed {type} '{path}' to constant value";
 
@@ -804,6 +805,11 @@ namespace MoBi.Assets
          {
             return $"Changed the simulation configuration of simulation '{simulationName}'";
          }
+
+         public static string AddOrReplaceParameterValuesToBuildingBlock(string buildingBlockName)
+         {
+            return $"Add or replace multiple parameter values to '{buildingBlockName}'";
+         }
       }
 
       public static class BarNames
@@ -860,6 +866,7 @@ namespace MoBi.Assets
          public static readonly string ApplyDefaultNaming = "Apply default renaming";
          public static readonly string RemoveSelectedResultsFromSimulations = "Do you really want to remove the selected results from simulations";
          public static readonly string RemoveSelectedResultsFromProject = "Do you really want to remove the selected result(s) from the project";
+         public static Size SelectSingleSize = new Size(475, 160);
 
          public static string RemoveSimulationsFromProject(string projectName)
          {
@@ -1593,6 +1600,9 @@ namespace MoBi.Assets
          public static readonly string AddExpressionDescription = "<b>The building block will be extended with expression parameter values for selected <i>molecules</i> in the selected <i>organ</i> </b>";
          public static readonly string AddDefaultCurveForNewSimulations = "Add default curve for new simulations";
          public static readonly string ChangeDefaultCurveForNewSimulations = "Change default curve for new simulations";
+         public static readonly string SelectTheBuildingBlockWhereParameterValuesWillBeAdded = "Select the building block where parameter values will be added";
+         public static readonly string SelectParameterValuesBuildingBlock = "Select Parameter Values Building Block";
+         public static readonly string NewParameterValuesBuildingBlock = "New Parameter Values Building Block";
          public static string SelectEntitiesThatWillBeReplaced(string entityType) => $"Select {entityType.Pluralize()} that will be replaced";
          public static string SelectEntitiesThatWillBeReplacedDescription(string entityType, string buildingBlockName) => $"<b>Selected <i>{entityType.Pluralize()}</i> will replace existing <i>{entityType.Pluralize()}</i> in the building block <i>{buildingBlockName}</i></b>";
          public static string ExportContainerDescription(string exportedContainerPath) => $"<b>Select a <i>file path</i> and optional <i>individual</i> and <i>expression profiles</i> for container export. Parameters from the <i>individual</i> and <i>expression profiles</i> that match the path {exportedContainerPath} will be added to the container before exporting.</b>";

--- a/src/MoBi.Core/Commands/PathAndValueEntityValueOrUnitChangedCommand.cs
+++ b/src/MoBi.Core/Commands/PathAndValueEntityValueOrUnitChangedCommand.cs
@@ -45,7 +45,7 @@ namespace MoBi.Core.Commands
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
       {
-         return new PathAndValueEntityValueOrUnitChangedCommandWithDistribution<TBuilder, TBuildingBlock>(_builder, _oldBaseValue, _oldDisplayUnit, _buildingBlock, _oldDistributionType).AsInverseFor(this);
+         return new PathAndValueEntityValueOrUnitChangedCommandWithDistribution(_builder, _oldBaseValue, _oldDisplayUnit, _buildingBlock, _oldDistributionType).AsInverseFor(this);
       }
 
       protected override void ClearReferences()
@@ -69,8 +69,8 @@ namespace MoBi.Core.Commands
       }
 
       // This command is used to restore a distribution when a distributed parameter is changed to non-distributed, and then the command is reversed.
-      // There is no general way to change between distribution types, so this class is private so it can only be used with restore functionality
-      private class PathAndValueEntityValueOrUnitChangedCommandWithDistribution<TBuilder, TBuildingBlock> : PathAndValueEntityValueOrUnitChangedCommand<TBuilder, TBuildingBlock> where TBuilder : PathAndValueEntity where TBuildingBlock : class, IBuildingBlock<TBuilder>
+      // There is no general way to change between distribution types, so this class is private, so it can only be used with restore functionality
+      private class PathAndValueEntityValueOrUnitChangedCommandWithDistribution : PathAndValueEntityValueOrUnitChangedCommand<TBuilder, TBuildingBlock>
       {
          private readonly DistributionType? _newDistributionType;
 

--- a/src/MoBi.Presentation/DTO/NullPathAndValueEntityBuildingBlocks.cs
+++ b/src/MoBi.Presentation/DTO/NullPathAndValueEntityBuildingBlocks.cs
@@ -8,5 +8,6 @@ namespace MoBi.Presentation.DTO
    {
       public static InitialConditionsBuildingBlock NullInitialConditions { get; } = new InitialConditionsBuildingBlock().WithName(AppConstants.Captions.NoInitialConditions);
       public static ParameterValuesBuildingBlock NullParameterValues { get; } = new ParameterValuesBuildingBlock().WithName(AppConstants.Captions.NoParameterValues);
+      public static ParameterValuesBuildingBlock NewParameterValues { get; } = new ParameterValuesBuildingBlock().WithName(AppConstants.Captions.NewParameterValuesBuildingBlock);
    }
 }

--- a/src/MoBi.Presentation/ModalPresenter.cs
+++ b/src/MoBi.Presentation/ModalPresenter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Drawing;
 using OSPSuite.Utility.Events;
 using MoBi.Presentation.Views;
 using OSPSuite.Presentation.Presenters;
@@ -11,12 +12,25 @@ namespace MoBi.Presentation
       bool Show();
       string Text { get; set; }
       IPresenter SubPresenter { get; }
+      bool CanCancel { get; set; }
+      bool Show(Size modalSize);
    }
 
    internal class ModalPresenter : AbstractDisposablePresenter<IContainerModalView, IModalPresenter>, IModalPresenter
    {
       private readonly IEventPublisher _eventPublisher;
       public IPresenter SubPresenter { get; protected set; }
+
+      public bool CanCancel
+      {
+         get => _view.CancelVisible;
+         set => _view.CancelVisible = value;
+      }
+
+      public bool Show(Size modalSize)
+      {
+         return _view.Show(modalSize);
+      }
 
       public ModalPresenter(IContainerModalView view, IEventPublisher eventPublisher) : base(view)
       {

--- a/src/MoBi.Presentation/PresentationRegister.cs
+++ b/src/MoBi.Presentation/PresentationRegister.cs
@@ -101,11 +101,11 @@ namespace MoBi.Presentation
          registerDiagramPresenter(container);
 
          //selection presenter
-         container.Register<ISelectionPresenter<XElement>, SelectXmlElementPresenter>();
          container.Register(typeof(IDescriptorConditionListPresenter<>), typeof(DescriptorConditionListPresenter<>));
          container.Register<ISelectManyPresenter<XElement>, SelectXmlElementPresenter>();
-         container.Register<ISelectManyPresenter<OSPSuite.Core.Domain.IContainer>, SelectObjectBasePresenter<OSPSuite.Core.Domain.IContainer>>();
-         container.Register<ISelectManyPresenter<EventGroupBuilder>, SelectObjectBasePresenter<EventGroupBuilder>>();
+         container.Register<ISelectManyPresenter<OSPSuite.Core.Domain.IContainer>, SelectManyObjectBasePresenter<OSPSuite.Core.Domain.IContainer>>();
+         container.Register<ISelectManyPresenter<EventGroupBuilder>, SelectManyObjectBasePresenter<EventGroupBuilder>>();
+         container.Register<ISelectSinglePresenter<ParameterValuesBuildingBlock>, SelectSingleObjectBasePresenter<ParameterValuesBuildingBlock>>();
 
          container.Register<ISettingsPersistor<IUserSettings>, UserSettingsPersistor>();
          container.Register<ISettingsPersistor<IApplicationSettings>, ApplicationSettingsPersistor>();

--- a/src/MoBi.Presentation/Presenter/SelectManyObjectBasePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectManyObjectBasePresenter.cs
@@ -1,0 +1,18 @@
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Views;
+using OSPSuite.Core.Domain;
+
+namespace MoBi.Presentation.Presenter
+{
+   public class SelectManyObjectBasePresenter<T> : SelectManyPresenter<T> where T : IObjectBase
+   {
+      public SelectManyObjectBasePresenter(ISelectManyView<T> view, IItemToListItemMapper<T> mapper) : base(view, mapper)
+      {
+      }
+
+      public override string GetName(T item)
+      {
+         return item.Name;
+      }
+   }
+}

--- a/src/MoBi.Presentation/Presenter/SelectManyPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectManyPresenter.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Views;
+using OSPSuite.Presentation.Presenters;
+
+namespace MoBi.Presentation.Presenter
+{
+   public interface ISelectManyPresenter<T> : IInitializablePresenter<IEnumerable<T>>, IPresenter<ISelectManyView<T>>
+   {
+      IEnumerable<T> Selections { get; }
+      string GetName(T item);
+   }
+
+   public abstract class SelectManyPresenter<T> : SelectionPresenter<ISelectManyView<T>, ISelectManyPresenter<T>, T>, ISelectManyPresenter<T>
+   {
+      protected SelectManyPresenter(ISelectManyView<T> view, IItemToListItemMapper<T> itemToListItemMapper)
+         : base(view, itemToListItemMapper)
+      {
+
+      }
+
+      protected override IEnumerable<ListItemDTO<T>> MapAllItems()
+      {
+         return base.MapAllItems().OrderBy(x => x.DisplayName);
+      }
+
+      public IEnumerable<T> Selections
+      {
+         get { return _view.Selections.Select(x => x.Item); }
+      }
+   }
+}

--- a/src/MoBi.Presentation/Presenter/SelectSingleObjectBasePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectSingleObjectBasePresenter.cs
@@ -1,0 +1,18 @@
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Views;
+using OSPSuite.Core.Domain;
+
+namespace MoBi.Presentation.Presenter
+{
+   public class SelectSingleObjectBasePresenter<T> : SelectSinglePresenter<T> where T : IObjectBase
+   {
+      public SelectSingleObjectBasePresenter(ISelectSingleView<T> view, IItemToListItemMapper<T> mapper) : base(view, mapper)
+      {
+      }
+
+      public override string GetName(T item)
+      {
+         return item.Name;
+      }
+   }
+}

--- a/src/MoBi.Presentation/Presenter/SelectSinglePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectSinglePresenter.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Views;
+using OSPSuite.Presentation.Presenters;
+
+namespace MoBi.Presentation.Presenter
+{
+   public interface ISelectSinglePresenter<T> : IInitializablePresenter<IEnumerable<T>>, IPresenter<ISelectSingleView<T>>
+   {
+      T Selection { get; }
+      void SetDescription(string description);
+   }
+
+   public abstract class SelectSinglePresenter<T> : SelectionPresenter<ISelectSingleView<T>, ISelectSinglePresenter<T>, T>, ISelectSinglePresenter<T>
+   {
+      protected SelectSinglePresenter(ISelectSingleView<T> view, IItemToListItemMapper<T> itemToListItemMapper) : base(view, itemToListItemMapper)
+      {
+      }
+
+      public T Selection => _view.Selection.Item;
+
+      public void SetDescription(string description)
+      {
+         _view.SetDescription(description);
+      }
+   }
+}

--- a/src/MoBi.Presentation/Presenter/SelectXMLElementPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectXMLElementPresenter.cs
@@ -1,49 +1,12 @@
-using System.Collections.Generic;
-using System.Linq;
 using System.Xml.Linq;
 using MoBi.Assets;
-using OSPSuite.Serializer.Xml.Extensions;
-using OSPSuite.Utility.Extensions;
 using MoBi.Core.Exceptions;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Views;
-using OSPSuite.Core.Domain;
-using OSPSuite.Presentation.Presenters;
+using OSPSuite.Serializer.Xml.Extensions;
 
 namespace MoBi.Presentation.Presenter
 {
-   public interface ISelectManyPresenter<T> : IInitializablePresenter<IEnumerable<T>>, IPresenter<ISelectManyView<T>>
-   {
-      IEnumerable<T> Selections { get; }
-      string GetName(T item);
-   }
-
-   public abstract class SelectManyPresenter<T> : AbstractPresenter<ISelectManyView<T>, ISelectManyPresenter<T>>, ISelectManyPresenter<T>
-   {
-      private readonly IItemToListItemMapper<T> _itemToListItemMapper;
-      private IEnumerable<T> _allItems;
-
-      protected SelectManyPresenter(ISelectManyView<T> view, IItemToListItemMapper<T> itemToListItemMapper)
-         : base(view)
-      {
-         _itemToListItemMapper = itemToListItemMapper;
-         _itemToListItemMapper.Initialize(GetName);
-      }
-
-      public void InitializeWith(IEnumerable<T> allItems)
-      {
-         _allItems = allItems;
-         _view.InitializeWith(_allItems.MapAllUsing(_itemToListItemMapper).OrderBy(x => x.DisplayName));
-      }
-
-      public IEnumerable<T> Selections
-      {
-         get { return _view.Selections.Select(x => x.Item); }
-      }
-
-      public abstract string GetName(T item);
-   }
-
    public class SelectXmlElementPresenter : SelectManyPresenter<XElement>
    {
       public SelectXmlElementPresenter(ISelectManyView<XElement> view, IItemToListItemMapper<XElement> mapper) : base(view, mapper)
@@ -55,21 +18,10 @@ namespace MoBi.Presentation.Presenter
          var name = item.GetAttribute(AppConstants.XmlNames.NameAttribute);
          if (name.Equals(string.Empty))
          {
-            throw new MoBiException("xElement has not requiered attribute name");
+            throw new MoBiException("xElement has not required attribute name");
          }
+
          return name;
-      }
-   }
-
-   public class SelectObjectBasePresenter<T> : SelectManyPresenter<T> where T : IObjectBase
-   {
-      public SelectObjectBasePresenter(ISelectManyView<T> view, IItemToListItemMapper<T> mapper) : base(view, mapper)
-      {
-      }
-
-      public override string GetName(T item)
-      {
-         return item.Name;
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/SelectionPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectionPresenter.cs
@@ -1,19 +1,35 @@
 using System.Collections.Generic;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Views;
 using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Views;
+using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation.Presenter
 {
-   public interface ISelectionPresenter
+   public abstract class SelectionPresenter<TView, TPresenter, TSelectable> : AbstractPresenter<TView, TPresenter> where TView : IView<TPresenter>, ISelectionView<TSelectable> where TPresenter : IPresenter
    {
-      object Select();
-      ISelectionView GetView();
-      void SetDefault();
-   }
+      private readonly IItemToListItemMapper<TSelectable> _itemToListItemMapper;
+      private IEnumerable<TSelectable> _allItems;
 
-   public interface ISelectionPresenter<T> : ISelectionPresenter,IPresenter
-   {
-      IEnumerable<T> SelectionList { get; set; }
-      T Selection { set; get; }
+      protected SelectionPresenter(TView view, IItemToListItemMapper<TSelectable> itemToListItemMapper) : base(view)
+      {
+         _itemToListItemMapper = itemToListItemMapper;
+         _itemToListItemMapper.Initialize(GetName);
+      }
+
+      public void InitializeWith(IEnumerable<TSelectable> allItems)
+      {
+         _allItems = allItems;
+         _view.InitializeWith(MapAllItems());
+      }
+
+      protected virtual IEnumerable<ListItemDTO<TSelectable>> MapAllItems()
+      {
+         return _allItems.MapAllUsing(_itemToListItemMapper);
+      }
+
+      public abstract string GetName(TSelectable item);
    }
 }

--- a/src/MoBi.Presentation/Views/IContainerModalView.cs
+++ b/src/MoBi.Presentation/Views/IContainerModalView.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using OSPSuite.Presentation.Views;
 
 namespace MoBi.Presentation.Views
@@ -6,5 +7,6 @@ namespace MoBi.Presentation.Views
    {
       void AddSubView(IView subView);
       bool Show();
+      bool Show(Size modalSize);
    }
 }

--- a/src/MoBi.Presentation/Views/INameEdit.cs
+++ b/src/MoBi.Presentation/Views/INameEdit.cs
@@ -1,7 +1,0 @@
-﻿namespace MoBi.Presentation.Views
-{
-   public interface INameEdit : ISelectionView
-   {
-      string NewName { get; set; }
-   }
-}

--- a/src/MoBi.Presentation/Views/ISelectManyView.cs
+++ b/src/MoBi.Presentation/Views/ISelectManyView.cs
@@ -6,9 +6,9 @@ using OSPSuite.Presentation.Views;
 
 namespace MoBi.Presentation.Views
 {
-   public interface ISelectManyView<T> : IView<ISelectManyPresenter<T>>
+   public interface ISelectManyView<T> : IView<ISelectManyPresenter<T>>, ISelectionView<T>
    {
-      void InitializeWith(IEnumerable<ListItemDTO<T>> allItems);
+      
       IEnumerable<ListItemDTO<T>> Selections { get; }
    }
 }

--- a/src/MoBi.Presentation/Views/ISelectSingleView.cs
+++ b/src/MoBi.Presentation/Views/ISelectSingleView.cs
@@ -1,0 +1,12 @@
+﻿using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+using OSPSuite.Presentation.Views;
+
+namespace MoBi.Presentation.Views
+{
+   public interface ISelectSingleView<T> : IView<ISelectSinglePresenter<T>>, ISelectionView<T>
+   {
+      ListItemDTO<T> Selection { get; }
+      void SetDescription(string description);
+   }
+}

--- a/src/MoBi.Presentation/Views/ISelectionView.cs
+++ b/src/MoBi.Presentation/Views/ISelectionView.cs
@@ -1,20 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using MoBi.Presentation.Presenter;
-using OSPSuite.Presentation.Views;
+﻿using System.Collections.Generic;
+using MoBi.Presentation.DTO;
 
 namespace MoBi.Presentation.Views
 {
-   public interface ISelectionView:IView
+   public interface ISelectionView<T>
    {
-      void SetError(string message);
-   }
-
-   public interface ISelectionView<T> : ISelectionView
-   {
-      IEnumerable<T> SelectionList { get; set; }
-      T Selection { get; set; }
-      void AttachPresenter(ISelectionPresenter<T> presenter);
-      void Initialise(Func<T, string> toString);
+      void InitializeWith(IEnumerable<ListItemDTO<T>> allItems);
    }
 }

--- a/src/MoBi.UI/UserInterfaceRegister.cs
+++ b/src/MoBi.UI/UserInterfaceRegister.cs
@@ -46,6 +46,7 @@ namespace MoBi.UI
          container.Register<IReactionDiagramPresenter, IBaseDiagramPresenter<MoBiReactionBuildingBlock>, ReactionDiagramPresenter>(LifeStyle.Transient);
 
          container.Register(typeof(ISelectManyView<>), typeof(SelectManyView<>));
+         container.Register(typeof(ISelectSingleView<>), typeof(SelectSingleView<>));
 
          var mainView = container.Resolve<IMoBiMainView>();
          var exceptionView = container.Resolve<IExceptionView>();

--- a/src/MoBi.UI/Views/ModalForm.cs
+++ b/src/MoBi.UI/Views/ModalForm.cs
@@ -1,4 +1,5 @@
-﻿using MoBi.Presentation;
+﻿using System.Drawing;
+using MoBi.Presentation;
 using MoBi.Presentation.Views;
 using OSPSuite.Presentation.Views;
 using OSPSuite.UI.Extensions;
@@ -24,6 +25,12 @@ namespace MoBi.UI.Views
       {
          Display();
          return !Canceled;
+      }
+
+      public bool Show(Size modalSize)
+      {
+         Size = modalSize;
+         return Show();
       }
 
       public void AttachPresenter(IModalPresenter presenter)

--- a/src/MoBi.UI/Views/SelectSingleView.Designer.cs
+++ b/src/MoBi.UI/Views/SelectSingleView.Designer.cs
@@ -1,0 +1,147 @@
+﻿namespace MoBi.UI.Views
+{
+   partial class SelectSingleView<T>
+   {
+      /// <summary> 
+      /// Required designer variable.
+      /// </summary>
+      private System.ComponentModel.IContainer components = null;
+
+      /// <summary> 
+      /// Clean up any resources being used.
+      /// </summary>
+      /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+      protected override void Dispose(bool disposing)
+      {
+         if (disposing && (components != null))
+         {
+            components.Dispose();
+         }
+         base.Dispose(disposing);
+      }
+
+      #region Component Designer generated code
+
+      /// <summary> 
+      /// Required method for Designer support - do not modify 
+      /// the contents of this method with the code editor.
+      /// </summary>
+      private void InitializeComponent()
+      {
+         this.uxLayoutControl1 = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.Root = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.cbItems = new OSPSuite.UI.Controls.UxComboBoxEdit();
+         this.layoutControlItemParameterValues = new DevExpress.XtraLayout.LayoutControlItem();
+         this.emptySpaceItem1 = new DevExpress.XtraLayout.EmptySpaceItem();
+         this.lblDescription = new DevExpress.XtraEditors.LabelControl();
+         this.layoutControlItem2 = new DevExpress.XtraLayout.LayoutControlItem();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.uxLayoutControl1)).BeginInit();
+         this.uxLayoutControl1.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.Root)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.cbItems.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemParameterValues)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem1)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem2)).BeginInit();
+         this.SuspendLayout();
+         // 
+         // uxLayoutControl1
+         // 
+         this.uxLayoutControl1.AllowCustomization = false;
+         this.uxLayoutControl1.Controls.Add(this.lblDescription);
+         this.uxLayoutControl1.Controls.Add(this.cbItems);
+         this.uxLayoutControl1.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.uxLayoutControl1.Location = new System.Drawing.Point(0, 0);
+         this.uxLayoutControl1.Name = "uxLayoutControl1";
+         this.uxLayoutControl1.Root = this.Root;
+         this.uxLayoutControl1.Size = new System.Drawing.Size(356, 150);
+         this.uxLayoutControl1.TabIndex = 0;
+         this.uxLayoutControl1.Text = "uxLayoutControl1";
+         // 
+         // Root
+         // 
+         this.Root.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
+         this.Root.GroupBordersVisible = false;
+         this.Root.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutControlItemParameterValues,
+            this.emptySpaceItem1,
+            this.layoutControlItem2});
+         this.Root.Name = "Root";
+         this.Root.Size = new System.Drawing.Size(356, 150);
+         this.Root.TextVisible = false;
+         // 
+         // cbItems
+         // 
+         this.cbItems.Location = new System.Drawing.Point(62, 29);
+         this.cbItems.Name = "cbItems";
+         this.cbItems.Properties.AllowMouseWheel = false;
+         this.cbItems.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+         this.cbItems.Size = new System.Drawing.Size(282, 20);
+         this.cbItems.StyleController = this.uxLayoutControl1;
+         this.cbItems.TabIndex = 4;
+         // 
+         // layoutControlItemParameterValues
+         // 
+         this.layoutControlItemParameterValues.Control = this.cbItems;
+         this.layoutControlItemParameterValues.Location = new System.Drawing.Point(0, 17);
+         this.layoutControlItemParameterValues.Name = "layoutControlItemParameterValues";
+         this.layoutControlItemParameterValues.Size = new System.Drawing.Size(336, 24);
+         this.layoutControlItemParameterValues.Text = "cbItems";
+         this.layoutControlItemParameterValues.TextSize = new System.Drawing.Size(38, 13);
+         // 
+         // emptySpaceItem1
+         // 
+         this.emptySpaceItem1.AllowHotTrack = false;
+         this.emptySpaceItem1.Location = new System.Drawing.Point(0, 41);
+         this.emptySpaceItem1.Name = "emptySpaceItem1";
+         this.emptySpaceItem1.Size = new System.Drawing.Size(336, 89);
+         this.emptySpaceItem1.TextSize = new System.Drawing.Size(0, 0);
+         // 
+         // lblDescription
+         // 
+         this.lblDescription.Location = new System.Drawing.Point(12, 12);
+         this.lblDescription.Name = "lblDescription";
+         this.lblDescription.Size = new System.Drawing.Size(63, 13);
+         this.lblDescription.StyleController = this.uxLayoutControl1;
+         this.lblDescription.TabIndex = 5;
+         this.lblDescription.Text = "lblDescription";
+         // 
+         // layoutControlItem2
+         // 
+         this.layoutControlItem2.Control = this.lblDescription;
+         this.layoutControlItem2.Location = new System.Drawing.Point(0, 0);
+         this.layoutControlItem2.Name = "layoutControlItem2";
+         this.layoutControlItem2.Size = new System.Drawing.Size(336, 17);
+         this.layoutControlItem2.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutControlItem2.TextVisible = false;
+         // 
+         // SelectSingleView
+         // 
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+         this.Controls.Add(this.uxLayoutControl1);
+         this.Name = "SelectSingleView";
+         this.Size = new System.Drawing.Size(356, 150);
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.uxLayoutControl1)).EndInit();
+         this.uxLayoutControl1.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.Root)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.cbItems.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemParameterValues)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItem1)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem2)).EndInit();
+         this.ResumeLayout(false);
+
+      }
+
+      #endregion
+
+      private OSPSuite.UI.Controls.UxLayoutControl uxLayoutControl1;
+      private DevExpress.XtraLayout.LayoutControlGroup Root;
+      private OSPSuite.UI.Controls.UxComboBoxEdit cbItems;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlItemParameterValues;
+      private DevExpress.XtraLayout.EmptySpaceItem emptySpaceItem1;
+      private DevExpress.XtraEditors.LabelControl lblDescription;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlItem2;
+   }
+}

--- a/src/MoBi.UI/Views/SelectSingleView.cs
+++ b/src/MoBi.UI/Views/SelectSingleView.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using DevExpress.XtraEditors.Controls;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+using OSPSuite.UI.Controls;
+using OSPSuite.Utility.Extensions;
+
+namespace MoBi.UI.Views
+{
+   public partial class SelectSingleView<T> : BaseUserControl, ISelectSingleView<T>
+   {
+      public SelectSingleView()
+      {
+         InitializeComponent();
+      }
+
+      public override void InitializeResources()
+      {
+         layoutControlItemParameterValues.TextVisible = false;
+         cbItems.Properties.TextEditStyle = TextEditStyles.DisableTextEditor;
+      }
+
+      public void InitializeWith(IEnumerable<ListItemDTO<T>> allItems)
+      {
+         cbItems.Properties.Items.Clear();
+         allItems.Each(item => cbItems.Properties.Items.Add(item));
+         cbItems.SelectedIndex = 0;
+      }
+
+      public ListItemDTO<T> Selection => cbItems.SelectedItem as ListItemDTO<T>;
+
+      public void SetDescription(string description)
+      {
+         lblDescription.Text = description;
+      }
+
+      public void AttachPresenter(ISelectSinglePresenter<T> presenter)
+      {
+      }
+   }
+}

--- a/src/MoBi.UI/Views/SelectSingleView.resx
+++ b/src/MoBi.UI/Views/SelectSingleView.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="errorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>


### PR DESCRIPTION
Fixes #1269

# Description
When a user imports a spatial structure transfer, it contains parameter values for the containers that were exported. Up to now, a new PV building block was always created for them. Now the user can select an existing one, or create a new one.

If an existing one is selected, then if there are colliding paths, the old parameter value is removed and the new one is added.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):