### PR TITLE
#1364 new passive transport default label when unnamed

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
@@ -15,6 +15,7 @@ using MoBi.Presentation.Views;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
@@ -72,6 +73,7 @@ namespace MoBi.Presentation.Presenter
       private readonly IEditDistributedParameterPresenter _editDistributedParameterPresenter;
       private readonly IEditParameterPresenter _editParameterPresenter;
       private bool _ignoreAddEvents;
+
       public bool ChangeLocalisationAllowed { set; private get; }
 
       public EditParametersInContainerPresenter(IEditParametersInContainerView view,
@@ -109,7 +111,7 @@ namespace MoBi.Presentation.Presenter
          RhsReference = getNewReferencePresenterFor(container);
          ShowBuildMode = container.CanSetBuildModeForParameters();
          ParameterBuildModes = container.AvailableBuildModeForParameters();
-         _view.ParentName = container.Name;
+         _view.SetNameForContainer(container);
          createParameterCache(_getParametersFunc(container));
          showParameters();
       }

--- a/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
@@ -18,7 +18,6 @@ using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Services;
-using OSPSuite.Presentation.Extensions;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Utility.Collections;
 using OSPSuite.Utility.Events;
@@ -89,7 +88,7 @@ namespace MoBi.Presentation.Presenter
          IClipboardManager clipboardManager,
          IEditTaskFor<IParameter> editTask,
          ISelectReferencePresenterFactory selectReferencePresenterFactory,
-         IFavoriteTask favoriteTask, 
+         IFavoriteTask favoriteTask,
          IObjectTypeResolver typeResolver)
          : base(view, quantityTask, interactionTaskContext, formulaMapper, parameterTask, favoriteTask)
       {

--- a/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
@@ -168,7 +168,7 @@ namespace MoBi.Presentation.Presenter
 
       private string getContainerName(IContainer container)
       {
-         return string.IsNullOrEmpty(container.Name) ? $"New {_typeResolver.TypeFor(container)}" : container.Name;
+         return string.IsNullOrEmpty(container.Name) ? AppConstants.Captions.NewWindow(_typeResolver.TypeFor(container)) : container.Name;
       }
 
       public void Select(IParameter parameter)

--- a/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
@@ -166,10 +166,9 @@ namespace MoBi.Presentation.Presenter
          return referencePresenter;
       }
 
-      private string getContainerName(IContainer container)
-      {
-         return string.IsNullOrEmpty(container.Name) ? AppConstants.Captions.NewWindow(_typeResolver.TypeFor(container)) : container.Name;
-      }
+      private string getContainerName(IContainer container) =>
+         string.IsNullOrEmpty(container.Name) ? AppConstants.Captions.NewWindow(_typeResolver.TypeFor(container)) : container.Name;
+      
 
       public void Select(IParameter parameter)
       {

--- a/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
@@ -15,8 +15,10 @@ using MoBi.Presentation.Views;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Services;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Utility.Collections;
 using OSPSuite.Utility.Events;
@@ -72,6 +74,7 @@ namespace MoBi.Presentation.Presenter
       private readonly IEditDistributedParameterPresenter _editDistributedParameterPresenter;
       private readonly IEditParameterPresenter _editParameterPresenter;
       private bool _ignoreAddEvents;
+      private readonly IObjectTypeResolver _typeResolver;
 
       public bool ChangeLocalisationAllowed { set; private get; }
 
@@ -86,7 +89,8 @@ namespace MoBi.Presentation.Presenter
          IClipboardManager clipboardManager,
          IEditTaskFor<IParameter> editTask,
          ISelectReferencePresenterFactory selectReferencePresenterFactory,
-         IFavoriteTask favoriteTask)
+         IFavoriteTask favoriteTask, 
+         IObjectTypeResolver typeResolver)
          : base(view, quantityTask, interactionTaskContext, formulaMapper, parameterTask, favoriteTask)
       {
          _clipboardManager = clipboardManager;
@@ -101,6 +105,7 @@ namespace MoBi.Presentation.Presenter
          AddSubPresenters(_editDistributedParameterPresenter, _editParameterPresenter);
          _getParametersFunc = x => x.GetChildrenSortedByName<IParameter>();
          ChangeLocalisationAllowed = true;
+         _typeResolver = typeResolver;
       }
 
       public void Edit(IContainer container)
