### PR TITLE
Fixes #1022

### DIFF
--- a/src/MoBi.Presentation/DTO/ObjectBaseDTO.cs
+++ b/src/MoBi.Presentation/DTO/ObjectBaseDTO.cs
@@ -112,6 +112,17 @@ namespace MoBi.Presentation.DTO
       }
    }
 
+   public class NeighborDTO : ObjectBaseDTO
+   {
+      public NeighborDTO(ObjectPath objectPath)
+      {
+         Name = objectPath;
+         Path = objectPath;
+      }
+
+      public ObjectPath Path { get; }
+   }
+
    public class BuildingBlockViewItem : ObjectBaseDTO
    {
       public IBuildingBlock BuildingBlock { get; }

--- a/src/MoBi.Presentation/Presenter/HierarchicalSpatialStructurePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalSpatialStructurePresenter.cs
@@ -10,6 +10,7 @@ using MoBi.Presentation.Views;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Presenters.ContextMenus;
@@ -156,6 +157,18 @@ namespace MoBi.Presentation.Presenter
 
          var entityToSelect = entity.IsAnImplementationOf<IParameter>() ? entity.ParentContainer : entity;
          _view.Select(entityToSelect);
+      }
+
+      protected override void RaiseEntitySelectedEvent(ObjectBaseDTO objectBaseDTO)
+      {
+         base.RaiseEntitySelectedEvent(objectBaseDTO);
+         if (!(objectBaseDTO is NeighborDTO neighborDTO)) 
+            return;
+
+         var entity = _spatialStructure.TopContainers.Select(x => neighborDTO.Path.Resolve<IEntity>(x)).FirstOrDefault();
+         
+         if(entity != null)
+            _context.PublishEvent(new EntitySelectedEvent(entity, this));
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/HierarchicalSpatialStructurePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalSpatialStructurePresenter.cs
@@ -165,7 +165,7 @@ namespace MoBi.Presentation.Presenter
          if (!(objectBaseDTO is NeighborDTO neighborDTO)) 
             return;
 
-         var entity = _spatialStructure.TopContainers.Select(x => neighborDTO.Path.Resolve<IEntity>(x)).FirstOrDefault();
+         var entity = _spatialStructure.TopContainers.Select(x => neighborDTO.Path.Resolve<IEntity>(x)).FirstOrDefault(x => x != default);
          
          if(entity != null)
             _context.PublishEvent(new EntitySelectedEvent(entity, this));

--- a/src/MoBi.Presentation/Presenter/HierarchicalStructureEditPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalStructureEditPresenter.cs
@@ -34,14 +34,12 @@ namespace MoBi.Presentation.Presenter
             RaiseUserDefinedSelectedEvent();
 
          else
-            raiseEntitySelectedEvent(objectBaseDTO);
+            RaiseEntitySelectedEvent(objectBaseDTO);
       }
 
-      private void raiseEntitySelectedEvent(ObjectBaseDTO objectBaseDTO)
+      protected virtual void RaiseEntitySelectedEvent(ObjectBaseDTO objectBaseDTO)
       {
-         // First and second neighbor node selections should not trigger an EntitySelectedEvent
-         // because they are not a selectable entity
-         if(objectBaseDTO.ObjectBase != null)
+         if(!(objectBaseDTO is NeighborDTO))
             _context.PublishEvent(new EntitySelectedEvent(objectBaseDTO.ObjectBase, this));
       }
 

--- a/src/MoBi.Presentation/Presenter/HierarchicalStructureEditPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalStructureEditPresenter.cs
@@ -39,6 +39,7 @@ namespace MoBi.Presentation.Presenter
 
       protected virtual void RaiseEntitySelectedEvent(ObjectBaseDTO objectBaseDTO)
       {
+         // This presenter cannot handle the Neighbor selection, but a derived presenter can
          if(!(objectBaseDTO is NeighborDTO))
             _context.PublishEvent(new EntitySelectedEvent(objectBaseDTO.ObjectBase, this));
       }

--- a/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
@@ -65,10 +65,10 @@ namespace MoBi.Presentation.Presenter
       private IEnumerable<ObjectBaseDTO> neighborsOf(NeighborhoodBuilder neighborhoodBuilder)
       {
          if (neighborhoodBuilder.FirstNeighborPath != null)
-            yield return new ObjectBaseDTO { Name = neighborhoodBuilder.FirstNeighborPath, Icon = ApplicationIcons.Neighbor, Id = createNeighborhoodId(neighborhoodBuilder, neighborhoodBuilder.FirstNeighborPath) };
+            yield return new NeighborDTO(neighborhoodBuilder.FirstNeighborPath) { Icon = ApplicationIcons.Neighbor, Id = createNeighborhoodId(neighborhoodBuilder, neighborhoodBuilder.FirstNeighborPath) };
 
          if (neighborhoodBuilder.SecondNeighborPath != null)
-            yield return new ObjectBaseDTO { Name = neighborhoodBuilder.SecondNeighborPath, Icon = ApplicationIcons.Neighbor, Id = createNeighborhoodId(neighborhoodBuilder, neighborhoodBuilder.SecondNeighborPath) };
+            yield return new NeighborDTO(neighborhoodBuilder.SecondNeighborPath) { Icon = ApplicationIcons.Neighbor, Id = createNeighborhoodId(neighborhoodBuilder, neighborhoodBuilder.SecondNeighborPath) };
       }
 
       /// <summary>

