### PR TITLE
Fixes #1284 Show neighbors in the neighborhood view of a simulation

### DIFF
--- a/src/MoBi.Presentation/Mappers/NeighborhoodToNeighborDTOMapper.cs
+++ b/src/MoBi.Presentation/Mappers/NeighborhoodToNeighborDTOMapper.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using MoBi.Presentation.DTO;
+using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Utility;
+
+namespace MoBi.Presentation.Mappers
+{
+   public interface INeighborhoodToNeighborDTOMapper : IMapper<Neighborhood, IEnumerable<NeighborDTO>>, IMapper<NeighborhoodBuilder, IEnumerable<NeighborDTO>>
+   {
+   }
+
+   public class NeighborhoodToNeighborDTOMapper : INeighborhoodToNeighborDTOMapper
+   {
+      private readonly IObjectPathFactory _objectPathFactory;
+
+      public NeighborhoodToNeighborDTOMapper(IObjectPathFactory objectPathFactory)
+      {
+         _objectPathFactory = objectPathFactory;
+      }
+
+      public IEnumerable<NeighborDTO> MapFrom(Neighborhood neighborhood)
+      {
+         return createDTOFromNeighborhoodPaths(neighborhood.Id, _objectPathFactory.CreateAbsoluteObjectPath(neighborhood.FirstNeighbor), _objectPathFactory.CreateAbsoluteObjectPath(neighborhood.SecondNeighbor));
+      }
+
+      public IEnumerable<NeighborDTO> MapFrom(NeighborhoodBuilder neighborhoodBuilder)
+      {
+         return createDTOFromNeighborhoodPaths(neighborhoodBuilder.Id, neighborhoodBuilder.FirstNeighborPath, neighborhoodBuilder.SecondNeighborPath);
+      }
+
+      private IEnumerable<NeighborDTO> createDTOFromNeighborhoodPaths(string parentId, ObjectPath firstNeighborPath, ObjectPath secondNeighborPath)
+      {
+         if(firstNeighborPath != null)
+            yield return new NeighborDTO(firstNeighborPath) { Icon = ApplicationIcons.Neighbor, Id = createNeighborhoodId(parentId, firstNeighborPath) };
+         if(secondNeighborPath != null)
+            yield return new NeighborDTO(secondNeighborPath) { Icon = ApplicationIcons.Neighbor, Id = createNeighborhoodId(parentId, secondNeighborPath) };
+      }
+
+      /// <summary>
+      ///    Creates an Id for neighbors in a neighborhood.
+      ///    The Id must be distinct for each neighborhood and neighbor, so it cannot be just the
+      ///    <paramref name="neighborPath" />, but must include the <paramref name="parentId"/>
+      /// </summary>
+      /// <returns>An Id that combines the two Ids of the neighborhood and neighbor</returns>
+      private string createNeighborhoodId(string parentId, ObjectPath neighborPath)
+      {
+         return $"{parentId}-{neighborPath}";
+      }
+   }
+}