@@ -110,7 +115,7 @@ namespace MoBi.Presentation.Presenter
          RhsReference = getNewReferencePresenterFor(container);
          ShowBuildMode = container.CanSetBuildModeForParameters();
          ParameterBuildModes = container.AvailableBuildModeForParameters();
-         _view.SetNameForContainer(container);
+         _view.ParentName = getContainerName(container);
          createParameterCache(_getParametersFunc(container));
          showParameters();
       }
@@ -160,6 +165,11 @@ namespace MoBi.Presentation.Presenter
          var referencePresenter = _selectReferencePresenterFactory.ReferenceAtParameterFor(container);
          referencePresenter.ChangeLocalisationAllowed = ChangeLocalisationAllowed;
          return referencePresenter;
+      }
+
+      private string getContainerName(IContainer container)
+      {
+         return string.IsNullOrEmpty(container.Name) ? $"New {_typeResolver.TypeFor(container)}" : container.Name;
       }
 
       public void Select(IParameter parameter)

--- a/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
@@ -15,7 +15,6 @@ using MoBi.Presentation.Views;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
-using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
@@ -374,7 +373,7 @@ namespace MoBi.Presentation.Presenter
 
          if (parameter.IsAnImplementationOf<IDistributedParameter>())
          {
-            _editDistributedParameterPresenter.Edit((IDistributedParameter) parameter);
+            _editDistributedParameterPresenter.Edit((IDistributedParameter)parameter);
             _view.SetEditParameterView(_editDistributedParameterPresenter.View);
          }
          else

