### PR TITLE
#1424 Selecting a neighbor not present should remove view

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditBuildingBlockPresenterBase.cs
+++ b/src/MoBi.Presentation/Presenter/EditBuildingBlockPresenterBase.cs
@@ -87,8 +87,9 @@ namespace MoBi.Presentation.Presenter
       {
          var selectedObject = eventToHandle.ObjectBase;
          var (canHandle, containerObject) = CanHandle(selectedObject);
-         if (!canHandle) return;
-
+         if (!canHandle && selectedObject != null)
+            return;
+         
          selectObjectAndContainer(containerObject, selectedObject);
       }
 

--- a/src/MoBi.Presentation/Presenter/HierarchicalStructureEditPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalStructureEditPresenter.cs
@@ -1,3 +1,4 @@
+using MoBi.Core;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
 using MoBi.Presentation.DTO;
@@ -43,11 +44,8 @@ namespace MoBi.Presentation.Presenter
 
       protected void RaiseEntitySelectedEvent(ObjectBaseDTO objectBaseDTO)
       {
-
          var entity = GetSelectedObject(objectBaseDTO);
-
-         if (entity != null)
-            _context.PublishEvent(new EntitySelectedEvent(entity, this));
+         _context.PublishEvent(new EntitySelectedEvent(entity, this));
       }
 
       protected IObjectBase GetSelectedObject(ObjectBaseDTO dto)

--- a/src/MoBi.UI/Views/EditSpatialStructureView.cs
+++ b/src/MoBi.UI/Views/EditSpatialStructureView.cs
@@ -64,7 +64,7 @@ namespace MoBi.UI.Views
       {
          if (view == null && splitHierarchyEdit.Panel2.Controls.Count > 0)
             splitHierarchyEdit.Panel2.Controls.RemoveAt(0);
-
+         
          splitHierarchyEdit.Panel2.FillWith(view);
       }
 

--- a/src/MoBi.UI/Views/EditSpatialStructureView.cs
+++ b/src/MoBi.UI/Views/EditSpatialStructureView.cs
@@ -63,7 +63,7 @@ namespace MoBi.UI.Views
       public void SetEditView(IView view)
       {
          if (view == null && splitHierarchyEdit.Panel2.Controls.Count > 0)
-            splitHierarchyEdit.Panel2.Controls.RemoveAt(0);
+            splitHierarchyEdit.Panel2.Controls.Clear();
          
          splitHierarchyEdit.Panel2.FillWith(view);
       }

--- a/src/MoBi.UI/Views/EditSpatialStructureView.cs
+++ b/src/MoBi.UI/Views/EditSpatialStructureView.cs
@@ -62,6 +62,9 @@ namespace MoBi.UI.Views
 
       public void SetEditView(IView view)
       {
+         if (view == null && splitHierarchyEdit.Panel2.Controls.Count > 0)
+            splitHierarchyEdit.Panel2.Controls.RemoveAt(0);
+
          splitHierarchyEdit.Panel2.FillWith(view);
       }
 

--- a/tests/MoBi.Tests/Presentation/EditSpatialStructureViewSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditSpatialStructureViewSpecs.cs
@@ -1,0 +1,56 @@
+﻿using System.Reflection;
+using System.Windows.Forms;
+using DevExpress.XtraEditors;
+using FakeItEasy;
+using MoBi.UI.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Presentation.Views;
+
+namespace MoBi.Presentation
+{
+   public class concern_for_EditSpatialStructureViewSpecs :
+      ContextSpecification<EditSpatialStructureView>
+   {
+      protected EditSpatialStructureView _sut;
+      protected SplitContainerControl _splitContainer;
+
+      protected override void Context()
+      {
+         _sut = new EditSpatialStructureView(A.Fake<IMainView>());
+         _splitContainer = new SplitContainerControl();
+
+         var splitHierarchyEditField = typeof(EditSpatialStructureView).GetField("splitHierarchyEdit", BindingFlags.NonPublic | BindingFlags.Instance);
+         splitHierarchyEditField.SetValue(_sut, _splitContainer);
+         _splitContainer.Panel2.Controls.Add(new Control());
+      }
+   }
+
+   public class set_edit_view_with_null_value_should_remove_control : concern_for_EditSpatialStructureViewSpecs
+   {
+      protected override void Because()
+      {
+         _sut.SetEditView(null);
+      }
+
+      [Observation]
+      public void should_remove_control()
+      {
+         _splitContainer.Panel2.Controls.Count.ShouldBeEqualTo(0);
+      }
+   }
+
+   public class set_edit_view_with_value_should_not_remove_control : concern_for_EditSpatialStructureViewSpecs
+   {
+      protected override void Because()
+      {
+         _sut.SetEditView(A.Fake<IView>());
+      }
+
+      [Observation]
+      public void should_not_remove_control()
+      {
+         _splitContainer.Panel2.Controls.Count.ShouldBeEqualTo(1);
+      }
+   }
+}


### PR DESCRIPTION
Fixes #1424 

# Description

Selecting a neighbor in the neighborhood view: behavior when the container is not present in the module should be not to show it.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/6f8da9e2-fd1a-4a43-bd59-9377c67b7768)


# Questions (if appropriate):