--- a/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
@@ -6,9 +6,7 @@ using MoBi.Core.Domain.Model;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Views;
-using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
-using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Utility.Events;
@@ -45,42 +43,10 @@ namespace MoBi.Presentation.Presenter
 
       protected virtual IReadOnlyList<ObjectBaseDTO> GetChildrenSorted(IContainer container, Func<IEntity, bool> predicate)
       {
-         IReadOnlyList<ObjectBaseDTO> allChildrenDTO()
-         {
-            return container.GetChildren(predicate)
-               .OrderBy(groupingTypeFor)
-               .ThenBy(x => x.Name)
-               .MapAllUsing(_objectBaseMapper);
-         }
-
-         switch (container)
-         {
-            case NeighborhoodBuilder neighborhood:
-               return neighborsOf(neighborhood).Union(allChildrenDTO()).ToList();
-            default:
-               return allChildrenDTO();
-         }
-      }
-
-      private IEnumerable<ObjectBaseDTO> neighborsOf(NeighborhoodBuilder neighborhoodBuilder)
-      {
-         if (neighborhoodBuilder.FirstNeighborPath != null)
-            yield return new NeighborDTO(neighborhoodBuilder.FirstNeighborPath) { Icon = ApplicationIcons.Neighbor, Id = createNeighborhoodId(neighborhoodBuilder, neighborhoodBuilder.FirstNeighborPath) };
-
-         if (neighborhoodBuilder.SecondNeighborPath != null)
-            yield return new NeighborDTO(neighborhoodBuilder.SecondNeighborPath) { Icon = ApplicationIcons.Neighbor, Id = createNeighborhoodId(neighborhoodBuilder, neighborhoodBuilder.SecondNeighborPath) };
-      }
-
-      /// <summary>
-      ///    Creates an Id for neighbors in a neighborhood.
-      ///    The Id must be distinct for each neighborhood and neighbor, so it cannot be just the
-      ///    <paramref name="neighborPath" />, but must
-      ///    include the id of the <paramref name="neighborhood" />
-      /// </summary>
-      /// <returns>An Id that combines the two Ids of the neighborhood and neighbor</returns>
-      private string createNeighborhoodId(NeighborhoodBuilder neighborhood, ObjectPath neighborPath)
-      {
-         return $"{neighborhood.Id}-{neighborPath}";
+         return container.GetChildren(predicate)
+            .OrderBy(groupingTypeFor)
+            .ThenBy(x => x.Name)
+            .MapAllUsing(_objectBaseMapper);
       }
 
       private ContainerType groupingTypeFor(IEntity entity)

--- a/tests/MoBi.Tests/Presentation/HierarchicalSpatialStructurePresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/HierarchicalSpatialStructurePresenterSpecs.cs
@@ -1,4 +1,5 @@
-﻿using FakeItEasy;
+﻿using System.Collections.Generic;
+using FakeItEasy;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
 using MoBi.Presentation.DTO;
