### PR TITLE
Fixes #1521 "TIME" cannot be selected as x-argument of table formula with x argument

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditTableFormulaWithOffSetFormulaPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditTableFormulaWithOffSetFormulaPresenter.cs
@@ -92,6 +92,7 @@ namespace MoBi.Presentation.Presenter
          using (var presenter = _applicationController.Start<ISelectFormulaUsablePathPresenter>())
          {
             var referencePresenter = _selectReferencePresenterFactory.ReferenceAtParameterFor(UsingObject.ParentContainer);
+            referencePresenter.DisableTimeSelection();
             presenter.Init(predicate, UsingObject, new[] {UsingObject.RootContainer}, caption, referencePresenter);
             return presenter.GetSelection();
          }

--- a/src/MoBi.Presentation/Presenter/EditTableFormulaWithXArgumentFormulaPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditTableFormulaWithXArgumentFormulaPresenter.cs
@@ -89,6 +89,7 @@ namespace MoBi.Presentation.Presenter
          using (var presenter = _applicationController.Start<ISelectFormulaUsablePathPresenter>())
          {
             var referencePresenter = _selectReferencePresenterFactory.ReferenceAtParameterFor(UsingObject?.ParentContainer);
+            referencePresenter.DisableTimeSelection();
             presenter.Init(predicate, UsingObject, UsingObject == null ? Enumerable.Empty<IObjectBase>() : new[] {UsingObject.RootContainer}, caption, referencePresenter);
             return presenter.GetSelection();
          }

--- a/src/MoBi.Presentation/Presenter/SelectReferenceAtParameterPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferenceAtParameterPresenter.cs
@@ -9,10 +9,13 @@ namespace MoBi.Presentation.Presenter
    public interface ISelectReferenceAtParameterPresenter : ISelectReferencePresenter
    {
       bool ChangeLocalisationAllowed { get; set; }
+      void DisableTimeSelection();
    }
 
    public class SelectReferenceAtParameterPresenter : SelectReferencePresenterBase, ISelectReferenceAtParameterPresenter
    {
+      private bool _addTime = true;
+
       public SelectReferenceAtParameterPresenter(ISelectReferenceView view,
          IObjectBaseToObjectBaseDTOMapper objectBaseDTOMapper,
          IMoBiContext context,
@@ -30,14 +33,20 @@ namespace MoBi.Presentation.Presenter
 
       protected override void AddSpecificInitialObjects()
       {
-         AddTimeReference();
+         if(_addTime)
+            AddTimeReference();
          AddSpatialStructures();
       }
 
       public bool ChangeLocalisationAllowed
       {
-         get { return _view.ChangeLocalisationAllowed; }
-         set { _view.ChangeLocalisationAllowed = value; }
+         get => _view.ChangeLocalisationAllowed;
+         set => _view.ChangeLocalisationAllowed = value;
+      }
+
+      public void DisableTimeSelection()
+      {
+         _addTime = false;
       }
    }
 }

--- a/tests/MoBi.Tests/Presentation/EditTableFormulaWithOffSetFormulaPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditTableFormulaWithOffSetFormulaPresenterSpecs.cs
@@ -17,6 +17,7 @@ using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.Nodes;
 
 namespace MoBi.Presentation
 {
@@ -137,70 +138,76 @@ namespace MoBi.Presentation
          A.CallTo(() => _view.BindTo(A<TableFormulaWithOffsetDTO>._)).MustHaveHappenedTwiceExactly();
       }
 
-      public class When_the_user_is_selecting_a_new_offset_formula_for_the_edited_table_formula_and_the_selection_is_canceled : concern_for_EditTableFormulaWithOffSetFormulaPresenter
+      [Observation]
+      public void the_time_reference_should_not_be_added()
       {
-         protected override void Context()
-         {
-            base.Context();
-            A.CallTo(() => _selectFormulaUsablePathPresenter.GetSelection()).Returns(null);
-            sut.Edit(_formula, _usingFormula);
-         }
+         A.CallTo(() => _selectReferenceAtParameterPresenter.DisableTimeSelection()).MustHaveHappened();
+      }
+   }
 
