### PR TITLE
1296 output selections set from project defaults and set as project defaults should be available from define settings and run view

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1593,6 +1593,9 @@ namespace MoBi.Assets
          public static readonly string AddExpressionDescription = "<b>The building block will be extended with expression parameter values for selected <i>molecules</i> in the selected <i>organ</i> </b>";
          public static readonly string AddDefaultCurveForNewSimulations = "Add default curve for new simulations";
          public static readonly string ChangeDefaultCurveForNewSimulations = "Change default curve for new simulations";
+         public static readonly string MakeDefault = "Make defaults";
+         public static readonly string LoadFromDefaults = "Load from defaults";
+
          public static string SelectEntitiesThatWillBeReplaced(string entityType) => $"Select {entityType.Pluralize()} that will be replaced";
          public static string SelectEntitiesThatWillBeReplacedDescription(string entityType, string buildingBlockName) => $"<b>Selected <i>{entityType.Pluralize()}</i> will replace existing <i>{entityType.Pluralize()}</i> in the building block <i>{buildingBlockName}</i></b>";
          public static string ExportContainerDescription(string exportedContainerPath) => $"<b>Select a <i>file path</i> and optional <i>individual</i> and <i>expression profiles</i> for container export. Parameters from the <i>individual</i> and <i>expression profiles</i> that match the path {exportedContainerPath} will be added to the container before exporting.</b>";

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.279" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.282" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.282" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.279" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.279" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.0-NlGVx" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.282" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.279" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-NlGVx" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.282" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.279" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.282" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/OutputSelectionsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/OutputSelectionsPresenter.cs
@@ -19,9 +19,6 @@ namespace MoBi.Presentation.Presenter
       ///    available in <paramref name="simulation" />. Returns null if the operation was cancelled
       /// </summary>
       OutputSelections StartSelection(IMoBiSimulation simulation);
-
-      void LoadSelectionFromDefaults();
-      void MakeCurrentSelectionDefault();
    }
 
    public class OutputSelectionsPresenter : MoBiDisposablePresenter<IOutputSelectionsView, IOutputSelectionsPresenter>, IOutputSelectionsPresenter
@@ -33,8 +30,12 @@ namespace MoBi.Presentation.Presenter
       private IMoBiSimulation _simulation;
       private OutputSelections _editedSelection;
 
-      public OutputSelectionsPresenter(IOutputSelectionsView view, IQuantitySelectionPresenter quantitySelectionPresenter,
-         ISimulationPersistableUpdater simulationPersistableUpdater, IInteractionTasksForSimulationSettings simulationSettingsTask, IMoBiProjectRetriever projectRetriever)
+      public OutputSelectionsPresenter(IOutputSelectionsView view, 
+         IQuantitySelectionPresenter quantitySelectionPresenter,
+         ISimulationPersistableUpdater simulationPersistableUpdater, 
+         IInteractionTasksForSimulationSettings simulationSettingsTask, 
+         IMoBiProjectRetriever projectRetriever,
+         IDefaultOutputSelectionsButtonsView defaultButtonsView)
          : base(view)
       {
          _quantitySelectionPresenter = quantitySelectionPresenter;
@@ -44,6 +45,9 @@ namespace MoBi.Presentation.Presenter
          _quantitySelectionPresenter.AutomaticallyHideEmptyColumns = true;
          _quantitySelectionPresenter.StatusChanged += (o, e) => refreshView();
          _view.AddSettingsView(_quantitySelectionPresenter.BaseView);
+         defaultButtonsView.MakeProjectDefaultsClicked = makeCurrentSelectionDefault;
+         defaultButtonsView.LoadProjectDefaultsClicked = loadSelectionFromDefaults;
+         _view.AddDefaultButtonsView(defaultButtonsView);
          _quantitySelectionPresenter.Description = AppConstants.Captions.SimulationSettingsDescription.FormatForDescription();
          AddSubPresenters( _quantitySelectionPresenter);
       }
@@ -71,12 +75,12 @@ namespace MoBi.Presentation.Presenter
          return _editedSelection;
       }
 
