### PR TITLE
1382 remove terminology default when referring to merge behavior

### DIFF
--- a/appveyor-coverage.yml
+++ b/appveyor-coverage.yml
@@ -1,5 +1,5 @@
 configuration: Debug
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 version: '{build}'
 
@@ -20,7 +20,6 @@ clone_depth: 1
 install:
   - set PATH=C:\Ruby22\bin;C:\\Python34;C:\\Python34\\Scripts;%PATH%"
   - pip install codecov
-  - ps: cinst nunit-extension-vs-project-loader --no-progress
 
 before_build:
   - nuget sources add -name bddhelper -source https://ci.appveyor.com/nuget/ospsuite-bddhelper 

--- a/appveyor-nightly.yml
+++ b/appveyor-nightly.yml
@@ -1,5 +1,5 @@
 configuration: Debug
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 version: '{build}'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 configuration: Debug
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 version: '{build}'
 

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1105,7 +1105,7 @@ namespace MoBi.Assets
          public static readonly string AddProteinExpression = "Add Protein Expression";
          public static readonly string OutputSelections = "Output Selections";
          public static readonly string SettingsAndSchema = "Settings and Schema";
-         public static readonly string DefaultMergeBehavior = "Default Merge Behavior";
+         public static readonly string MergeBehavior = "Merge Behavior";
 
          public static string AddNew(string objectTypeName) => $"Create {objectTypeName}...";
 
@@ -1606,7 +1606,7 @@ namespace MoBi.Assets
          public static readonly string NewParameterValuesBuildingBlock = "New Parameter Values Building Block";
          public static readonly string MakeDefault = "Make defaults";
          public static readonly string LoadFromDefaults = "Load from defaults";
-         public static readonly string DefaultMergeBehavior = "Default Merge Behavior";
+         public static readonly string MergeBehavior = "Merge Behavior";
          public static readonly string ExtendMergeBehaviorDescription = "The module containers will be merged recursively using add and update behavior";
          public static readonly string OverwriteMergeBehaviorDescription = "The module containers will be replaced by path";
 

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.294" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.294" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.Core/Commands/SetMergeBehaviorCommand.cs
+++ b/src/MoBi.Core/Commands/SetMergeBehaviorCommand.cs
@@ -6,13 +6,13 @@ using OSPSuite.Core.Domain;
 
 namespace MoBi.Core.Commands
 {
-   public class SetDefaultMergeBehaviorCommand : MoBiReversibleCommand
+   public class SetMergeBehaviorCommand : MoBiReversibleCommand
    {
       private Module _module;
       private MergeBehavior _oldBehavior;
       private readonly MergeBehavior _newMergeBehavior;
 
-      public SetDefaultMergeBehaviorCommand(Module module, MergeBehavior newMergeBehavior)
+      public SetMergeBehaviorCommand(Module module, MergeBehavior newMergeBehavior)
       {
          ObjectType = new ObjectTypeResolver().TypeFor<Module>();
          CommandType = AppConstants.Commands.EditCommand;
@@ -29,13 +29,13 @@ namespace MoBi.Core.Commands
 
       protected override void ExecuteWith(IMoBiContext context)
       {
-         _oldBehavior = _module.DefaultMergeBehavior;
-         _module.DefaultMergeBehavior = _newMergeBehavior;
+         _oldBehavior = _module.MergeBehavior;
+         _module.MergeBehavior = _newMergeBehavior;
       }
 
       protected override void ClearReferences() => _module = null;
 
-      protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context) => new SetDefaultMergeBehaviorCommand(_module, _oldBehavior).AsInverseFor(this);
+      protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context) => new SetMergeBehaviorCommand(_module, _oldBehavior).AsInverseFor(this);
 
       public override void RestoreExecutionData(IMoBiContext context) => _module = context.Get<Module>(ModuleId);
    }

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.294" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.0-subZE" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.296" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.296" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.294" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-subZE" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/DTO/AddBuildingBlocksToModuleDTO.cs
+++ b/src/MoBi.Presentation/DTO/AddBuildingBlocksToModuleDTO.cs
@@ -40,7 +40,7 @@ namespace MoBi.Presentation.DTO
          _existingParameterValuesNames = new List<string>();
          _existingInitialConditionsNames = new List<string>();
 
