### PR TITLE
Fixes #1442

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -887,7 +887,6 @@ namespace MoBi.Assets
          public static readonly string RemoveSelectedResultsFromProject = "Do you really want to remove the selected result(s) from the project";
          public static readonly Size SELECT_SINGLE_SIZE = new Size(475, 160);
          public static readonly string RemoveMultipleModules = "Do you really want to remove the selected Modules?";
-         public static readonly string DoYouWantToLoadSimulationSettingsAsDefaultForCurrentProject = "Do you want to load the simulation settings as default for the current project?";
 
          public static string RemoveSimulationsFromProject(string projectName)
          {

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -158,13 +158,7 @@ namespace MoBi.Presentation.Tasks
       public void LoadSimulationIntoProject()
       {
          var fileName = _dialogCreator.AskForFileToOpen(AppConstants.Dialog.LoadSimulation, Constants.Filter.PKML_FILE_FILTER, Constants.DirectoryKey.MODEL_PART);
-         var simulationTransfer = loadSimulationFromFileInProject(fileName);
-         if (simulationTransfer == null)
-            return;
-
-         var response = _dialogCreator.MessageBoxYesNo(AppConstants.Dialog.DoYouWantToLoadSimulationSettingsAsDefaultForCurrentProject);
-         if (response == ViewResult.Yes)
-            loadProjectDefaultsFromSimulationSettings(simulationTransfer);
+         loadSimulationFromFileInProject(fileName);
       }
 
       public void OpenSBMLModel()

--- a/tests/MoBi.Tests/Presentation/ProjectTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ProjectTaskSpecs.cs
@@ -121,18 +121,6 @@ namespace MoBi.Presentation
       {
          _simulationTransfer.Favorites.Each(favorite => _project.Favorites.ShouldContain(favorite));
       }
-
-      [Observation]
-      public void should_not_update_default_simulation_settings_in_project()
-      {
-         A.CallTo(() => _interactionTasksForSimulationSettings.UpdateDefaultSimulationSettingsInProject(_simulationTransfer.Simulation.Settings.OutputSchema, _simulationTransfer.Simulation.Settings.Solver)).MustNotHaveHappened();
-      }
-
-      [Observation]
-      public void should_not_update_default_output_selections_in_project()
-      {
-         A.CallTo(() => _interactionTasksForSimulationSettings.UpdateDefaultOutputSelectionsInProject(A<IReadOnlyList<QuantitySelection>>.Ignored)).MustNotHaveHappened();
-      }
    }
 
    internal class When_opening_a_simulation_as_project : When_loading_a_simulation


### PR DESCRIPTION
Fixes #1442

# Description
No more prompting for subsequent simulation loads whether the user wants to update default simulations

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):