-      public void LoadSelectionFromDefaults()
+      private void loadSelectionFromDefaults()
       {
          _quantitySelectionPresenter.UpdateSelection(_projectRetriever.Current.SimulationSettings.OutputSelections.ToList());
       }
 
-      public void MakeCurrentSelectionDefault()
+      private void makeCurrentSelectionDefault()
       {
          _simulationSettingsTask.UpdateDefaultOutputSelectionsInProject(_quantitySelectionPresenter.SelectedQuantities().ToList());
       }

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulationSettings.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulationSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Builder;
 using MoBi.Core.Domain.Model;
@@ -14,8 +15,8 @@ namespace MoBi.Presentation.Tasks.Interaction
    {
       void LoadDefaultSimulationSettingsInProject();
       void Edit(SimulationSettings simulationSettings);
-      void UpdateDefaultSimulationSettingsInProject(SimulationSettings simulationSettings);
-      void UpdateDefaultOutputSelectionsInProject(SimulationSettings simulationSettings);
+      void UpdateDefaultSimulationSettingsInProject(OutputSchema outputSchema, SolverSettings solverSettings);
+      void UpdateDefaultOutputSelectionsInProject(IReadOnlyList<QuantitySelection> selectedQuantities);
    }
 
    public class InteractionTasksForSimulationSettings : InteractionTasksForBuildingBlock<MoBiProject, SimulationSettings>, IInteractionTasksForSimulationSettings
@@ -64,19 +65,19 @@ namespace MoBi.Presentation.Tasks.Interaction
          Context.PublishEvent(new DefaultSimulationSettingsUpdatedEvent(Context.CurrentProject.SimulationSettings));
       }
 
-      public void UpdateDefaultSimulationSettingsInProject(SimulationSettings simulationSettings)
+      public void UpdateDefaultSimulationSettingsInProject(OutputSchema outputSchema, SolverSettings solverSettings)
       {
-         var clonedSettings = Context.Clone(simulationSettings);
-         Context.CurrentProject.SimulationSettings.OutputSchema = clonedSettings.OutputSchema;
-         Context.CurrentProject.SimulationSettings.Solver = clonedSettings.Solver;
+         Context.CurrentProject.SimulationSettings.OutputSchema = Context.Clone(outputSchema);
+         Context.CurrentProject.SimulationSettings.Solver = Context.Clone(solverSettings);
 
          Context.PublishEvent(new DefaultSimulationSettingsUpdatedEvent(Context.CurrentProject.SimulationSettings));
       }
 
-      public void UpdateDefaultOutputSelectionsInProject(SimulationSettings simulationSettings)
+      public void UpdateDefaultOutputSelectionsInProject(IReadOnlyList<QuantitySelection> selectedQuantities)
       {
-         var clonedSettings = Context.Clone(simulationSettings);
-         Context.CurrentProject.SimulationSettings.OutputSelections = clonedSettings.OutputSelections;
+         var projectSelections = Context.CurrentProject.SimulationSettings.OutputSelections;
+         projectSelections.Clear();
+         selectedQuantities.Each(x => projectSelections.AddOutput(x.Clone()));
          Context.PublishEvent(new DefaultSimulationSettingsUpdatedEvent(Context.CurrentProject.SimulationSettings));
       }
 

--- a/src/MoBi.Presentation/UICommand/CommitSimulationOutputSelectionsUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/CommitSimulationOutputSelectionsUICommand.cs
@@ -1,4 +1,5 @@
-﻿using MoBi.Presentation.Tasks.Interaction;
+﻿using System.Linq;
+using MoBi.Presentation.Tasks.Interaction;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.UICommands;
@@ -19,7 +20,7 @@ namespace MoBi.Presentation.UICommand
 
       protected override void PerformExecute()
       {
-         _simulationSettingsTask.UpdateDefaultOutputSelectionsInProject(Subject);
+         _simulationSettingsTask.UpdateDefaultOutputSelectionsInProject(Subject.OutputSelections.ToList());
       }
    }
 }