-         protected override void Because()
-         {
-            sut.SetOffsetFormulaPath();
-         }
-
-         [Observation]
-         public void should_not_add_a_command_to_the_history()
-         {
-            A.CallTo(() => _commandCollector.AddCommand(A<ICommand>._)).MustNotHaveHappened();
-         }
+   public class When_the_user_is_selecting_a_new_offset_formula_for_the_edited_table_formula_and_the_selection_is_canceled : concern_for_EditTableFormulaWithOffSetFormulaPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _selectFormulaUsablePathPresenter.GetSelection()).Returns(null);
+         sut.Edit(_formula, _usingFormula);
       }
 
-      public class When_the_user_is_selecting_a_new_table_object_for_the_edited_table_formula : concern_for_EditTableFormulaWithOffSetFormulaPresenter
+      protected override void Because()
       {
-         private IObjectBase _tableParameter;
-         private IObjectBase _anotherParameter;
-         private IObjectBase _notAParameter;
-         private FormulaUsablePath _selectedFormulaUsablePath;
+         sut.SetOffsetFormulaPath();
+      }
 
-         protected override void Context()
-         {
-            base.Context();
-            _tableParameter = new Parameter().WithFormula(new TableFormula());
-            _anotherParameter = new Parameter().WithFormula(new ConstantFormula());
-            _notAParameter = A.Fake<IObjectBase>();
-            _selectedFormulaUsablePath = new FormulaUsablePath();
-            A.CallTo(() => _selectFormulaUsablePathPresenter.GetSelection()).Returns(_selectedFormulaUsablePath);
-            sut.Edit(_formula, _usingFormula);
-         }
+      [Observation]
+      public void should_not_add_a_command_to_the_history()
+      {
+         A.CallTo(() => _commandCollector.AddCommand(A<ICommand>._)).MustNotHaveHappened();
+      }
+   }
 
