### PR TITLE
#1369 Changing the "Merge behavior" of a module should mark the simulation as "not synched"

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.297" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.297" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />

--- a/src/MoBi.Core/Commands/SetMergeBehaviorCommand.cs
+++ b/src/MoBi.Core/Commands/SetMergeBehaviorCommand.cs
@@ -1,8 +1,10 @@
 ﻿using MoBi.Assets;
 using MoBi.Core.Domain.Model;
+using MoBi.Core.Events;
 using MoBi.Core.Helper;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
+using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Core.Commands
 {
@@ -21,7 +23,7 @@ namespace MoBi.Core.Commands
          _module = module;
          _newMergeBehavior = newMergeBehavior;
          ModuleId = module.Id;
-         
+
          _module = module;
       }
 
@@ -31,6 +33,7 @@ namespace MoBi.Core.Commands
       {
          _oldBehavior = _module.MergeBehavior;
          _module.MergeBehavior = _newMergeBehavior;
+         context.CurrentProject.SimulationsUsing(_module).Each(x => context.PublishEvent(new SimulationStatusChangedEvent(x)));
       }
 
       protected override void ClearReferences() => _module = null;

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="2.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.297" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.297" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.297" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.297" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -72,13 +72,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.297" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.296" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.297" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.4" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -45,10 +45,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.297" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.54" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.56" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.8" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.296" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.296" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.297" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.297" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1369 

# Description

Added SimulationStatusChangedEvents firing when modifying MergeBehavior, so diff between versions of modules are re-evaluated. Together with an issue-fix in Core ( https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/issues/2271 ) to take the mergebehavior into account in the version-hash this results in a correct sync-no sync indicator. 

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
When the module is set to extend: 
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/27804639/63a31e8e-b8dc-4eb0-b4aa-6a711ee8b6cb)

the simulation-view looks like this: 
![image](https://github.com/Open-Systems-Pharmacology/MoBi/assets/27804639/ee1d1eb5-2f3d-4e96-8e38-b3e5ef36901d)


# Questions (if appropriate):