--- a/src/MoBi.Presentation/UICommand/CommitSimulationSolverAndSchemaUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/CommitSimulationSolverAndSchemaUICommand.cs
@@ -20,7 +20,7 @@ namespace MoBi.Presentation.UICommand
 
       protected override void PerformExecute()
       {
-         _simulationSettingsTask.UpdateDefaultSimulationSettingsInProject(Subject);
+         _simulationSettingsTask.UpdateDefaultSimulationSettingsInProject(Subject.OutputSchema, Subject.Solver);
       }
    }
 }

--- a/src/MoBi.Presentation/Views/IOutputSelectionsView.cs
+++ b/src/MoBi.Presentation/Views/IOutputSelectionsView.cs
@@ -1,10 +1,18 @@
-﻿using MoBi.Presentation.Presenter;
+﻿using System;
+using MoBi.Presentation.Presenter;
 using OSPSuite.Presentation.Views;
 
 namespace MoBi.Presentation.Views
 {
+   public interface IDefaultOutputSelectionsButtonsView : IView
+   {
+      Action MakeProjectDefaultsClicked { get; set; }
+      Action LoadProjectDefaultsClicked { get; set; }
+   }
+
    public interface IOutputSelectionsView : IModalView<IOutputSelectionsPresenter>
    {
       void AddSettingsView(IView view);
+      void AddDefaultButtonsView(IView view);
    }
 }

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.282" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.279" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/Views/DefaultOutputSelectionsButtonsView.Designer.cs
+++ b/src/MoBi.UI/Views/DefaultOutputSelectionsButtonsView.Designer.cs
@@ -1,0 +1,102 @@
+﻿namespace MoBi.UI.Views
+{
+   partial class DefaultOutputSelectionsButtonsView
+   {
+      /// <summary> 
+      /// Required designer variable.
+      /// </summary>
+      private System.ComponentModel.IContainer components = null;
+
+      /// <summary> 
+      /// Clean up any resources being used.
+      /// </summary>
+      /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+      protected override void Dispose(bool disposing)
+      {
+         if (disposing && (components != null))
+         {
+            components.Dispose();
+         }
+         base.Dispose(disposing);
+      }
+
+      #region Component Designer generated code
+
+      /// <summary> 
+      /// Required method for Designer support - do not modify 
+      /// the contents of this method with the code editor.
+      /// </summary>
+      private void InitializeComponent()
+      {
+         this.tablePanel = new DevExpress.Utils.Layout.TablePanel();
+         this.btnLoadProjectDefaults = new OSPSuite.UI.Controls.UxSimpleButton();
+         this.btnMakeProjectDefaults = new OSPSuite.UI.Controls.UxSimpleButton();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.tablePanel)).BeginInit();
+         this.tablePanel.SuspendLayout();
+         this.SuspendLayout();
+         // 
+         // tablePanel
+         // 
+         this.tablePanel.AutoSize = true;
+         this.tablePanel.Columns.AddRange(new DevExpress.Utils.Layout.TablePanelColumn[] {
+            new DevExpress.Utils.Layout.TablePanelColumn(DevExpress.Utils.Layout.TablePanelEntityStyle.Relative, 50F),
+            new DevExpress.Utils.Layout.TablePanelColumn(DevExpress.Utils.Layout.TablePanelEntityStyle.Relative, 50F)});
+         this.tablePanel.Controls.Add(this.btnLoadProjectDefaults);
+         this.tablePanel.Controls.Add(this.btnMakeProjectDefaults);
+         this.tablePanel.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.tablePanel.Location = new System.Drawing.Point(0, 0);
+         this.tablePanel.Name = "tablePanel";
+         this.tablePanel.Rows.AddRange(new DevExpress.Utils.Layout.TablePanelRow[] {
+            new DevExpress.Utils.Layout.TablePanelRow(DevExpress.Utils.Layout.TablePanelEntityStyle.Absolute, 26F)});
+         this.tablePanel.Size = new System.Drawing.Size(321, 29);
+         this.tablePanel.TabIndex = 0;
+         // 
+         // btnLoadProjectDefaults
+         // 
+         this.tablePanel.SetColumn(this.btnLoadProjectDefaults, 1);
+         this.btnLoadProjectDefaults.Dock = System.Windows.Forms.DockStyle.Top;
+         this.btnLoadProjectDefaults.Location = new System.Drawing.Point(164, 3);
+         this.btnLoadProjectDefaults.Manager = null;
+         this.btnLoadProjectDefaults.Name = "btnLoadProjectDefaults";
+         this.tablePanel.SetRow(this.btnLoadProjectDefaults, 0);
+         this.btnLoadProjectDefaults.Shortcut = System.Windows.Forms.Keys.None;
+         this.btnLoadProjectDefaults.Size = new System.Drawing.Size(155, 23);
+         this.btnLoadProjectDefaults.TabIndex = 1;
+         this.btnLoadProjectDefaults.Text = "btnLoadProjectDefaults";
+         // 
+         // btnMakeProjectDefaults
+         // 
+         this.tablePanel.SetColumn(this.btnMakeProjectDefaults, 0);
+         this.btnMakeProjectDefaults.Dock = System.Windows.Forms.DockStyle.Top;
+         this.btnMakeProjectDefaults.Location = new System.Drawing.Point(3, 3);
+         this.btnMakeProjectDefaults.Manager = null;
+         this.btnMakeProjectDefaults.Name = "btnMakeProjectDefaults";
+         this.tablePanel.SetRow(this.btnMakeProjectDefaults, 0);
+         this.btnMakeProjectDefaults.Shortcut = System.Windows.Forms.Keys.None;
+         this.btnMakeProjectDefaults.Size = new System.Drawing.Size(155, 23);
+         this.btnMakeProjectDefaults.TabIndex = 0;
+         this.btnMakeProjectDefaults.Text = "btnMakeProjectDefaults";
+         // 
+         // DefaultOutputSelectionsButtonsView
+         // 
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.Controls.Add(this.tablePanel);
+         this.Name = "DefaultOutputSelectionsButtonsView";
+         this.Size = new System.Drawing.Size(321, 29);
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.tablePanel)).EndInit();
+         this.tablePanel.ResumeLayout(false);
+         this.ResumeLayout(false);
+         this.PerformLayout();
+
+      }
+
+      #endregion
+
+      private DevExpress.Utils.Layout.TablePanel tablePanel;
+      private OSPSuite.UI.Controls.UxSimpleButton btnLoadProjectDefaults;
+      private OSPSuite.UI.Controls.UxSimpleButton btnMakeProjectDefaults;
+   }
+}

