### PR TITLE
Fixes #1464

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1920,24 +1920,17 @@ namespace MoBi.Assets
             var sb = new StringBuilder();
 
             if (numberOfModules == 1)
-            {
                sb.AppendLine("A module could not be deleted");
-            }
             else
-            {
+               
                sb.AppendLine("Some modules could not be deleted");
-            }
 
             sb.AppendLine(namesList(modulesNotRemoved));
 
             if (numberOfModules == 1)
-            {
                sb.AppendLine("It is used in one ore move simulations");
-            }
             else
-            {
                sb.AppendLine("They are used in one or more simulations");
-            }
 
             return sb.ToString();
          }

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1914,6 +1914,34 @@ namespace MoBi.Assets
             return $"Select building blocks to clone from {module.Name}";
          }
 
+         public static string CouldNotRemoveModules(List<string> modulesNotRemoved)
+         {
+            var numberOfModules = modulesNotRemoved.Count;
+            var sb = new StringBuilder();
+
+            if (numberOfModules == 1)
+            {
+               sb.AppendLine("A module could not be deleted");
+            }
+            else
+            {
+               sb.AppendLine("Some modules could not be deleted");
+            }
+
+            sb.AppendLine(namesList(modulesNotRemoved));
+
+            if (numberOfModules == 1)
+            {
+               sb.AppendLine("It is used in one ore move simulations");
+            }
+            else
+            {
+               sb.AppendLine("They are used in one or more simulations");
+            }
+
+            return sb.ToString();
+         }
+
          public static string AlsoImportIndividualsAndExpressions(string individualName, IReadOnlyList<string> expressionNames)
          {
             var numberOfIndividuals = string.IsNullOrEmpty(individualName) ? 0 : 1;

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1922,7 +1922,6 @@ namespace MoBi.Assets
             if (numberOfModules == 1)
                sb.AppendLine("A module could not be deleted");
             else
-               
                sb.AppendLine("Some modules could not be deleted");
 
             sb.AppendLine(namesList(modulesNotRemoved));

--- a/src/MoBi.Core/Services/TemplateResolverTask.cs
+++ b/src/MoBi.Core/Services/TemplateResolverTask.cs
@@ -28,7 +28,14 @@ namespace MoBi.Core.Services
          if (buildingBlock == null)
             return null;
 
-         return _buildingBlockRepository.All().Single(x => x.IsTemplateMatchFor(buildingBlock)) as TBuildingBlock;
+         try
+         {
+            return _buildingBlockRepository.All().Single(x => x.IsTemplateMatchFor(buildingBlock)) as TBuildingBlock;
+         }
+         catch
+         {
+            return null;
+         }
       }
       
       public Module TemplateModuleFor(Module module) => _moBiProjectRetriever.Current.ModuleByName(module.Name);

--- a/src/MoBi.Core/Services/TemplateResolverTask.cs
+++ b/src/MoBi.Core/Services/TemplateResolverTask.cs
@@ -28,16 +28,9 @@ namespace MoBi.Core.Services
          if (buildingBlock == null)
             return null;
 
-         try
-         {
-            return _buildingBlockRepository.All().Single(x => x.IsTemplateMatchFor(buildingBlock)) as TBuildingBlock;
-         }
-         catch
-         {
-            return null;
-         }
+         return _buildingBlockRepository.All().Single(x => x.IsTemplateMatchFor(buildingBlock)) as TBuildingBlock;
       }
-      
+
       public Module TemplateModuleFor(Module module) => _moBiProjectRetriever.Current.ModuleByName(module.Name);
    }
 }


### PR DESCRIPTION
Fixes #1464

# Description
We were not checking if modules are used before removing them if the task was initiated with a multiple module context menu.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/bb7064e0-5f0c-4a1a-b4ff-fb079b418511)


# Questions (if appropriate):