--- a/src/MoBi.Presentation/Views/IEditParametersInContainerView.cs
+++ b/src/MoBi.Presentation/Views/IEditParametersInContainerView.cs
@@ -6,13 +6,13 @@ using OSPSuite.Presentation.Views;
 
 namespace MoBi.Presentation.Views
 {
-   public interface IEditParametersInContainerView :  IView<IEditParametersInContainerPresenter>
+   public interface IEditParametersInContainerView : IView<IEditParametersInContainerPresenter>
    {
       void SetNameForContainer(IContainer container);
       void BindTo(IEnumerable<ParameterDTO> dtos);
       EditParameterMode EditMode { get; set; }
       bool ShowBuildMode { get; set; }
-      string ParentName {  set; }
+      string ParentName { set; }
       void SetEditParameterView(IView view);
       void RefreshList();
       void Select(ParameterDTO parameterToSelect);

--- a/src/MoBi.Presentation/Views/IEditParametersInContainerView.cs
+++ b/src/MoBi.Presentation/Views/IEditParametersInContainerView.cs
@@ -1,12 +1,14 @@
 ﻿using System.Collections.Generic;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Presenter;
+using OSPSuite.Core.Domain;
 using OSPSuite.Presentation.Views;
 
 namespace MoBi.Presentation.Views
 {
    public interface IEditParametersInContainerView :  IView<IEditParametersInContainerPresenter>
    {
+      void SetNameForContainer(IContainer container);
       void BindTo(IEnumerable<ParameterDTO> dtos);
       EditParameterMode EditMode { get; set; }
       bool ShowBuildMode { get; set; }

--- a/src/MoBi.Presentation/Views/IEditParametersInContainerView.cs
+++ b/src/MoBi.Presentation/Views/IEditParametersInContainerView.cs
@@ -8,7 +8,6 @@ namespace MoBi.Presentation.Views
 {
    public interface IEditParametersInContainerView : IView<IEditParametersInContainerPresenter>
    {
-      void SetNameForContainer(IContainer container);
       void BindTo(IEnumerable<ParameterDTO> dtos);
       EditParameterMode EditMode { get; set; }
       bool ShowBuildMode { get; set; }

--- a/src/MoBi.UI/Views/EditParametersInContainerView.cs
+++ b/src/MoBi.UI/Views/EditParametersInContainerView.cs
@@ -56,9 +56,9 @@ namespace MoBi.UI.Views
       private readonly RepositoryItemButtonEdit _removeButtonRepository = new UxRepositoryItemButtonEdit(ButtonPredefines.Delete);
       private RepositoryItemButtonEdit _nameButtonRepository;
       private readonly UxRepositoryItemCheckEdit _checkBoxRepository;
-      private readonly IObjectTypeResolver _typeResolver;
+      
 
-      public EditParametersInContainerView(IToolTipCreator toolTipCreator, ValueOriginBinder<ParameterDTO> valueOriginBinder, IObjectTypeResolver typeResolver)
+      public EditParametersInContainerView(IToolTipCreator toolTipCreator, ValueOriginBinder<ParameterDTO> valueOriginBinder)
       {
          _toolTipCreator = toolTipCreator;
          _valueOriginBinder = valueOriginBinder;
@@ -81,7 +81,7 @@ namespace MoBi.UI.Views
          toolTipController.GetActiveObjectInfo += onToolTipControllerGetActiveObjectInfo;
 
          _checkBoxRepository = new UxRepositoryItemCheckEdit(_gridView);
-         _typeResolver = typeResolver;
+      
       }
 
       private void hideEditor()
@@ -373,9 +373,6 @@ namespace MoBi.UI.Views
       {
          set => lblParentName.Text = value.FormatForLabel(checkCase: false);
       }
-
-      public void SetNameForContainer(IContainer container) =>
-         lblParentName.Text = string.IsNullOrEmpty(container.Name) ? $"New {_typeResolver.TypeFor(container)}".FormatForLabel(checkCase: false) : container.Name.FormatForLabel(checkCase: false);
 
       public void SetEditParameterView(IView subView)
       {

--- a/src/MoBi.UI/Views/EditParametersInContainerView.cs
+++ b/src/MoBi.UI/Views/EditParametersInContainerView.cs
@@ -17,7 +17,6 @@ using MoBi.UI.Extensions;
 using MoBi.UI.Services;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
-using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
@@ -56,7 +55,6 @@ namespace MoBi.UI.Views
       private readonly RepositoryItemButtonEdit _removeButtonRepository = new UxRepositoryItemButtonEdit(ButtonPredefines.Delete);
       private RepositoryItemButtonEdit _nameButtonRepository;
       private readonly UxRepositoryItemCheckEdit _checkBoxRepository;
-      
 
       public EditParametersInContainerView(IToolTipCreator toolTipCreator, ValueOriginBinder<ParameterDTO> valueOriginBinder)
       {
@@ -81,7 +79,6 @@ namespace MoBi.UI.Views
          toolTipController.GetActiveObjectInfo += onToolTipControllerGetActiveObjectInfo;
 
          _checkBoxRepository = new UxRepositoryItemCheckEdit(_gridView);
-      
       }
 
       private void hideEditor()

--- a/src/MoBi.UI/Views/EditParametersInContainerView.cs
+++ b/src/MoBi.UI/Views/EditParametersInContainerView.cs
@@ -368,7 +368,7 @@ namespace MoBi.UI.Views
 
       public string ParentName
       {
-         set => lblParentName.Text = value.FormatForLabel(checkCase: false);
+         set => lblParentName.Text = string.IsNullOrEmpty(value) ? "New passive transport:" : value.FormatForLabel(checkCase: false);
       }
 
       public void SetEditParameterView(IView subView)

--- a/src/MoBi.UI/Views/EditParametersInContainerView.cs
+++ b/src/MoBi.UI/Views/EditParametersInContainerView.cs
@@ -286,7 +286,6 @@ namespace MoBi.UI.Views
          return repository;
       }
 
-    
       public void BindTo(IEnumerable<ParameterDTO> parameters)
       {
          chkShowAdvancedParameter.Checked = _presenter.ShowAdvancedParameters;

--- a/src/MoBi.UI/Views/EditParametersInContainerView.cs
+++ b/src/MoBi.UI/Views/EditParametersInContainerView.cs
@@ -17,6 +17,7 @@ using MoBi.UI.Extensions;
 using MoBi.UI.Services;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
@@ -55,8 +56,9 @@ namespace MoBi.UI.Views
       private readonly RepositoryItemButtonEdit _removeButtonRepository = new UxRepositoryItemButtonEdit(ButtonPredefines.Delete);
       private RepositoryItemButtonEdit _nameButtonRepository;
       private readonly UxRepositoryItemCheckEdit _checkBoxRepository;
+      private readonly IObjectTypeResolver _typeResolver;
 
-      public EditParametersInContainerView(IToolTipCreator toolTipCreator, ValueOriginBinder<ParameterDTO> valueOriginBinder)
+      public EditParametersInContainerView(IToolTipCreator toolTipCreator, ValueOriginBinder<ParameterDTO> valueOriginBinder, IObjectTypeResolver typeResolver)
       {
          _toolTipCreator = toolTipCreator;
          _valueOriginBinder = valueOriginBinder;
@@ -79,6 +81,7 @@ namespace MoBi.UI.Views
          toolTipController.GetActiveObjectInfo += onToolTipControllerGetActiveObjectInfo;
 
          _checkBoxRepository = new UxRepositoryItemCheckEdit(_gridView);
+         _typeResolver = typeResolver;
       }
 
       private void hideEditor()
@@ -283,6 +286,7 @@ namespace MoBi.UI.Views
          return repository;
       }
 
+    
       public void BindTo(IEnumerable<ParameterDTO> parameters)
       {
          chkShowAdvancedParameter.Checked = _presenter.ShowAdvancedParameters;
@@ -368,8 +372,11 @@ namespace MoBi.UI.Views
 
       public string ParentName
       {
-         set => lblParentName.Text = string.IsNullOrEmpty(value) ? "New passive transport:" : value.FormatForLabel(checkCase: false);
+         set => lblParentName.Text = value.FormatForLabel(checkCase: false);
       }
+
+      public void SetNameForContainer(IContainer container) =>
+         lblParentName.Text = string.IsNullOrEmpty(container.Name) ? $"New {_typeResolver.TypeFor(container)}".FormatForLabel(checkCase: false) : container.Name.FormatForLabel(checkCase: false);
 
       public void SetEditParameterView(IView subView)
       {

--- a/tests/MoBi.Tests/Presentation/EditParameterListSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditParameterListSpecs.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using DevExpress.XtraEditors;
+using DevExpress.XtraExport.Helpers;
 using FakeItEasy;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Services;
@@ -39,15 +40,15 @@ namespace MoBi.Presentation
       protected IParameter _advancedParameter;
       protected IQuantityTask _quantityTask;
       protected IInteractionTaskContext _interactionTaskContext;
-      private IClipboardManager _clipboardManager;
-      private IEditTaskFor<IParameter> _editTask;
+      protected IClipboardManager _clipboardManager;
+      protected IEditTaskFor<IParameter> _editTask;
       protected ISelectReferencePresenterFactory _selectReferencePresenterFactory;
       protected IFavoriteTask _favoriteTask;
       protected IObjectTypeResolver _typeResolver;
 
       protected override void Context()
       {
-         _view = new EditParametersInContainerView(A.Fake<IToolTipCreator>(), A.Fake<ValueOriginBinder<ParameterDTO>>());
+         _view = A.Fake<IEditParametersInContainerView>();
          _formulaMapper = A.Fake<IFormulaToFormulaBuilderDTOMapper>();
          _parameterMapper = A.Fake<IParameterToParameterDTOMapper>();
          _inteactionTasks = A.Fake<IInteractionTasksForParameter>();
@@ -422,6 +423,11 @@ namespace MoBi.Presentation
          base.Context();
          _container = new Container();
          _container.Name = _containterName;
+         _view = new EditParametersInContainerView(A.Fake<IToolTipCreator>(), A.Fake<ValueOriginBinder<ParameterDTO>>());
+         sut = new EditParametersInContainerPresenter(_view, _formulaMapper, _parameterMapper, _inteactionTasks,
+            _distributeParameterPresenter, _parameterPresenter, _quantityTask, _interactionTaskContext, _clipboardManager, _editTask, _selectReferencePresenterFactory, _favoriteTask, _typeResolver);
+         sut.InitializeWith(A.Fake<ICommandCollector>());
+
       }
 
       protected override void Because()

--- a/tests/MoBi.Tests/Presentation/EditParameterListSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditParameterListSpecs.cs
@@ -387,13 +387,16 @@ namespace MoBi.Presentation
 
    public class When_containter_does_not_have_a_name : concern_for_EditParameterListPresenter
    {
-      private IContainer _container;
+      protected IContainer _container;
       private readonly string _containterType = "Container";
 
       protected override void Context()
       {
          base.Context();
          _container = new Container();
+         _view = new EditParametersInContainerView(A.Fake<IToolTipCreator>(), A.Fake<ValueOriginBinder<ParameterDTO>>());
+         sut = new EditParametersInContainerPresenter(_view, _formulaMapper, _parameterMapper, _inteactionTasks,
+            _distributeParameterPresenter, _parameterPresenter, _quantityTask, _interactionTaskContext, _clipboardManager, _editTask, _selectReferencePresenterFactory, _favoriteTask, _typeResolver);
          A.CallTo(() => _typeResolver.TypeFor(_container)).Returns(_containterType);
       }
 
@@ -413,21 +416,14 @@ namespace MoBi.Presentation
       }
    }
 
-   public class When_containter_does_have_a_name : concern_for_EditParameterListPresenter
+   public class When_containter_does_have_a_name : When_containter_does_not_have_a_name
    {
-      private IContainer _container;
       private readonly string _containterName = "Container Name";
 
       protected override void Context()
       {
          base.Context();
-         _container = new Container();
          _container.Name = _containterName;
-         _view = new EditParametersInContainerView(A.Fake<IToolTipCreator>(), A.Fake<ValueOriginBinder<ParameterDTO>>());
-         sut = new EditParametersInContainerPresenter(_view, _formulaMapper, _parameterMapper, _inteactionTasks,
-            _distributeParameterPresenter, _parameterPresenter, _quantityTask, _interactionTaskContext, _clipboardManager, _editTask, _selectReferencePresenterFactory, _favoriteTask, _typeResolver);
-         sut.InitializeWith(A.Fake<ICommandCollector>());
-
       }
 
       protected override void Because()

--- a/tests/MoBi.Tests/Presentation/EditParameterListSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditParameterListSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using DevExpress.Entity.Model;
 using DevExpress.XtraEditors;
 using DevExpress.XtraExport.Helpers;
 using FakeItEasy;
@@ -385,10 +386,10 @@ namespace MoBi.Presentation
       }
    }
 
-   public class When_containter_does_not_have_a_name : concern_for_EditParameterListPresenter
+   public class When_container_does_not_have_a_name : concern_for_EditParameterListPresenter
    {
       protected IContainer _container;
-      private readonly string _containterType = "Container";
+      private readonly string _containerType = "Container";
 
       protected override void Context()
       {
@@ -397,7 +398,7 @@ namespace MoBi.Presentation
          _view = new EditParametersInContainerView(A.Fake<IToolTipCreator>(), A.Fake<ValueOriginBinder<ParameterDTO>>());
          sut = new EditParametersInContainerPresenter(_view, _formulaMapper, _parameterMapper, _inteactionTasks,
             _distributeParameterPresenter, _parameterPresenter, _quantityTask, _interactionTaskContext, _clipboardManager, _editTask, _selectReferencePresenterFactory, _favoriteTask, _typeResolver);
-         A.CallTo(() => _typeResolver.TypeFor(_container)).Returns(_containterType);
+         A.CallTo(() => _typeResolver.TypeFor(_container)).Returns(_containerType);
       }
 
       protected override void Because()
@@ -406,24 +407,30 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void edit_must_be_called_after_pasting()
+      public void label_should_containt_name()
       {
          var lblParentNameField = _view.GetType()
             .GetField("lblParentName", BindingFlags.NonPublic | BindingFlags.Instance);
          var lblParentName = (LabelControl)lblParentNameField.GetValue(_view);
 
-         lblParentName.Text.ShouldBeEqualTo($"New {_containterType}:");
+         lblParentName.Text.ShouldBeEqualTo($"New {_containerType}:");
       }
    }
 
-   public class When_containter_does_have_a_name : When_containter_does_not_have_a_name
+   public class When_containter_does_have_a_name : concern_for_EditParameterListPresenter
    {
-      private readonly string _containterName = "Container Name";
+      protected IContainer _container;
+      private readonly string _containerName = "Container Name";
 
       protected override void Context()
       {
          base.Context();
-         _container.Name = _containterName;
+         _container = new Container();
+         _view = new EditParametersInContainerView(A.Fake<IToolTipCreator>(), A.Fake<ValueOriginBinder<ParameterDTO>>());
+         sut = new EditParametersInContainerPresenter(_view, _formulaMapper, _parameterMapper, _inteactionTasks,
+            _distributeParameterPresenter, _parameterPresenter, _quantityTask, _interactionTaskContext, _clipboardManager, _editTask, _selectReferencePresenterFactory, _favoriteTask, _typeResolver);
+
+         _container.Name = _containerName;
       }
 
       protected override void Because()
@@ -432,13 +439,13 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void edit_must_be_called_after_pasting()
+      public void label_should_containt_name()
       {
          var lblParentNameField = _view.GetType()
             .GetField("lblParentName", BindingFlags.NonPublic | BindingFlags.Instance);
          var lblParentName = (LabelControl)lblParentNameField.GetValue(_view);
 
-         lblParentName.Text.ShouldBeEqualTo($"{_containterName}:");
+         lblParentName.Text.ShouldBeEqualTo($"{_containerName}:");
       }
    }
 }

--- a/tests/MoBi.Tests/Presentation/EditParameterListSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditParameterListSpecs.cs
@@ -1,9 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using DevExpress.Entity.Model;
-using DevExpress.XtraEditors;
-using DevExpress.XtraExport.Helpers;
 using FakeItEasy;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Services;
@@ -13,8 +9,6 @@ using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Edit;
 using MoBi.Presentation.Tasks.Interaction;
 using MoBi.Presentation.Views;
-using MoBi.UI.Services;
-using MoBi.UI.Views;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
@@ -25,7 +19,6 @@ using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.DTO;
-using OSPSuite.UI.Binders;
 
 namespace MoBi.Presentation
 {
@@ -395,7 +388,6 @@ namespace MoBi.Presentation
       {
          base.Context();
          _container = new Container();
-         _view = new EditParametersInContainerView(A.Fake<IToolTipCreator>(), A.Fake<ValueOriginBinder<ParameterDTO>>());
          sut = new EditParametersInContainerPresenter(_view, _formulaMapper, _parameterMapper, _inteactionTasks,
             _distributeParameterPresenter, _parameterPresenter, _quantityTask, _interactionTaskContext, _clipboardManager, _editTask, _selectReferencePresenterFactory, _favoriteTask, _typeResolver);
          A.CallTo(() => _typeResolver.TypeFor(_container)).Returns(_containerType);
@@ -407,17 +399,13 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void label_should_containt_name()
+      public void label_should_contain_name()
       {
-         var lblParentNameField = _view.GetType()
-            .GetField("lblParentName", BindingFlags.NonPublic | BindingFlags.Instance);
-         var lblParentName = (LabelControl)lblParentNameField.GetValue(_view);
-
-         lblParentName.Text.ShouldBeEqualTo($"New {_containerType}:");
+         A.CallTo(_view).Where(x => x.Method.Name.Equals("set_ParentName") && x.Arguments.Get<string>(0).Equals($"New {_containerType}")).MustHaveHappened();
       }
    }
 
-   public class When_containter_does_have_a_name : concern_for_EditParameterListPresenter
+   public class When_container_does_have_a_name : concern_for_EditParameterListPresenter
    {
       protected IContainer _container;
       private readonly string _containerName = "Container Name";
@@ -426,7 +414,7 @@ namespace MoBi.Presentation
       {
          base.Context();
          _container = new Container();
-         _view = new EditParametersInContainerView(A.Fake<IToolTipCreator>(), A.Fake<ValueOriginBinder<ParameterDTO>>());
+         //_view = new EditParametersInContainerView(A.Fake<IToolTipCreator>(), A.Fake<ValueOriginBinder<ParameterDTO>>());
          sut = new EditParametersInContainerPresenter(_view, _formulaMapper, _parameterMapper, _inteactionTasks,
             _distributeParameterPresenter, _parameterPresenter, _quantityTask, _interactionTaskContext, _clipboardManager, _editTask, _selectReferencePresenterFactory, _favoriteTask, _typeResolver);
 
@@ -439,13 +427,9 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void label_should_containt_name()
+      public void label_should_contain_name()
       {
-         var lblParentNameField = _view.GetType()
-            .GetField("lblParentName", BindingFlags.NonPublic | BindingFlags.Instance);
-         var lblParentName = (LabelControl)lblParentNameField.GetValue(_view);
-
-         lblParentName.Text.ShouldBeEqualTo($"{_containerName}:");
+         A.CallTo(_view).Where(x => x.Method.Name.Equals("set_ParentName") && x.Arguments.Get<string>(0).Equals(_containerName)).MustHaveHappened();
       }
    }
 }


### PR DESCRIPTION
Fixes #1364

# Description

Add new default label when containter is unnamed

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/3456ef74-9bc3-4ebb-bf98-06731e7b8407)
![image](https://github.com/user-attachments/assets/6b7b4bc8-2045-4066-8ad9-4c591c8ea04b)




# Questions (if appropriate):