### PR TITLE
#1442 when importing a simulation set project simulation settings

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1532,7 +1532,6 @@ namespace MoBi.Assets
          public static readonly string DisplayUnit = "Display Unit";
          public static readonly string DefaultDisplayUnits = "Default Display Units";
          public static readonly string ApplicationSettings = "Application";
-         public static readonly string OutputSelections = "Output Selections";
          public static readonly string StartImport = "Start Import";
          public static readonly string ImportParameterValues = "Import Parameter Values";
          public static readonly string ImportParameterQuantitiesFileFormatHint = "The file format must have at least 4 columns. Columns should be Container Path, Parameter Name, Value, and Units." + Environment.NewLine + "The first row is ignored for import.";

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -881,6 +881,7 @@ namespace MoBi.Assets
          public static readonly string RemoveSelectedResultsFromProject = "Do you really want to remove the selected result(s) from the project";
          public static readonly Size SELECT_SINGLE_SIZE = new Size(475, 160);
          public static readonly string RemoveMultipleModules = "Do you really want to remove the selected Modules?";
+         public static readonly string DoYouWantToLoadSimulationSettingsAsDefaultForCurrentProject = "Do you want to load the simulation settings as default for the current project?";
 
          public static string RemoveSimulationsFromProject(string projectName)
          {

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulationSettings.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulationSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Builder;
@@ -36,12 +37,12 @@ namespace MoBi.Presentation.Tasks.Interaction
 
       public override IMoBiCommand GetRemoveCommand(SimulationSettings objectToRemove, MoBiProject parent, IBuildingBlock buildingBlock)
       {
-         throw new System.NotImplementedException();
+         throw new NotImplementedException();
       }
 
       public override IMoBiCommand GetAddCommand(SimulationSettings itemToAdd, MoBiProject parent, IBuildingBlock buildingBlock)
       {
-         throw new System.NotImplementedException();
+         throw new NotImplementedException();
       }
 
       public void LoadDefaultSimulationSettingsInProject()

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulationSettings.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulationSettings.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Builder;
@@ -37,12 +36,12 @@ namespace MoBi.Presentation.Tasks.Interaction
 
       public override IMoBiCommand GetRemoveCommand(SimulationSettings objectToRemove, MoBiProject parent, IBuildingBlock buildingBlock)
       {
-         throw new NotImplementedException();
+         throw new System.NotImplementedException();
       }
 
       public override IMoBiCommand GetAddCommand(SimulationSettings itemToAdd, MoBiProject parent, IBuildingBlock buildingBlock)
       {
-         throw new NotImplementedException();
+         throw new System.NotImplementedException();
       }
 
       public void LoadDefaultSimulationSettingsInProject()

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -158,7 +158,13 @@ namespace MoBi.Presentation.Tasks
       public void LoadSimulationIntoProject()
       {
          var fileName = _dialogCreator.AskForFileToOpen(AppConstants.Dialog.LoadSimulation, Constants.Filter.PKML_FILE_FILTER, Constants.DirectoryKey.MODEL_PART);
-         loadSimulationFromFileInProject(fileName);
+         var simulationTransfer = loadSimulationFromFileInProject(fileName);
+         if (simulationTransfer != null)
+         {
+            var response = _dialogCreator.MessageBoxYesNo(AppConstants.Dialog.DoYouWantToLoadSimulationSettingsAsDefaultForCurrentProject);
+            if (response == ViewResult.Yes)
+               loadProjectDefaultsFromSimulationSettings(simulationTransfer);
+         }
       }
 
       public void OpenSBMLModel()

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -100,20 +100,18 @@ namespace MoBi.Presentation.Tasks
       private SimulationTransfer loadSimulationFromFileInProject(string fileName)
       {
          var project = _context.CurrentProject;
-         if (project == null) return null;
-
-         if (string.IsNullOrEmpty(fileName))
+         if (project == null || string.IsNullOrEmpty(fileName))
             return null;
 
          SimulationTransfer simulationTransfer = null;
-
          _heavyWorkManager.Start(() => simulationTransfer = LoadSimulationTransferDataFromFile(fileName));
-         if (simulationTransfer == null)
-            return simulationTransfer;
 
-         _context.AddToHistory(addSimulationTransferToProject(simulationTransfer));
-         loadJournalIfNotLoadedAlready(project, simulationTransfer.JournalPath);
-         notifyProjectLoaded();
+         if (simulationTransfer != null)
+         {
+            _context.AddToHistory(addSimulationTransferToProject(simulationTransfer));
+            loadJournalIfNotLoadedAlready(project, simulationTransfer.JournalPath);
+            notifyProjectLoaded();
+         }
 
          return simulationTransfer;
       }

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -1,8 +1,10 @@
 using System.IO;
+using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Exceptions;
 using MoBi.Core.Services;
+using MoBi.Presentation.Tasks.Interaction;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
@@ -106,6 +108,11 @@ namespace MoBi.Presentation.Tasks
          _heavyWorkManager.Start(() => simulationTransfer = LoadSimulationTransferDataFromFile(fileName));
          if (simulationTransfer == null)
             return;
+
+         var simulationSettingsTask = _context.Resolve<IInteractionTasksForSimulationSettings>();
+         var simulationSettings = simulationTransfer.Simulation.Settings;
+         simulationSettingsTask.UpdateDefaultSimulationSettingsInProject(simulationSettings.OutputSchema, simulationSettings.Solver);
+         simulationSettingsTask.UpdateDefaultOutputSelectionsInProject(simulationSettings.OutputSelections.ToList());
 
          _context.AddToHistory(addSimulationTransferToProject(simulationTransfer));
          loadJournalIfNotLoadedAlready(project, simulationTransfer.JournalPath);

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -106,13 +106,12 @@ namespace MoBi.Presentation.Tasks
          SimulationTransfer simulationTransfer = null;
          _heavyWorkManager.Start(() => simulationTransfer = LoadSimulationTransferDataFromFile(fileName));
 
-         if (simulationTransfer != null)
-         {
-            _context.AddToHistory(addSimulationTransferToProject(simulationTransfer));
-            loadJournalIfNotLoadedAlready(project, simulationTransfer.JournalPath);
-            notifyProjectLoaded();
-         }
+         if (simulationTransfer == null)
+            return simulationTransfer;
 
+         _context.AddToHistory(addSimulationTransferToProject(simulationTransfer));
+         loadJournalIfNotLoadedAlready(project, simulationTransfer.JournalPath);
+         notifyProjectLoaded();
          return simulationTransfer;
       }
 

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -159,12 +159,12 @@ namespace MoBi.Presentation.Tasks
       {
          var fileName = _dialogCreator.AskForFileToOpen(AppConstants.Dialog.LoadSimulation, Constants.Filter.PKML_FILE_FILTER, Constants.DirectoryKey.MODEL_PART);
          var simulationTransfer = loadSimulationFromFileInProject(fileName);
-         if (simulationTransfer != null)
-         {
-            var response = _dialogCreator.MessageBoxYesNo(AppConstants.Dialog.DoYouWantToLoadSimulationSettingsAsDefaultForCurrentProject);
-            if (response == ViewResult.Yes)
-               loadProjectDefaultsFromSimulationSettings(simulationTransfer);
-         }
+         if (simulationTransfer == null)
+            return;
+
+         var response = _dialogCreator.MessageBoxYesNo(AppConstants.Dialog.DoYouWantToLoadSimulationSettingsAsDefaultForCurrentProject);
+         if (response == ViewResult.Yes)
+            loadProjectDefaultsFromSimulationSettings(simulationTransfer);
       }
 
       public void OpenSBMLModel()

--- a/tests/MoBi.Tests/Presentation/ProjectTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ProjectTaskSpecs.cs
@@ -123,13 +123,13 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void should_update_default_simulation_settings_in_project()
+      public void should_not_update_default_simulation_settings_in_project()
       {
          A.CallTo(() => _interactionTasksForSimulationSettings.UpdateDefaultSimulationSettingsInProject(_simulationTransfer.Simulation.Settings.OutputSchema, _simulationTransfer.Simulation.Settings.Solver)).MustNotHaveHappened();
       }
 
       [Observation]
-      public void should_update_default_output_selections_in_project()
+      public void should_not_update_default_output_selections_in_project()
       {
          A.CallTo(() => _interactionTasksForSimulationSettings.UpdateDefaultOutputSelectionsInProject(A<IReadOnlyList<QuantitySelection>>.Ignored)).MustNotHaveHappened();
       }


### PR DESCRIPTION
Fixes #1442

# Description

When importing a simulation from PK-Sim, set the project-wide simulation settings

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):