--- a/src/MoBi.UI/Views/DefaultOutputSelectionsButtonsView.cs
+++ b/src/MoBi.UI/Views/DefaultOutputSelectionsButtonsView.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using MoBi.Assets;
+using MoBi.Presentation.Views;
+using OSPSuite.UI.Controls;
+
+namespace MoBi.UI.Views
+{
+   public partial class DefaultOutputSelectionsButtonsView : BaseUserControl, IDefaultOutputSelectionsButtonsView
+   {
+      public DefaultOutputSelectionsButtonsView()
+      {
+         InitializeComponent();
+         btnMakeProjectDefaults.Click += (o, e) => makeProjectDefaultsClicked();
+         btnLoadProjectDefaults.Click += (o, e) => loadProjectDefaultsClicked();
+
+         btnMakeProjectDefaults.Text = AppConstants.Captions.MakeDefault;
+         btnLoadProjectDefaults.Text = AppConstants.Captions.LoadFromDefaults;
+      }
+
+      private void loadProjectDefaultsClicked()
+      {
+         LoadProjectDefaultsClicked();
+      }
+
+      private void makeProjectDefaultsClicked()
+      {
+         MakeProjectDefaultsClicked();
+      }
+
+      public Action MakeProjectDefaultsClicked { get; set; } = () => { };
+      public Action LoadProjectDefaultsClicked { get; set; } = () => { };
+
+   }
+}