-         DefaultMergeBehavior = module.DefaultMergeBehavior;
+         MergeBehavior = module.MergeBehavior;
 
          Rules.AddRange(AllRules.All);
       }

--- a/src/MoBi.Presentation/DTO/CloneBuildingBlocksToModuleDTO.cs
+++ b/src/MoBi.Presentation/DTO/CloneBuildingBlocksToModuleDTO.cs
@@ -40,7 +40,7 @@ namespace MoBi.Presentation.DTO
          CanSelectParameterValues = module.ParameterValuesCollection.Any();
          WithParameterValues = CanSelectParameterValues;
 
-         DefaultMergeBehavior = module.DefaultMergeBehavior;
+         MergeBehavior = module.MergeBehavior;
       }
 
       public IReadOnlyCollection<IBuildingBlock> BuildingBlocksToRemove {

--- a/src/MoBi.Presentation/DTO/ModuleContentDTO.cs
+++ b/src/MoBi.Presentation/DTO/ModuleContentDTO.cs
@@ -4,7 +4,7 @@ namespace MoBi.Presentation.DTO
 {
    public class ModuleContentDTO : ObjectBaseDTO, IWithProhibitedNames
    {
-      public MergeBehavior DefaultMergeBehavior { get; set; }
+      public MergeBehavior MergeBehavior { get; set; }
       public bool WithReaction { get; set; }
       public bool WithEventGroup { get; set; }
       public bool WithSpatialStructure { get; set; }

--- a/src/MoBi.Presentation/Mappers/CreateModuleDTOToModuleMapper.cs
+++ b/src/MoBi.Presentation/Mappers/CreateModuleDTOToModuleMapper.cs
@@ -80,7 +80,7 @@ namespace MoBi.Presentation.Mappers
             module.Add(CreateDefault<InitialConditionsBuildingBlock>(DefaultNames.InitialConditions));
          }
 
-         module.DefaultMergeBehavior = createModuleDTO.DefaultMergeBehavior;
+         module.MergeBehavior = createModuleDTO.MergeBehavior;
 
          return module;
       }

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForModule.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForModule.cs
@@ -50,12 +50,12 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
 
       private IMenuBarItem createDefaultMergeBehaviorItemFor(Module module)
       {
-         return CreateSubMenu.WithCaption(AppConstants.MenuNames.DefaultMergeBehavior)
+         return CreateSubMenu.WithCaption(AppConstants.MenuNames.MergeBehavior)
             .WithItem(CreateMenuCheckButton.WithCaption(MergeBehavior.Overwrite.ToString())
-               .WithChecked(module.DefaultMergeBehavior == MergeBehavior.Overwrite)
+               .WithChecked(module.MergeBehavior == MergeBehavior.Overwrite)
                .WithCommandFor<MakeOverwriteModuleUICommand, Module>(module, _container))
             .WithItem(CreateMenuCheckButton.WithCaption(MergeBehavior.Extend.ToString())
-               .WithChecked(module.DefaultMergeBehavior == MergeBehavior.Extend)
+               .WithChecked(module.MergeBehavior == MergeBehavior.Extend)
                .WithCommandFor<MakeExtendModuleUICommand, Module>(module, _container));
       }
 

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.294" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/AddContentToModulePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/AddContentToModulePresenter.cs
@@ -19,7 +19,7 @@ namespace MoBi.Presentation.Presenter
       protected abstract Module Module { get; }
       protected abstract ModuleContentDTO ContentDTO { get; }
 
-      public override MergeBehavior SelectedBehavior => ContentDTO.DefaultMergeBehavior;
+      public override MergeBehavior SelectedBehavior => ContentDTO.MergeBehavior;
 
       public void AddMoleculesSelectionChanged(bool moleculesSelected)
       {

--- a/src/MoBi.Presentation/Presenter/BaseModuleContentPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/BaseModuleContentPresenter.cs
@@ -12,7 +12,7 @@ namespace MoBi.Presentation.Presenter
    public interface IBaseModuleContentPresenter : IDisposablePresenter
    {
       IReadOnlyList<MergeBehavior> AllMergeBehaviors { get; }
-      void DefaultMergeBehaviorChanged();
+      void MergeBehaviorChanged();
    }
 
    public abstract class BaseModuleContentPresenter<TView, TPresenter> : AbstractDisposablePresenter<TView, TPresenter> where TView : IBaseModuleContentView<TPresenter> where TPresenter : IBaseModuleContentPresenter
@@ -25,7 +25,7 @@ namespace MoBi.Presentation.Presenter
       public IReadOnlyList<MergeBehavior> AllMergeBehaviors => EnumHelper.AllValuesFor<MergeBehavior>().ToList();
 
 
-      public void DefaultMergeBehaviorChanged()
+      public void MergeBehaviorChanged()
       {
          updateMergeBehaviorDescription();
       }

--- a/src/MoBi.Presentation/Presenter/CloneBuildingBlocksToModulePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/CloneBuildingBlocksToModulePresenter.cs
@@ -42,11 +42,11 @@ namespace MoBi.Presentation.Presenter
          _dto.BuildingBlocksToRemove.Each(clonedModule.Remove);
 
          clonedModule.Name = _dto.Name;
-         clonedModule.DefaultMergeBehavior = _dto.DefaultMergeBehavior;
+         clonedModule.MergeBehavior = _dto.MergeBehavior;
 
          return true;
       }
 
-      public override MergeBehavior SelectedBehavior => _dto.DefaultMergeBehavior;
+      public override MergeBehavior SelectedBehavior => _dto.MergeBehavior;
    }
 }

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForModule.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForModule.cs
@@ -82,9 +82,9 @@ namespace MoBi.Presentation.Tasks.Interaction
 
       public void AddNewParameterValuesBuildingBlock(Module module) => addBuildingBlocksToModule(module, presenter => presenter.AddParameterValuesToModule(module));
 
