### PR TITLE
Fixes  #1461 Cannot create a top level container "Events"

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -2169,8 +2169,7 @@ namespace MoBi.Assets
          "SRND",
          "TAN",
          "TANH",
-         "NEQ",
-         "EVENTS"
+         "NEQ"
       };
 
       public static readonly string None = "<None>";

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/RootContextMenuForSpatialStructure.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/RootContextMenuForSpatialStructure.cs
@@ -13,11 +13,11 @@ using OSPSuite.Utility.Container;
 
 namespace MoBi.Presentation.MenusAndBars.ContextMenus
 {
-   public class RootContextMenuForSpacialStructure : ContextMenuBase
+   public class RootContextMenuForSpatialStructure : ContextMenuBase
    {
       private readonly IContainer _container;
 
-      public RootContextMenuForSpacialStructure(IContainer container)
+      public RootContextMenuForSpatialStructure(IContainer container)
       {
          _container = container;
       }
@@ -33,18 +33,18 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
       }
    }
 
-   public class RootContextMenuForSpacialStructureFactory : IContextMenuSpecificationFactory<IViewItem>
+   public class RootContextMenuForSpatialStructureFactory : IContextMenuSpecificationFactory<IViewItem>
    {
       private readonly IContainer _container;
 
-      public RootContextMenuForSpacialStructureFactory(IContainer container)
+      public RootContextMenuForSpatialStructureFactory(IContainer container)
       {
          _container = container;
       }
 
       public IContextMenu CreateFor(IViewItem objectRequestingContextMenu, IPresenterWithContextMenu<IViewItem> presenter)
       {
-         return new RootContextMenuForSpacialStructure(_container);
+         return new RootContextMenuForSpatialStructure(_container);
       }
 
       public bool IsSatisfiedBy(IViewItem objectRequestingContextMenu, IPresenterWithContextMenu<IViewItem> presenter)

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSpatialStructure.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSpatialStructure.cs
@@ -1,9 +1,6 @@
-﻿using System.Linq;
-using MoBi.Assets;
-using MoBi.Core.Commands;
+﻿using MoBi.Core.Commands;
 using MoBi.Core.Domain.Builder;
 using MoBi.Core.Domain.Model;
-using MoBi.Core.Exceptions;
 using MoBi.Presentation.Tasks.Edit;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;

--- a/src/MoBi.Presentation/UICommand/AddCommandFor.cs
+++ b/src/MoBi.Presentation/UICommand/AddCommandFor.cs
@@ -5,7 +5,6 @@ using MoBi.Presentation.Tasks.Interaction;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Services;
-using OSPSuite.Presentation.MenuAndBars;
 using OSPSuite.Presentation.UICommands;
 
 namespace MoBi.Presentation.UICommand

--- a/tests/MoBi.Tests/Presentation/ObjectBaseDTOSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ObjectBaseDTOSpecs.cs
@@ -1,0 +1,29 @@
+﻿using MoBi.Presentation.DTO;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Utility.Validation;
+
+namespace MoBi.Presentation
+{
+   public class concern_for_ObjectBaseDTO : ContextSpecification<ObjectBaseDTO>
+   {
+      protected override void Context()
+      {
+         sut = new ObjectBaseDTO();
+      }
+   }
+
+   public class when_object_name_is_events_the_object_should_be_valid : concern_for_ObjectBaseDTO
+   {
+      protected override void Because()
+      {
+         sut.Name = "events";
+      }
+
+      [Observation]
+      public void the_object_should_be_valid()
+      {
+         sut.IsValid().ShouldBeTrue();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #1461 - I assume "Events" is a valid name for any object now. I don't think it needs to be reserved.

# Description
Removing "Events" as an unusable name for objects

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):