--- a/src/MoBi.UI/Views/DefaultOutputSelectionsButtonsView.resx
+++ b/src/MoBi.UI/Views/DefaultOutputSelectionsButtonsView.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="errorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/src/MoBi.UI/Views/OutputSelectionsView.Designer.cs
+++ b/src/MoBi.UI/Views/OutputSelectionsView.Designer.cs
@@ -29,19 +29,43 @@
       private void InitializeComponent()
       {
          this.panel = new DevExpress.XtraEditors.PanelControl();
+         this.btnLoadDefaults = new OSPSuite.UI.Controls.UxSimpleButton();
+         ((System.ComponentModel.ISupportInitialize)(this.tablePanel)).BeginInit();
+         this.tablePanel.SuspendLayout();
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.panel)).BeginInit();
          this.SuspendLayout();
+         // 
+         // tablePanel
+         // 
+         this.tablePanel.Columns.AddRange(new DevExpress.Utils.Layout.TablePanelColumn[] {
+            new DevExpress.Utils.Layout.TablePanelColumn(DevExpress.Utils.Layout.TablePanelEntityStyle.Relative, 50F)});
+         this.tablePanel.Controls.Add(this.btnLoadDefaults);
+         this.tablePanel.Location = new System.Drawing.Point(0, 526);
+         this.tablePanel.Size = new System.Drawing.Size(745, 43);
+         this.tablePanel.Controls.SetChildIndex(this.btnLoadDefaults, 0);
          // 
          // panel
          // 
          this.panel.Dock = System.Windows.Forms.DockStyle.Fill;
          this.panel.Location = new System.Drawing.Point(0, 0);
          this.panel.Name = "panel";
-         this.panel.Size = new System.Drawing.Size(745, 523);
+         this.panel.Size = new System.Drawing.Size(745, 569);
          this.panel.TabIndex = 38;
          // 
-         // SimulationSettingsView
+         // btnLoadDefaults
+         // 
+         this.tablePanel.SetColumn(this.btnLoadDefaults, 1);
+         this.btnLoadDefaults.Location = new System.Drawing.Point(164, 10);
+         this.btnLoadDefaults.Manager = null;
+         this.btnLoadDefaults.Name = "btnLoadDefaults";
+         this.tablePanel.SetRow(this.btnLoadDefaults, 0);
+         this.btnLoadDefaults.Shortcut = System.Windows.Forms.Keys.None;
+         this.btnLoadDefaults.Size = new System.Drawing.Size(140, 23);
+         this.btnLoadDefaults.TabIndex = 3;
+         this.btnLoadDefaults.Text = "btnLoadDefaults";
+         // 
+         // OutputSelectionsView
          // 
          this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -50,14 +74,20 @@
          this.Controls.Add(this.panel);
          this.Name = "OutputSelectionsView";
          this.Text = "SimulationSettingsView";
+         this.Controls.SetChildIndex(this.panel, 0);
+         this.Controls.SetChildIndex(this.tablePanel, 0);
+         ((System.ComponentModel.ISupportInitialize)(this.tablePanel)).EndInit();
+         this.tablePanel.ResumeLayout(false);
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.panel)).EndInit();
          this.ResumeLayout(false);
+         this.PerformLayout();
 
       }
 
       #endregion
 
       private DevExpress.XtraEditors.PanelControl panel;
+      private OSPSuite.UI.Controls.UxSimpleButton btnLoadDefaults;
    }
 }

--- a/src/MoBi.UI/Views/OutputSelectionsView.Designer.cs
+++ b/src/MoBi.UI/Views/OutputSelectionsView.Designer.cs
@@ -29,43 +29,19 @@
       private void InitializeComponent()
       {
          this.panel = new DevExpress.XtraEditors.PanelControl();
-         this.btnLoadDefaults = new OSPSuite.UI.Controls.UxSimpleButton();
-         ((System.ComponentModel.ISupportInitialize)(this.tablePanel)).BeginInit();
-         this.tablePanel.SuspendLayout();
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.panel)).BeginInit();
          this.SuspendLayout();
