### PR TITLE
Fixes #1488 "Clone" simulation should show the configuration dialog

### DIFF
--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
@@ -41,8 +41,9 @@ namespace MoBi.Presentation.Tasks.Interaction
 
       /// <summary>
       /// Create a clone of the <paramref name="simulationToClone"/> and add it to the current project
+      /// Returns the cloned simulation if created, otherwise null
       /// </summary>
-      void CloneSimulation(IMoBiSimulation simulationToClone);
+      IMoBiSimulation CloneSimulation(IMoBiSimulation simulationToClone);
    }
 
    public class InteractionTasksForSimulation : InteractionTasksForChildren<MoBiProject, IMoBiSimulation>, IInteractionTasksForSimulation
@@ -181,15 +182,17 @@ namespace MoBi.Presentation.Tasks.Interaction
          return simulation.Configuration.ModuleConfigurations.Where(moduleConfiguration => !versionMatch(TemplateModuleFor(moduleConfiguration.Module), moduleConfiguration)).Select(moduleConfiguration => moduleConfiguration.Module).ToList();
       }
 
-      public void CloneSimulation(IMoBiSimulation simulationToClone)
+      public IMoBiSimulation CloneSimulation(IMoBiSimulation simulationToClone)
       {
          var newName = InteractionTask.PromptForNewName(simulationToClone, _editTask.GetForbiddenNames(simulationToClone, _interactionTaskContext.Context.CurrentProject.Simulations));
          if (newName.IsNullOrEmpty())
-            return;
+            return null;
 
          var newSimulation = _cloneManager.CloneSimulation(simulationToClone).WithName(newName);
          
          _interactionTaskContext.Context.AddToHistory(new AddSimulationCommand(newSimulation).Run(_interactionTaskContext.Context));
+
+         return newSimulation;
       }
 
       private bool versionMatch(Module templateModule, ModuleConfiguration moduleConfiguration)

--- a/src/MoBi.Presentation/UICommand/CloneSimulationUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/CloneSimulationUICommand.cs
@@ -1,5 +1,5 @@
-﻿using FluentNHibernate.Utils;
-using MoBi.Core.Domain.Model;
+﻿using MoBi.Core.Domain.Model;
+using MoBi.Presentation.Tasks;
 using MoBi.Presentation.Tasks.Interaction;
 using OSPSuite.Presentation.UICommands;
 
@@ -8,15 +8,22 @@ namespace MoBi.Presentation.UICommand
    public class CloneSimulationUICommand : ObjectUICommand<IMoBiSimulation>
    {
       private readonly IInteractionTasksForSimulation _interactionTasksForSimulation;
+      private readonly ISimulationUpdateTask _simulationUpdateTask;
 
-      public CloneSimulationUICommand(IInteractionTasksForSimulation interactionTasksForSimulation)
+      public CloneSimulationUICommand(IInteractionTasksForSimulation interactionTasksForSimulation, ISimulationUpdateTask simulationUpdateTask)
       {
          _interactionTasksForSimulation = interactionTasksForSimulation;
+         _simulationUpdateTask = simulationUpdateTask;
       }
 
       protected override void PerformExecute()
       {
-         _interactionTasksForSimulation.CloneSimulation(Subject);
+         var clonedSimulation = _interactionTasksForSimulation.CloneSimulation(Subject);
+
+         if (clonedSimulation == null) 
+            return;
+         
+         _simulationUpdateTask.ConfigureSimulation(clonedSimulation);
       }
    }
 }

--- a/src/MoBi.Presentation/UICommand/CloneSimulationUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/CloneSimulationUICommand.cs
@@ -9,11 +9,13 @@ namespace MoBi.Presentation.UICommand
    {
       private readonly IInteractionTasksForSimulation _interactionTasksForSimulation;
       private readonly ISimulationUpdateTask _simulationUpdateTask;
+      private readonly IMoBiContext _context;
 
-      public CloneSimulationUICommand(IInteractionTasksForSimulation interactionTasksForSimulation, ISimulationUpdateTask simulationUpdateTask)
+      public CloneSimulationUICommand(IInteractionTasksForSimulation interactionTasksForSimulation, ISimulationUpdateTask simulationUpdateTask, IMoBiContext context)
       {
          _interactionTasksForSimulation = interactionTasksForSimulation;
          _simulationUpdateTask = simulationUpdateTask;
+         _context = context;
       }
 
       protected override void PerformExecute()
@@ -22,8 +24,8 @@ namespace MoBi.Presentation.UICommand
 
          if (clonedSimulation == null) 
             return;
-         
-         _simulationUpdateTask.ConfigureSimulation(clonedSimulation);
+
+         _context.AddToHistory(_simulationUpdateTask.ConfigureSimulation(clonedSimulation));
       }
    }
 }


### PR DESCRIPTION
Fixes #1488

# Description
When the simulation is cloned, it should be opened in the configuration editor. Most likely the user is trying to make some changes to the clone and this saves a click or two in the workflow

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):