### PR TITLE
Fixes #1085 Error when modifying a table formula with x argument

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditTableFormulaWithXArgumentFormulaPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditTableFormulaWithXArgumentFormulaPresenter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Domain.Services;
 using MoBi.Presentation.DTO;
@@ -87,8 +88,8 @@ namespace MoBi.Presentation.Presenter
       {
          using (var presenter = _applicationController.Start<ISelectFormulaUsablePathPresenter>())
          {
-            var referencePresenter = _selectReferencePresenterFactory.ReferenceAtParameterFor(UsingObject.ParentContainer);
-            presenter.Init(predicate, UsingObject, new[] {UsingObject.RootContainer}, caption, referencePresenter);
+            var referencePresenter = _selectReferencePresenterFactory.ReferenceAtParameterFor(UsingObject?.ParentContainer);
+            presenter.Init(predicate, UsingObject, UsingObject == null ? Enumerable.Empty<IObjectBase>() : new[] {UsingObject.RootContainer}, caption, referencePresenter);
             return presenter.GetSelection();
          }
       }

--- a/src/MoBi.Presentation/Presenter/SelectReferencePresenterBase.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferencePresenterBase.cs
@@ -174,7 +174,10 @@ namespace MoBi.Presentation.Presenter
       public ObjectPath GetSelection()
       {
          var selection = getSelected<IEntity>();
-         return _objectPathFactory.CreateRelativeObjectPath(_refObject, selection);
+
+         return shouldCreateAbsolutePaths ? 
+            _objectPathFactory.CreateAbsoluteObjectPath(selection) : 
+            _objectPathFactory.CreateRelativeObjectPath(_refObject, selection);
       }
 
       private T getSelected<T>() where T : class, IObjectBase

--- a/src/MoBi.Presentation/Presenter/SelectReferencePresenterFactory.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferencePresenterFactory.cs
@@ -22,7 +22,7 @@ namespace MoBi.Presentation.Presenter
 
       public ISelectReferenceAtParameterPresenter ReferenceAtParameterFor(IContainer container)
       {
-         return ReferenceAtParameterFor(container.GetType());
+         return ReferenceAtParameterFor(container?.GetType());
       }
 
       public ISelectReferenceAtParameterPresenter ReferenceAtParameterFor(Type parentType)


### PR DESCRIPTION
Fixes #1085

# Description
In this case, we are editing the formula from the formula cache and do not have the context of what is using the formula. There seems to be some provisions for that and I just made some more so the application will not crash.

I'm not sure if there's another way that would be preferred. Essentially, if you edit from the formula cache, you lose the ability to specify relative paths (it seems). It seems to make sense to me.

For now, I would like a quick comment on whether this approach makes sense, then I'll add some tests for it.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):