-         // 
-         // tablePanel
-         // 
-         this.tablePanel.Columns.AddRange(new DevExpress.Utils.Layout.TablePanelColumn[] {
-            new DevExpress.Utils.Layout.TablePanelColumn(DevExpress.Utils.Layout.TablePanelEntityStyle.Relative, 50F)});
-         this.tablePanel.Controls.Add(this.btnLoadDefaults);
-         this.tablePanel.Location = new System.Drawing.Point(0, 526);
-         this.tablePanel.Size = new System.Drawing.Size(745, 43);
-         this.tablePanel.Controls.SetChildIndex(this.btnLoadDefaults, 0);
          // 
          // panel
          // 
          this.panel.Dock = System.Windows.Forms.DockStyle.Fill;
          this.panel.Location = new System.Drawing.Point(0, 0);
          this.panel.Name = "panel";
-         this.panel.Size = new System.Drawing.Size(745, 569);
+         this.panel.Size = new System.Drawing.Size(745, 523);
          this.panel.TabIndex = 38;
          // 
-         // btnLoadDefaults
-         // 
-         this.tablePanel.SetColumn(this.btnLoadDefaults, 1);
-         this.btnLoadDefaults.Location = new System.Drawing.Point(164, 10);
-         this.btnLoadDefaults.Manager = null;
-         this.btnLoadDefaults.Name = "btnLoadDefaults";
-         this.tablePanel.SetRow(this.btnLoadDefaults, 0);
-         this.btnLoadDefaults.Shortcut = System.Windows.Forms.Keys.None;
-         this.btnLoadDefaults.Size = new System.Drawing.Size(140, 23);
-         this.btnLoadDefaults.TabIndex = 3;
-         this.btnLoadDefaults.Text = "btnLoadDefaults";
-         // 
-         // OutputSelectionsView
+         // SimulationSettingsView
          // 
          this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -74,20 +50,14 @@
          this.Controls.Add(this.panel);
          this.Name = "OutputSelectionsView";
          this.Text = "SimulationSettingsView";
-         this.Controls.SetChildIndex(this.panel, 0);
-         this.Controls.SetChildIndex(this.tablePanel, 0);
-         ((System.ComponentModel.ISupportInitialize)(this.tablePanel)).EndInit();
-         this.tablePanel.ResumeLayout(false);
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.panel)).EndInit();
          this.ResumeLayout(false);
-         this.PerformLayout();
 
       }
 
       #endregion
 
       private DevExpress.XtraEditors.PanelControl panel;
-      private OSPSuite.UI.Controls.UxSimpleButton btnLoadDefaults;
    }
 }

--- a/src/MoBi.UI/Views/OutputSelectionsView.cs
+++ b/src/MoBi.UI/Views/OutputSelectionsView.cs
@@ -10,6 +10,8 @@ namespace MoBi.UI.Views
 {
    public partial class OutputSelectionsView : BaseModalView, IOutputSelectionsView
    {
+      private IOutputSelectionsPresenter _presenter;
+
       public OutputSelectionsView(IMainView shell)
          : base(shell)
       {
@@ -18,6 +20,7 @@ namespace MoBi.UI.Views
 
       public void AttachPresenter(IOutputSelectionsPresenter presenter)
       {
+         _presenter = presenter;
       }
 
       public void AddSettingsView(IView view)
@@ -30,6 +33,25 @@ namespace MoBi.UI.Views
          base.InitializeResources();
          Caption = AppConstants.Captions.SimulationSettings;
          ApplicationIcon = ApplicationIcons.Simulation;
+
+         ExtraCaption = AppConstants.Captions.MakeDefault;
+         ExtraEnabled = true;
+         ExtraVisible = true;
+
+         btnLoadDefaults.Text = AppConstants.Captions.LoadFromDefaults;
+         btnLoadDefaults.Click += (o, e) => OnEvent(loadDefaultsClicked);
+
+         tablePanel.AdjustButton(btnLoadDefaults);
+      }
+
+      private void loadDefaultsClicked()
+      {
+         _presenter.LoadSelectionFromDefaults();
+      }
+
+      protected override void ExtraClicked()
+      {
+         _presenter.MakeCurrentSelectionDefault();
       }
    }
 }