@@ -7,9 +8,11 @@ using MoBi.Presentation.Nodes;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Views;
 using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation
 {
@@ -21,6 +24,7 @@ namespace MoBi.Presentation
       protected IMoBiContext _context;
       protected IHierarchicalStructureView _view;
       protected MoBiSpatialStructure _spatialStructure;
+      private INeighborhoodToNeighborDTOMapper _neighborhoodDTOMapper;
 
       protected override void Context()
       {
@@ -29,8 +33,9 @@ namespace MoBi.Presentation
          _objectBaseToObjectBaseDTOMapper = A.Fake<IObjectBaseToObjectBaseDTOMapper>();
          _contextMenuFactory = A.Fake<IViewItemContextMenuFactory>();
          _treeNodeFactory = A.Fake<ITreeNodeFactory>();
+         _neighborhoodDTOMapper = A.Fake<INeighborhoodToNeighborDTOMapper>();
 
-         sut = new HierarchicalSpatialStructurePresenter(_view, _context, _objectBaseToObjectBaseDTOMapper, _contextMenuFactory, _treeNodeFactory);
+         sut = new HierarchicalSpatialStructurePresenter(_view, _context, _objectBaseToObjectBaseDTOMapper, _contextMenuFactory, _treeNodeFactory, _neighborhoodDTOMapper);
 
          _spatialStructure = new MoBiSpatialStructure();
          sut.Edit(_spatialStructure);

--- a/tests/MoBi.Tests/Presentation/Mapper/NeighborhoodToNeighborDTOMapperSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Mapper/NeighborhoodToNeighborDTOMapperSpecs.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+
+namespace MoBi.Presentation.Mapper
+{
+   internal class concern_for_NeighborhoodToNeighborDTOMapper : ContextSpecification<NeighborhoodToNeighborDTOMapper>
+   {
+      protected IObjectPathFactory _objectPathFactory;
+
+      protected override void Context()
+      {
+         _objectPathFactory = A.Fake<IObjectPathFactory>();
+         sut = new NeighborhoodToNeighborDTOMapper(_objectPathFactory);
+      }
+   }
+
+   internal class When_mapping_a_neighborhood : concern_for_NeighborhoodToNeighborDTOMapper
+   {
+      private Neighborhood _neighborhood;
+      private ObjectPath _firstNeighborPath;
+      private ObjectPath _secondNeighborPath;
+      private IReadOnlyList<NeighborDTO> _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _neighborhood = new Neighborhood().WithName("Neighborhood");
+         _neighborhood.FirstNeighbor = new Container();
+         _neighborhood.SecondNeighbor = new Container();
+         _firstNeighborPath = new ObjectPath("first");
+         _secondNeighborPath = new ObjectPath("second");
+
+         A.CallTo(() => _objectPathFactory.CreateAbsoluteObjectPath(_neighborhood.FirstNeighbor)).Returns(_firstNeighborPath);
+         A.CallTo(() => _objectPathFactory.CreateAbsoluteObjectPath(_neighborhood.SecondNeighbor)).Returns(_secondNeighborPath);
+      }
+
+      protected override void Because()
+      {
+         _result = sut.MapFrom(_neighborhood).ToList();
+      }
+
+      [Observation]
+      public void should_create_a_dto_for_the_neighbors()
+      {
+         _result[0].Path.ShouldBeEqualTo(_firstNeighborPath);
+         _result[1].Path.ShouldBeEqualTo(_secondNeighborPath);
+      }
+
+      [Observation]
+      public void the_ids_should_contain_the_parent_id()
+      {
+         _result[0].Id.Contains(_neighborhood.Id).ShouldBeTrue();
+         _result[1].Id.Contains(_neighborhood.Id).ShouldBeTrue();
+      }
+   }
+
+   internal class When_mapping_an_incomplete_neighborhood : concern_for_NeighborhoodToNeighborDTOMapper
+   {
+      private NeighborhoodBuilder _neighborhood;
+      private IReadOnlyList<NeighborDTO> _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _neighborhood = new NeighborhoodBuilder().WithName("Neighborhood");
+         _neighborhood.FirstNeighborPath = new ObjectPath("first");
+         _neighborhood.SecondNeighborPath = null;
+      }
+
+      protected override void Because()
+      {
+         _result = sut.MapFrom(_neighborhood).ToList();
+      }
+
+      [Observation]
+      public void should_create_a_dto_for_the_non_null_neighbors()
+      {
+         _result.Count.ShouldBeEqualTo(1);
+      }
+   }
+
+   internal class When_mapping_a_neighborhood_builder : concern_for_NeighborhoodToNeighborDTOMapper
+   {
+      private NeighborhoodBuilder _neighborhood;
+      private IReadOnlyList<NeighborDTO> _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _neighborhood = new NeighborhoodBuilder().WithName("Neighborhood");
+         _neighborhood.FirstNeighborPath = new ObjectPath("first");
+         _neighborhood.SecondNeighborPath = new ObjectPath("second");
+      }
+
+      protected override void Because()
+      {
+         _result = sut.MapFrom(_neighborhood).ToList();
+      }
+
+      [Observation]
+      public void should_create_a_dto_for_the_neighbors()
+      {
+         _result[0].Path.ShouldBeEqualTo(_neighborhood.FirstNeighborPath);
+         _result[1].Path.ShouldBeEqualTo(_neighborhood.SecondNeighborPath);
+      }
+
+      [Observation]
+      public void the_ids_should_contain_the_parent_id()
+      {
+         _result[0].Id.Contains(_neighborhood.Id).ShouldBeTrue();
+         _result[1].Id.Contains(_neighborhood.Id).ShouldBeTrue();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #1284

# Description
Adding a node in the simulation editor to show each neighborhood and those nodes will also open the container editor when clicked.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/261477/79a8430e-7ef6-4f61-b94e-c1cb3ddf6d81)

# Questions (if appropriate):