### PR TITLE
Fixes #1282 "Local reference point" selection is not working

### DIFF
--- a/src/MoBi.Presentation/Presenter/SelectLocalisationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectLocalisationPresenter.cs
@@ -49,7 +49,7 @@ namespace MoBi.Presentation.Presenter
          var dto = new SpatialStructureDTO(spatialStructure)
          {
             Id = spatialStructure.Id,
-            Name = spatialStructure.Name,
+            Name = spatialStructure.DisplayName,
             Icon =ApplicationIcons.IconByName(spatialStructure.Icon)
          };
 


### PR DESCRIPTION
Fixes #1282

# Description
The underlying issue was fixed in another commit, but there was still an issue with the dialog because naming the Spatial Structure 'Organism' leads to only a single node created in the view. In this project there are 3 SS with the same name.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):