-      public void MakeExtendModule(Module module) => context.AddToHistory(new SetDefaultMergeBehaviorCommand(module, MergeBehavior.Extend).Run(context));
+      public void MakeExtendModule(Module module) => context.AddToHistory(new SetMergeBehaviorCommand(module, MergeBehavior.Extend).Run(context));
 
-      public void MakeOverwriteModule(Module module) => context.AddToHistory(new SetDefaultMergeBehaviorCommand(module, MergeBehavior.Overwrite).Run(context));
+      public void MakeOverwriteModule(Module module) => context.AddToHistory(new SetMergeBehaviorCommand(module, MergeBehavior.Overwrite).Run(context));
 
       public void AddNewInitialConditionsBuildingBlock(Module module) => addBuildingBlocksToModule(module, presenter => presenter.AddInitialConditionsToModule(module));
 

--- a/src/MoBi.Presentation/UICommand/MakeExtendModuleUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/MakeExtendModuleUICommand.cs
@@ -15,7 +15,7 @@ namespace MoBi.Presentation.UICommand
 
       protected override void PerformExecute()
       {
-         if(Subject.DefaultMergeBehavior != MergeBehavior.Extend)
+         if(Subject.MergeBehavior != MergeBehavior.Extend)
             _tasks.MakeExtendModule(Subject);
       }
    }

--- a/src/MoBi.Presentation/UICommand/MakeOverwriteModuleUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/MakeOverwriteModuleUICommand.cs
@@ -15,7 +15,7 @@ namespace MoBi.Presentation.UICommand
 
       protected override void PerformExecute()
       {
-         if(Subject.DefaultMergeBehavior != MergeBehavior.Overwrite)
+         if(Subject.MergeBehavior != MergeBehavior.Overwrite)
             _tasks.MakeOverwriteModule(Subject);
       } 
    }

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.294" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/Views/BaseModuleContentView.Designer.cs
+++ b/src/MoBi.UI/Views/BaseModuleContentView.Designer.cs
@@ -61,10 +61,10 @@
          this.moleculesItem = new DevExpress.XtraLayout.LayoutControlItem();
          this.parameterValuesNameItem = new DevExpress.XtraLayout.LayoutControlItem();
          this.initialConditionsNameItem = new DevExpress.XtraLayout.LayoutControlItem();
-         this.defaultMergeBehaviorItem = new DevExpress.XtraLayout.LayoutControlItem();
+         this.mergeBehaviorItem = new DevExpress.XtraLayout.LayoutControlItem();
          this.lblDescription = new DevExpress.XtraEditors.LabelControl();
          this.layoutControlItem1 = new DevExpress.XtraLayout.LayoutControlItem();
-         this.defaultMergeBehaviorGroup = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.mergeBehaviorGroup = new DevExpress.XtraLayout.LayoutControlGroup();
          ((System.ComponentModel.ISupportInitialize)(this.tablePanel)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.checkEdit1.Properties)).BeginInit();