--- a/src/MoBi.UI/Views/OutputSelectionsView.cs
+++ b/src/MoBi.UI/Views/OutputSelectionsView.cs
@@ -1,4 +1,5 @@
-﻿using MoBi.Assets;
+﻿using System.Windows.Forms;
+using MoBi.Assets;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Views;
 using OSPSuite.Assets;
@@ -10,8 +11,6 @@ namespace MoBi.UI.Views
 {
    public partial class OutputSelectionsView : BaseModalView, IOutputSelectionsView
    {
-      private IOutputSelectionsPresenter _presenter;
-
       public OutputSelectionsView(IMainView shell)
          : base(shell)
       {
@@ -20,12 +19,16 @@ namespace MoBi.UI.Views
 
       public void AttachPresenter(IOutputSelectionsPresenter presenter)
       {
-         _presenter = presenter;
       }
 
       public void AddSettingsView(IView view)
       {
          panel.FillWith(view);
+      }
+
+      public void AddDefaultButtonsView(IView view)
+      {
+         ReplaceExtraButtonWith(view as Control);
       }
 
       public override void InitializeResources()
@@ -34,24 +37,8 @@ namespace MoBi.UI.Views
          Caption = AppConstants.Captions.SimulationSettings;
          ApplicationIcon = ApplicationIcons.Simulation;
 
-         ExtraCaption = AppConstants.Captions.MakeDefault;
          ExtraEnabled = true;
          ExtraVisible = true;
-
-         btnLoadDefaults.Text = AppConstants.Captions.LoadFromDefaults;
-         btnLoadDefaults.Click += (o, e) => OnEvent(loadDefaultsClicked);
-
-         tablePanel.AdjustButton(btnLoadDefaults);
-      }
-
-      private void loadDefaultsClicked()
-      {
-         _presenter.LoadSelectionFromDefaults();
-      }
-
-      protected override void ExtraClicked()
-      {
-         _presenter.MakeCurrentSelectionDefault();
       }
    }
 }

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -72,13 +72,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.279" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.279" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-NlGVx" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -72,13 +72,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.282" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-NlGVx" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.282" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.279" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-NlGVx" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.282" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/OutputSelectionsPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/OutputSelectionsPresenterSpecs.cs
@@ -1,0 +1,99 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Services;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Tasks.Interaction;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Presentation.Presenters;
+using ISimulationPersistableUpdater = MoBi.Core.Services.ISimulationPersistableUpdater;
+
+namespace MoBi.Presentation
+{
+   internal class concern_for_OutputSelectionsPresenter : ContextSpecification<OutputSelectionsPresenter>
+   {
+      protected IOutputSelectionsView _view;
+      protected IQuantitySelectionPresenter _quantitySelectionPresenter;
+      protected ISimulationPersistableUpdater _simulationPersistableUpdater;
+      protected IInteractionTasksForSimulationSettings _simulationSettingsTask;
+      protected IMoBiProjectRetriever _projectRetriever;
+
+      protected override void Context()
+      {
+         _view = A.Fake<IOutputSelectionsView>();
+         _quantitySelectionPresenter = A.Fake<IQuantitySelectionPresenter>();
+         _simulationPersistableUpdater = A.Fake<ISimulationPersistableUpdater>();
+         _simulationSettingsTask = A.Fake<IInteractionTasksForSimulationSettings>();
+         _projectRetriever = A.Fake<IMoBiProjectRetriever>();
+
+         sut = new OutputSelectionsPresenter(_view, _quantitySelectionPresenter, _simulationPersistableUpdater, _simulationSettingsTask, _projectRetriever);
+      }
+
+      protected bool ContainsAllElementsFrom(IReadOnlyList<QuantitySelection> argumentList, IReadOnlyList<QuantitySelection> outputSelections)
+      {
+         return argumentList.All(outputSelections.Contains) && outputSelections.All(argumentList.Contains);
+      }
+   }
+
+   internal class When_setting_project_defaults_from_output_selection : concern_for_OutputSelectionsPresenter
+   {
+      private List<QuantitySelection> _outputSelections;
+
+      protected override void Context()
+      {
+         base.Context();
+         _outputSelections = new List<QuantitySelection>
+         {
+            new QuantitySelection("toto")
+         };
+
+         A.CallTo(() => _quantitySelectionPresenter.SelectedQuantities()).Returns(_outputSelections);
+      }
+
+      protected override void Because()
+      {
+         sut.MakeCurrentSelectionDefault();
+      }
+
+      [Observation]
+      public void the_project_defaults_should_be_updated_from_the_selected_outputs()
+      {
+         A.CallTo(() => _simulationSettingsTask.UpdateDefaultOutputSelectionsInProject(A<IReadOnlyList<QuantitySelection>>.That.Matches(x => ContainsAllElementsFrom(x, _outputSelections)))).MustHaveHappened();
+      }
+   }
+
+   internal class When_loading_project_default_output_selections : concern_for_OutputSelectionsPresenter
+   {
+      private OutputSelections _outputSelections;
+      private MoBiProject _project;
+
+      protected override void Context()
+      {
+         base.Context();
+         _project = new MoBiProject();
+         _outputSelections = new OutputSelections();
+         _outputSelections.AddOutput(new QuantitySelection("toto"));
+         _project.SimulationSettings = new SimulationSettings
+         {
+            OutputSelections = _outputSelections
+         };
+
+         A.CallTo(() => _projectRetriever.Current).Returns(_project);
+      }
+
+      protected override void Because()
+      {
+         sut.LoadSelectionFromDefaults();
+      }
+
+      [Observation]
+      public void the_selected_outputs_should_be_updated_from_the_project_defaults()
+      {
+         A.CallTo(() => _quantitySelectionPresenter.UpdateSelection(A<IReadOnlyList<QuantitySelection>>.That.Matches(x => ContainsAllElementsFrom(x, _outputSelections.ToList())))).MustHaveHappened();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/OutputSelectionsPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/OutputSelectionsPresenterSpecs.cs
@@ -6,6 +6,7 @@ using MoBi.Core.Services;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Interaction;
 using MoBi.Presentation.Views;
+using MoBi.UI.Views;
 using OSPSuite.BDDHelper;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
@@ -21,6 +22,7 @@ namespace MoBi.Presentation
       protected ISimulationPersistableUpdater _simulationPersistableUpdater;
       protected IInteractionTasksForSimulationSettings _simulationSettingsTask;
       protected IMoBiProjectRetriever _projectRetriever;
+      protected IDefaultOutputSelectionsButtonsView _defaultButtonsView;
 
       protected override void Context()
       {
@@ -29,8 +31,9 @@ namespace MoBi.Presentation
          _simulationPersistableUpdater = A.Fake<ISimulationPersistableUpdater>();
          _simulationSettingsTask = A.Fake<IInteractionTasksForSimulationSettings>();
          _projectRetriever = A.Fake<IMoBiProjectRetriever>();
+         _defaultButtonsView = new DefaultOutputSelectionsButtonsView();
 
-         sut = new OutputSelectionsPresenter(_view, _quantitySelectionPresenter, _simulationPersistableUpdater, _simulationSettingsTask, _projectRetriever);
+         sut = new OutputSelectionsPresenter(_view, _quantitySelectionPresenter, _simulationPersistableUpdater, _simulationSettingsTask, _projectRetriever, _defaultButtonsView);
       }
 
       protected bool ContainsAllElementsFrom(IReadOnlyList<QuantitySelection> argumentList, IReadOnlyList<QuantitySelection> outputSelections)
@@ -56,7 +59,7 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.MakeCurrentSelectionDefault();
+         _defaultButtonsView.MakeProjectDefaultsClicked();
       }
 
       [Observation]
@@ -87,7 +90,7 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.LoadSelectionFromDefaults();
+         _defaultButtonsView.LoadProjectDefaultsClicked();
       }
 
       [Observation]

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.282" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.282" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.279" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.279" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-NlGVx" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-NlGVx" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1296 

# Description
In the 'Define settings and run' dialog, the user can make the selections into project defaults, or load the selections from project defaults. When you create a simulation, the selections would already be project default, but maybe you want to undo some changes you made.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/396e13a2-e5c2-4a7d-9d6e-adad14b54c03)

# Questions (if appropriate):