-         protected override void Because()
-         {
-            sut.SetTableObjectPath();
-         }
+   public class When_the_user_is_selecting_a_new_table_object_for_the_edited_table_formula : concern_for_EditTableFormulaWithOffSetFormulaPresenter
+   {
+      private IObjectBase _tableParameter;
+      private IObjectBase _anotherParameter;
+      private IObjectBase _notAParameter;
+      private FormulaUsablePath _selectedFormulaUsablePath;
 
-         [Observation]
-         public void should_only_allow_selection_of_parameters_with_the_time_dimension()
-         {
-            _predicate(_tableParameter).ShouldBeTrue();
-            _predicate(_anotherParameter).ShouldBeFalse();
-            _predicate(_notAParameter).ShouldBeFalse();
-         }
+      protected override void Context()
+      {
+         base.Context();
+         _tableParameter = new Parameter().WithFormula(new TableFormula());
+         _anotherParameter = new Parameter().WithFormula(new ConstantFormula());
+         _notAParameter = A.Fake<IObjectBase>();
+         _selectedFormulaUsablePath = new FormulaUsablePath();
+         A.CallTo(() => _selectFormulaUsablePathPresenter.GetSelection()).Returns(_selectedFormulaUsablePath);
+         sut.Edit(_formula, _usingFormula);
+      }
 
-         [Observation]
-         public void should_register_a_command_in_the_history()
-         {
-            A.CallTo(() => _mobiFormulaTask.ChangeTableObject(_formula, _selectedFormulaUsablePath, _buildingBlock)).MustHaveHappened();
-            A.CallTo(() => _commandCollector.AddCommand(A<ICommand>._)).MustHaveHappened();
-         }
+      protected override void Because()
+      {
+         sut.SetTableObjectPath();
+      }
 
-         [Observation]
-         public void should_rebind_to_the_view()
-         {
-            A.CallTo(() => _view.BindTo(A<TableFormulaWithOffsetDTO>._)).MustHaveHappenedTwiceExactly();
-         }
+      [Observation]
+      public void should_only_allow_selection_of_parameters_with_the_time_dimension()
+      {
+         _predicate(_tableParameter).ShouldBeTrue();
+         _predicate(_anotherParameter).ShouldBeFalse();
+         _predicate(_notAParameter).ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_register_a_command_in_the_history()
+      {
+         A.CallTo(() => _mobiFormulaTask.ChangeTableObject(_formula, _selectedFormulaUsablePath, _buildingBlock)).MustHaveHappened();
+         A.CallTo(() => _commandCollector.AddCommand(A<ICommand>._)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_rebind_to_the_view()
+      {
+         A.CallTo(() => _view.BindTo(A<TableFormulaWithOffsetDTO>._)).MustHaveHappenedTwiceExactly();
       }
    }
 }

--- a/tests/MoBi.Tests/Presentation/EditTableFormulaWithXArgumentFormulaPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditTableFormulaWithXArgumentFormulaPresenterSpecs.cs
@@ -89,6 +89,12 @@ namespace MoBi.Presentation
       {
          A.CallTo(() => _commandCollector.AddCommand(_command)).MustHaveHappened();
       }
+
+      [Observation]
+      public void the_time_reference_should_not_be_added()
+      {
+         A.CallTo(() => _referencePresenter.DisableTimeSelection()).MustHaveHappened();
+      }
    }
 
    public class When_the_edit_table_formula_with_x_argument_presenter_is_selecting_a_x_argument_object_path_for_the_edited_table_formula : concern_for_EditTableFormulaWithXArgumentFormulaPresenter

--- a/tests/MoBi.Tests/Presentation/SelectReferenceAtParameterPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectReferenceAtParameterPresenterSpecs.cs
@@ -1,0 +1,68 @@
+﻿using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Domain.Repository;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Settings;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Domain;
+using System.Collections.Generic;
+using MoBi.Assets;
+using MoBi.Presentation.DTO;
+using OSPSuite.Presentation.Nodes;
+
+namespace MoBi.Presentation
+{
+   internal class concern_for_SelectReferenceAtParameterPresenter : ContextSpecification<SelectReferenceAtParameterPresenter>
+   {
+      protected ISelectReferenceView _view;
+
+      protected override void Context()
+      {
+         _view = A.Fake<ISelectReferenceView>();
+         sut = new SelectReferenceAtParameterPresenter(_view,
+            A.Fake<IObjectBaseToObjectBaseDTOMapper>(),
+            A.Fake<IMoBiContext>(),
+            A.Fake<IUserSettings>(),
+            A.Fake<IObjectBaseToDummyMoleculeDTOMapper>(),
+            A.Fake<IParameterToDummyParameterDTOMapper>(),
+            A.Fake<IObjectBaseDTOToReferenceNodeMapper>(),
+            A.Fake<IObjectPathCreatorAtParameter>(),
+            A.Fake<IBuildingBlockRepository>());
+      }
+   }
+
+
+   internal class When_time_selection_is_disabled : concern_for_SelectReferenceAtParameterPresenter
+   {
+      private IEntity _localReferencePoint;
+      private IEnumerable<IObjectBase> _contextSpecificEntitiesToAddToReferenceTree;
+      private IUsingFormula _editedObject;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.DisableTimeSelection();
+         _localReferencePoint = new Container();
+         _contextSpecificEntitiesToAddToReferenceTree = A.CollectionOfFake<IObjectBase>(3);
+         _editedObject = new Parameter();
+      }
+
+      protected override void Because()
+      {
+         sut.Init(_localReferencePoint, _contextSpecificEntitiesToAddToReferenceTree, _editedObject);
+      }
+
+      [Observation]
+      public void time_reference_should_not_be_added_to_the_view()
+      {
+         A.CallTo(() => _view.AddNode(A<ITreeNode>.That.Matches(x => isTime(x)))).MustNotHaveHappened();
+      }
+
+      private bool isTime(ITreeNode treeNode)
+      {
+         return (treeNode.TagAsObject as ObjectBaseDTO).Id == AppConstants.Time;
+      }
+   }
+}


### PR DESCRIPTION
Fixes #1521

# Description
Remove time as a selectable reference for TableFormulaWithXArgument

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):