@@ -99,9 +99,9 @@
          ((System.ComponentModel.ISupportInitialize)(this.moleculesItem)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.parameterValuesNameItem)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.initialConditionsNameItem)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.defaultMergeBehaviorItem)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.mergeBehaviorItem)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.defaultMergeBehaviorGroup)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.mergeBehaviorGroup)).BeginInit();
          this.SuspendLayout();
          // 
          // tablePanel
@@ -284,7 +284,7 @@
             this.emptySpaceItem1,
             this.moduleNameItem,
             this.createBuildingBlocksGroup,
-            this.defaultMergeBehaviorGroup});
+            this.mergeBehaviorGroup});
          this.Root.Name = "Root";
          this.Root.Size = new System.Drawing.Size(580, 401);
          this.Root.TextVisible = false;
@@ -412,11 +412,11 @@
          // 
          // defaultMergeBehaviorItem
          // 
-         this.defaultMergeBehaviorItem.Control = this.cbDefaultMergeBehavior;
-         this.defaultMergeBehaviorItem.Location = new System.Drawing.Point(0, 0);
-         this.defaultMergeBehaviorItem.Name = "defaultMergeBehaviorItem";
-         this.defaultMergeBehaviorItem.Size = new System.Drawing.Size(536, 24);
-         this.defaultMergeBehaviorItem.TextSize = new System.Drawing.Size(130, 13);
+         this.mergeBehaviorItem.Control = this.cbDefaultMergeBehavior;
+         this.mergeBehaviorItem.Location = new System.Drawing.Point(0, 0);
+         this.mergeBehaviorItem.Name = "mergeBehaviorItem";
+         this.mergeBehaviorItem.Size = new System.Drawing.Size(536, 24);
+         this.mergeBehaviorItem.TextSize = new System.Drawing.Size(130, 13);
          // 
          // lblDescription
          // 
@@ -438,12 +438,12 @@
          // 
          // defaultMergeBehaviorGroup
          // 
-         this.defaultMergeBehaviorGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+         this.mergeBehaviorGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
             this.layoutControlItem1,
-            this.defaultMergeBehaviorItem});
-         this.defaultMergeBehaviorGroup.Location = new System.Drawing.Point(0, 24);
-         this.defaultMergeBehaviorGroup.Name = "defaultMergeBehaviorGroup";
-         this.defaultMergeBehaviorGroup.Size = new System.Drawing.Size(560, 86);
+            this.mergeBehaviorItem});
+         this.mergeBehaviorGroup.Location = new System.Drawing.Point(0, 24);
+         this.mergeBehaviorGroup.Name = "mergeBehaviorGroup";
+         this.mergeBehaviorGroup.Size = new System.Drawing.Size(560, 86);
          // 
          // BaseModuleContentView
          // 
@@ -488,9 +488,9 @@
          ((System.ComponentModel.ISupportInitialize)(this.moleculesItem)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.parameterValuesNameItem)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.initialConditionsNameItem)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.defaultMergeBehaviorItem)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.mergeBehaviorItem)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.defaultMergeBehaviorGroup)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.mergeBehaviorGroup)).EndInit();
          this.ResumeLayout(false);
          this.PerformLayout();
 
@@ -528,9 +528,9 @@
       protected DevExpress.XtraLayout.LayoutControlItem parameterValuesNameItem;
       protected DevExpress.XtraLayout.LayoutControlItem initialConditionsNameItem;
       private OSPSuite.UI.Controls.UxComboBoxEdit cbDefaultMergeBehavior;
-      private DevExpress.XtraLayout.LayoutControlItem defaultMergeBehaviorItem;
+      private DevExpress.XtraLayout.LayoutControlItem mergeBehaviorItem;
       private DevExpress.XtraEditors.LabelControl lblDescription;
       private DevExpress.XtraLayout.LayoutControlItem layoutControlItem1;
-      private DevExpress.XtraLayout.LayoutControlGroup defaultMergeBehaviorGroup;
+      private DevExpress.XtraLayout.LayoutControlGroup mergeBehaviorGroup;
    }
 }

