### PR TITLE
#1343 override method Rename on EdisTaskForModule

### DIFF
--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskFor.cs
@@ -68,7 +68,7 @@ namespace MoBi.Presentation.Tasks.Edit
       {
          Rename(entity, entity.ParentContainer, buildingBlock);
       }
-      
+
       public virtual void Rename(T objectBase, IEnumerable<IObjectBase> existingObjectsInParent, IBuildingBlock buildingBlock)
       {
          var forbiddenNames = GetForbiddenNames(objectBase, existingObjectsInParent);

--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskFor.cs
@@ -68,7 +68,7 @@ namespace MoBi.Presentation.Tasks.Edit
       {
          Rename(entity, entity.ParentContainer, buildingBlock);
       }
-
+      
       public virtual void Rename(T objectBase, IEnumerable<IObjectBase> existingObjectsInParent, IBuildingBlock buildingBlock)
       {
          var forbiddenNames = GetForbiddenNames(objectBase, existingObjectsInParent);

--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskForModule.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskForModule.cs
@@ -22,6 +22,11 @@ namespace MoBi.Presentation.Tasks.Edit
 
       public override void Rename(Module objectBase, IEnumerable<IObjectBase> existingObjectsInParent, IBuildingBlock buildingBlock)
       {
+         //This method is sending null as the last parameter because the building block should not be used in the Rename method
+         //The caller of this method uses _activeSubjectRetriever.Active<IBuildingBlock>() to get this value
+         //Which sometimes does not match the building block of the object being renamed
+         //Causing the rename to check all the used names for it
+
          base.Rename(objectBase, existingObjectsInParent, null);
       }
 

--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskForModule.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskForModule.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using MoBi.Presentation.Tasks.Interaction;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
 
 namespace MoBi.Presentation.Tasks.Edit
 {
@@ -18,5 +19,11 @@ namespace MoBi.Presentation.Tasks.Edit
       {
          return _context.CurrentProject.Modules.AllNames();
       }
+
+      public override void Rename(Module objectBase, IEnumerable<IObjectBase> existingObjectsInParent, IBuildingBlock buildingBlock)
+      {
+         base.Rename(objectBase, existingObjectsInParent, null);
+      }
+
    }
 }

--- a/tests/MoBi.Tests/Presentation/Tasks/EditTaskForModuleSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/EditTaskForModuleSpecs.cs
@@ -8,6 +8,8 @@ using MoBi.Presentation.Tasks.Interaction;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using Module = OSPSuite.Core.Domain.Module;
 
 namespace MoBi.Presentation.Tasks
 {
@@ -47,6 +49,37 @@ namespace MoBi.Presentation.Tasks
       public void all_modules_in_project_should_be_listed()
       {
          _prohibitedNames.ShouldContain("newModule1", "newModule2");
+      }
+   }
+
+   public class When_renaming_a_module : ContextSpecification<EditTaskForModule>
+   {
+      private Module _module;
+      private List<IObjectBase> _existingObjectsInParent;
+      private EditTaskForModule _sut;
+      private IInteractionTaskContext _interactionTaskContext;
+
+      protected override void Context()
+      {
+         _interactionTaskContext = A.Fake<IInteractionTaskContext>();
+         _sut = A.Fake<EditTaskForModule>(options => options
+            .WithArgumentsForConstructor(() => new EditTaskForModule(_interactionTaskContext))
+            .CallsBaseMethods());
+
+         _module = new Module().WithName("newModule1");
+         _existingObjectsInParent = new List<IObjectBase> { new Module().WithName("newModule2") };
+         A.CallTo(() => _interactionTaskContext.NamingTask.RenameFor(A<IObjectBase>.Ignored, A<IReadOnlyList<string>>.Ignored)).Returns("Module1");
+      }
+
+      protected override void Because()
+      {
+         _sut.Rename(_module, _existingObjectsInParent, new MoleculeBuildingBlock().WithId("newMoleculeBuildingBlockId"));
+      }
+
+      [Observation]
+      public void should_rename_module_but_not_related_objects()
+      {
+         A.CallTo(_sut).Where(x => x.Method.Name.Contains("GetRenameCommandFor") && x.Arguments.Get<IBuildingBlock>(1) == null).MustHaveHappened();
       }
    }
 }


### PR DESCRIPTION
Fixes #1343

# Description

When renaming a module, should not trigger the renaming of the related entities.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):