--- a/tests/MoBi.Tests/Presentation/HierarchicalSimulationPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/HierarchicalSimulationPresenterSpecs.cs
@@ -1,12 +1,10 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using FakeItEasy;
 using OSPSuite.BDDHelper;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;
-using MoBi.Presentation.MenusAndBars.ContextMenus;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Views;
 using OSPSuite.Presentation.Presenters.ContextMenus;
@@ -16,14 +14,11 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using ITreeNodeFactory = MoBi.Presentation.Nodes.ITreeNodeFactory;
-using OSPSuite.Core.Extensions;
-using OSPSuite.Presentation.Presenters;
 using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation
 {
-   public abstract class concern_for_HierarchicalStructurePresenter :
-      ContextSpecification<IHierarchicalStructurePresenter>
+   internal abstract class concern_for_HierarchicalSimulationPresenter : ContextSpecification<HierarchicalSimulationPresenter>
    {
       private IHierarchicalStructureView _view;
       protected IMoBiContext _context;
@@ -40,7 +35,7 @@ namespace MoBi.Presentation
          _simulationSettingsMapper = A.Fake<ISimulationSettingsToObjectBaseDTOMapper>();
          _dtoMapper = A.Fake<IObjectBaseToObjectBaseDTOMapper>();
 
-         _favorites = new ObjectBaseDTO()
+         _favorites = new ObjectBaseDTO
          {
             Name = Captions.Favorites,
             Icon = ApplicationIcons.Favorites,
@@ -58,7 +53,7 @@ namespace MoBi.Presentation
       }
    }
 
-   internal class When_getting_child_objects : concern_for_HierarchicalStructurePresenter
+   internal class When_getting_child_objects : concern_for_HierarchicalSimulationPresenter
    {
       private IReadOnlyList<ObjectBaseDTO> _result;
       private ObjectBaseDTO _dto;
@@ -88,7 +83,7 @@ namespace MoBi.Presentation
       }
    }
 
-   internal class When_selecting_the_favorites_node : concern_for_HierarchicalStructurePresenter
+   internal class When_selecting_the_favorites_node : concern_for_HierarchicalSimulationPresenter
    {
       protected override void Because()
       {
@@ -109,7 +104,7 @@ namespace MoBi.Presentation
       }
    }
 
-   internal class When_selecting_a_node_with_an_object_base : concern_for_HierarchicalStructurePresenter
+   internal class When_selecting_a_node_with_an_object_base : concern_for_HierarchicalSimulationPresenter
    {
       private ObjectBaseDTO _dto;
 
@@ -131,14 +126,14 @@ namespace MoBi.Presentation
       }
    }
 
-   internal class When_selecting_a_node_without_an_object_base : concern_for_HierarchicalStructurePresenter
+   internal class When_selecting_a_neighbor_node : concern_for_HierarchicalSimulationPresenter
    {
       private ObjectBaseDTO _dto;
 
       protected override void Context()
       {
          base.Context();
-         _dto = new ObjectBaseDTO();
+         _dto = new NeighborDTO(new ObjectPath());
       }
 
       protected override void Because()

--- a/tests/MoBi.Tests/Presentation/HierarchicalSpatialStructurePresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/HierarchicalSpatialStructurePresenterSpecs.cs
@@ -124,5 +124,34 @@ namespace MoBi.Presentation
             A.CallTo(() => _view.Add(_dto, _neighborhoodsContainerDTO)).MustHaveHappened();
          }
       }
+
+      internal class When_selecting_a_neighbor_node : concern_for_HierarchicalSpatialStructurePresenter
+      {
+         private ObjectBaseDTO _dto;
+         private Container _pathContainer;
+
+         protected override void Context()
+         {
+            base.Context();
+            _dto = new NeighborDTO(new ObjectPath("Organism", "Path"));
+            var rootContainer = new Container().WithName("Organism");
+            rootContainer.Mode = ContainerMode.Physical;
+            _pathContainer = new Container().WithName("Path");
+            rootContainer.Add(_pathContainer);
+
+            _spatialStructure.AddTopContainer(rootContainer);
+         }
+
+         protected override void Because()
+         {
+            sut.Select(_dto);
+         }
+
+         [Observation]
+         public void should_raise_entity_selected_event_for_the_entity_resolved_from_the_neighbor_path()
+         {
+            A.CallTo(() => _context.PublishEvent(A<EntitySelectedEvent>.That.Matches(x => x.ObjectBase == _pathContainer))).MustHaveHappened();
+         }
+      }
    }
 }


### PR DESCRIPTION
Fixes #1022

# Description
When you click on neighbors in the spatial structure view the neighbor node will act as a link to the container that it references. So you can edit the container that the neighbor references when you select the neighbor

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):