--- a/src/MoBi.UI/Views/BaseModuleContentView.cs
+++ b/src/MoBi.UI/Views/BaseModuleContentView.cs
@@ -43,8 +43,8 @@ namespace MoBi.UI.Views
          cbInitialConditions.Text = InitialConditions;
          cbParameterValues.Text = ParameterValues;
          createBuildingBlocksGroup.Text = CreateBuildingBlocks;
-         defaultMergeBehaviorGroup.Text = DefaultMergeBehavior;
-         defaultMergeBehaviorItem.TextVisible = false;
+         mergeBehaviorGroup.Text = MergeBehavior;
+         mergeBehaviorItem.TextVisible = false;
          initialConditionsNameItem.Text = AppConstants.Captions.Name.FormatForLabel();
          parameterValuesNameItem.Text = AppConstants.Captions.Name.FormatForLabel();
 
@@ -73,7 +73,7 @@ namespace MoBi.UI.Views
 
       public virtual void AttachPresenter(TPresenter presenter) => _presenter = presenter;
 
-      public void DisableDefaultMergeBehavior() => defaultMergeBehaviorItem.Enabled = false;
+      public void DisableDefaultMergeBehavior() => mergeBehaviorItem.Enabled = false;
 
       public override void InitializeBinding()
       {
@@ -86,7 +86,7 @@ namespace MoBi.UI.Views
          _screenBinder.Bind(dto => dto.WithReaction).To(cbReactions);
          _screenBinder.Bind(dto => dto.WithParameterValues).To(cbParameterValues).OnValueUpdated += (o, newValue) => OnEvent(() => ShowOrHideNamingItem(parameterValuesNameItem, show: newValue));
          _screenBinder.Bind(dto => dto.WithInitialConditions).To(cbInitialConditions).OnValueUpdated += (o, newValue) => OnEvent(() => ShowOrHideNamingItem(initialConditionsNameItem, show: newValue));
-         _screenBinder.Bind(dto => dto.DefaultMergeBehavior).To(cbDefaultMergeBehavior).WithValues(_presenter.AllMergeBehaviors).Changed += () => OnEvent(_presenter.DefaultMergeBehaviorChanged);
+         _screenBinder.Bind(dto => dto.MergeBehavior).To(cbDefaultMergeBehavior).WithValues(_presenter.AllMergeBehaviors).Changed += () => OnEvent(_presenter.MergeBehaviorChanged);
 
          RegisterValidationFor(_screenBinder);
       }
@@ -96,7 +96,7 @@ namespace MoBi.UI.Views
       public virtual void BindTo(TDTO moduleContentDTO)
       {
          _screenBinder.BindToSource(moduleContentDTO);
-         _presenter.DefaultMergeBehaviorChanged();
+         _presenter.MergeBehaviorChanged();
          disableExistingBuildingBlocks(moduleContentDTO);
       }
 

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -72,13 +72,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-subZE" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.296" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -72,13 +72,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.294" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.294" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-subZE" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/Core/Commands/SetMergeBehaviorCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/SetMergeBehaviorCommandSpecs.cs
@@ -6,7 +6,7 @@ using OSPSuite.Core.Domain;
 
 namespace MoBi.Core.Commands
 {
-   internal abstract class concern_for_SetDefaultMergeBehaviorCommand : ContextSpecification<SetDefaultMergeBehaviorCommand>
+   internal abstract class concern_for_SetMergeBehaviorCommand : ContextSpecification<SetMergeBehaviorCommand>
    {
       protected Module _module;
       protected IMoBiContext _context;
@@ -16,20 +16,20 @@ namespace MoBi.Core.Commands
          _module = new Module().WithId("moduleid");
          _context = A.Fake<IMoBiContext>();
          A.CallTo(() => _context.Get<Module>(_module.Id)).Returns(_module);
-         sut = new SetDefaultMergeBehaviorCommand(_module, MergeBehavior);
+         sut = new SetMergeBehaviorCommand(_module, MergeBehavior);
       }
 
       public abstract MergeBehavior MergeBehavior { get; }
    }
 
-   internal class when_setting_module_to_extend : concern_for_SetDefaultMergeBehaviorCommand
+   internal class when_setting_module_to_extend : concern_for_SetMergeBehaviorCommand
    {
       public override MergeBehavior MergeBehavior => MergeBehavior.Extend;
 
       protected override void Context()
       {
          base.Context();
-         _module.DefaultMergeBehavior = MergeBehavior.Overwrite;
+         _module.MergeBehavior = MergeBehavior.Overwrite;
       }
 
       protected override void Because()
@@ -40,18 +40,18 @@ namespace MoBi.Core.Commands
       [Observation]
       public void the_module_merge_behavior_should_be_updated()
       {
-         _module.DefaultMergeBehavior.ShouldBeEqualTo(MergeBehavior.Extend);
+         _module.MergeBehavior.ShouldBeEqualTo(MergeBehavior.Extend);
       }
    }
 
-   internal class when_setting_module_to_overwrite : concern_for_SetDefaultMergeBehaviorCommand
+   internal class when_setting_module_to_overwrite : concern_for_SetMergeBehaviorCommand
    {
       public override MergeBehavior MergeBehavior => MergeBehavior.Overwrite;
 
       protected override void Context()
       {
          base.Context();
-         _module.DefaultMergeBehavior = MergeBehavior.Extend;
+         _module.MergeBehavior = MergeBehavior.Extend;
       }
 
       protected override void Because()
@@ -62,18 +62,18 @@ namespace MoBi.Core.Commands
       [Observation]
       public void the_module_merge_behavior_should_be_updated()
       {
-         _module.DefaultMergeBehavior.ShouldBeEqualTo(MergeBehavior.Overwrite);
+         _module.MergeBehavior.ShouldBeEqualTo(MergeBehavior.Overwrite);
       }
    }
 
-   internal class when_reversing_setting_module_to_overwrite : concern_for_SetDefaultMergeBehaviorCommand
+   internal class when_reversing_setting_module_to_overwrite : concern_for_SetMergeBehaviorCommand
    {
       public override MergeBehavior MergeBehavior => MergeBehavior.Overwrite;
 
       protected override void Context()
       {
          base.Context();
-         _module.DefaultMergeBehavior = MergeBehavior.Extend;
+         _module.MergeBehavior = MergeBehavior.Extend;
       }
 
       protected override void Because()
@@ -84,18 +84,18 @@ namespace MoBi.Core.Commands
       [Observation]
       public void the_module_merge_behavior_should_be_reverted()
       {
-         _module.DefaultMergeBehavior.ShouldBeEqualTo(MergeBehavior.Extend);
+         _module.MergeBehavior.ShouldBeEqualTo(MergeBehavior.Extend);
       }
    }
 
-   internal class when_reversing_setting_module_to_extend : concern_for_SetDefaultMergeBehaviorCommand
+   internal class when_reversing_setting_module_to_extend : concern_for_SetMergeBehaviorCommand
    {
       public override MergeBehavior MergeBehavior => MergeBehavior.Extend;
 
       protected override void Context()
       {
          base.Context();
-         _module.DefaultMergeBehavior = MergeBehavior.Overwrite;
+         _module.MergeBehavior = MergeBehavior.Overwrite;
       }
 
       protected override void Because()
@@ -106,7 +106,7 @@ namespace MoBi.Core.Commands
       [Observation]
       public void the_module_merge_behavior_should_be_reverted()
       {
-         _module.DefaultMergeBehavior.ShouldBeEqualTo(MergeBehavior.Overwrite);
+         _module.MergeBehavior.ShouldBeEqualTo(MergeBehavior.Overwrite);
       }
    }
 }

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.296" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.294" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-subZE" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/CloneBuildingBlocksToModulePresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/CloneBuildingBlocksToModulePresenterSpecs.cs
@@ -40,7 +40,7 @@ namespace MoBi.Presentation
          {
             dto.WithSpatialStructure = false;
             dto.Name = "a new name";
-            dto.DefaultMergeBehavior = MergeBehavior.Extend;
+            dto.MergeBehavior = MergeBehavior.Extend;
          });
       }
 
@@ -58,7 +58,7 @@ namespace MoBi.Presentation
       [Observation]
       public void the_cloned_module_should_retain_the_default_merge_behavior()
       {
-         _clonedModule.DefaultMergeBehavior.ShouldBeEqualTo(MergeBehavior.Extend);
+         _clonedModule.MergeBehavior.ShouldBeEqualTo(MergeBehavior.Extend);
       }
 
       [Observation]

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.294" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.294" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-subZE" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-subZE" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-subZE" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.296" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1382 

# Description
We don't want to refer to a module as having a 'Default' merge behavior, implying it can be overridden.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):