### PR TITLE
Fixes #1522 "Possible references objects" shows the spatial structure outside of the module

### DIFF
--- a/src/MoBi.Presentation/Presenter/CreateObjectPathsFromReferencesPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/CreateObjectPathsFromReferencesPresenter.cs
@@ -9,7 +9,7 @@ namespace MoBi.Presentation.Presenter
 {
    public interface ICreateObjectPathsFromReferencesPresenter : IPresenter<ICreateObjectPathsFromReferencesView>
    {
-      void Init(IEntity localReferencePoint, IEnumerable<IObjectBase> contextSpecificEntitiesToAddToReferenceTree, IUsingFormula editedObject);
+      void Init(IEntity localReferencePoint, IReadOnlyList<IObjectBase> contextSpecificEntitiesToAddToReferenceTree, IUsingFormula editedObject);
       IReadOnlyList<ObjectPath> GetAllSelections();
       void AddSelection();
    }
@@ -29,7 +29,7 @@ namespace MoBi.Presentation.Presenter
 
       private void enableDisableButtons() => _view.CanAdd(_selectReferencePresenter.CanClose);
 
-      public void Init(IEntity localReferencePoint, IEnumerable<IObjectBase> contextSpecificEntitiesToAddToReferenceTree, IUsingFormula editedObject) => _selectReferencePresenter.Init(localReferencePoint, contextSpecificEntitiesToAddToReferenceTree, editedObject);
+      public void Init(IEntity localReferencePoint, IReadOnlyList<IObjectBase> contextSpecificEntitiesToAddToReferenceTree, IUsingFormula editedObject) => _selectReferencePresenter.Init(localReferencePoint, contextSpecificEntitiesToAddToReferenceTree, editedObject);
 
       public IReadOnlyList<ObjectPath> GetAllSelections() => convertTextToObjectPaths(_view.AllPaths.Where(x => !string.IsNullOrWhiteSpace(x)).ToList());
 

--- a/src/MoBi.Presentation/Presenter/EditApplicationBuilderPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditApplicationBuilderPresenter.cs
@@ -141,7 +141,7 @@ namespace MoBi.Presentation.Presenter
          using (var presenter = _applicationController.Start<ISelectFormulaUsablePathPresenter>())
          {
             var selectionPresenter = _applicationController.Start<ISelectReferencePresenterAtApplicationBuilder>();
-            presenter.Init(ob => ob.IsAnImplementationOf<IEntityContainer>(), _applicationBuilder, _applicationBuilder.RootContainer, AppConstants.Captions.RelativeContainerPath, selectionPresenter);
+            presenter.Init(ob => ob.IsAnImplementationOf<IEntityContainer>(), _applicationBuilder, _applicationBuilder.RootContainer.ToList(), AppConstants.Captions.RelativeContainerPath, selectionPresenter);
             var path = presenter.GetSelection();
             if (path == null)
                return;

--- a/src/MoBi.Presentation/Presenter/EditApplicationMoleculeBuilderPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditApplicationMoleculeBuilderPresenter.cs
@@ -69,7 +69,7 @@ namespace MoBi.Presentation.Presenter
       {
          _applicationMoleculeBuilder = applicationMoleculeBuilder;
          _editFormulaPresenter.Init(_applicationMoleculeBuilder, BuildingBlock);
-         _selectItemPresenter.Init(_applicationMoleculeBuilder.ParentContainer, getEventGroupBuilding(BuildingBlock), applicationMoleculeBuilder);
+         _selectItemPresenter.Init(_applicationMoleculeBuilder.ParentContainer, getEventGroupBuilding(BuildingBlock).ToList(), applicationMoleculeBuilder);
          var dto = _applicationMoleculeMapper.MapFrom(_applicationMoleculeBuilder);
          _view.Show(dto);
       }

--- a/src/MoBi.Presentation/Presenter/EditAssignmentBuilderPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditAssignmentBuilderPresenter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Services;
@@ -71,7 +72,7 @@ namespace MoBi.Presentation.Presenter
       public override void Edit(EventAssignmentBuilder eventAssignmentBuilder, IReadOnlyList<IObjectBase> existingObjectsInParent)
       {
          _eventAssignmentBuilder = eventAssignmentBuilder;
-         _selectReferencePresenter.Init(eventAssignmentBuilder, _contextSpecificReferencesRetriever.RetrieveFor(_eventAssignmentBuilder), eventAssignmentBuilder);
+         _selectReferencePresenter.Init(eventAssignmentBuilder, _contextSpecificReferencesRetriever.RetrieveFor(_eventAssignmentBuilder).ToList(), eventAssignmentBuilder);
          _eventAssignmentBuilderDTO = _eventAssignmentToDTOAssignmentMapper.MapFrom(_eventAssignmentBuilder);
          _eventAssignmentBuilderDTO.AddUsedNames(_editTasksForAssignment.GetForbiddenNamesWithoutSelf(eventAssignmentBuilder, existingObjectsInParent));
          bindToView();

--- a/src/MoBi.Presentation/Presenter/EditMoleculeBuilderPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditMoleculeBuilderPresenter.cs
@@ -96,7 +96,7 @@ namespace MoBi.Presentation.Presenter
       {
          _moleculeBuilder = moleculeBuilder;
          _editMoleculeParameters.Edit(moleculeBuilder);
-         _referencePresenter.Init(null, Enumerable.Empty<IObjectBase>(), null);
+         _referencePresenter.Init(null, Enumerable.Empty<IObjectBase>().ToList(), null);
          setUpFormulaEditView();
          var dto = _moleculeBuilderDTOMapper.MapFrom(moleculeBuilder);
          dto.AddUsedNames(_editTasks.GetForbiddenNamesWithoutSelf(moleculeBuilder, existingObjectsInParent));

--- a/src/MoBi.Presentation/Presenter/EditParameterPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditParameterPresenter.cs
@@ -210,7 +210,7 @@ namespace MoBi.Presentation.Presenter
          _parameter = parameter;
          _editValueFormulaPresenter.Init(_parameter, BuildingBlock);
          _editValueFormulaPresenter.ReferencePresenter.Init(_contextSpecificReferencesRetriever.RetrieveLocalReferencePoint(parameter),
-            _contextSpecificReferencesRetriever.RetrieveFor(_parameter, BuildingBlock), _parameter);
+            _contextSpecificReferencesRetriever.RetrieveFor(_parameter, BuildingBlock).ToList(), _parameter);
          _editValueOriginPresenter.Edit(parameter);
 
          if (hasRHS(parameter))
@@ -247,7 +247,7 @@ namespace MoBi.Presentation.Presenter
       {
          _editRHSFormulaPresenter.Init(_parameter, BuildingBlock);
          _editRHSFormulaPresenter.ReferencePresenter.Init(_contextSpecificReferencesRetriever.RetrieveLocalReferencePoint(_parameter),
-            _contextSpecificReferencesRetriever.RetrieveFor(_parameter, BuildingBlock), _parameter);
+            _contextSpecificReferencesRetriever.RetrieveFor(_parameter, BuildingBlock).ToList(), _parameter);
       }
 
       public override object Subject => _parameter;

--- a/src/MoBi.Presentation/Presenter/EditTableFormulaWithXArgumentFormulaPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditTableFormulaWithXArgumentFormulaPresenter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Domain.Services;
@@ -90,7 +91,7 @@ namespace MoBi.Presentation.Presenter
          {
             var referencePresenter = _selectReferencePresenterFactory.ReferenceAtParameterFor(UsingObject?.ParentContainer);
             referencePresenter.DisableTimeSelection();
-            presenter.Init(predicate, UsingObject, UsingObject == null ? Enumerable.Empty<IObjectBase>() : new[] {UsingObject.RootContainer}, caption, referencePresenter);
+            presenter.Init(predicate, UsingObject, UsingObject == null ? Enumerable.Empty<IObjectBase>().ToList() : new List<IObjectBase> {UsingObject.RootContainer}, caption, referencePresenter);
             return presenter.GetSelection();
          }
       }

--- a/src/MoBi.Presentation/Presenter/NewFormulaPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/NewFormulaPresenter.cs
@@ -42,7 +42,7 @@ namespace MoBi.Presentation.Presenter
          var formulaCache = buildingBlock.FormulaCache;
          dto.AddUsedNames(formulaCache.Select(f => f.Name));
          _view.BindTo(dto);
-         _referencePresenter.Init(parameter, Enumerable.Empty<IObjectBase>(), parameter);
+         _referencePresenter.Init(parameter, Enumerable.Empty<IObjectBase>().ToList(), parameter);
          _view.Display();
          formula.Name = dto.Name;
          return !_view.Canceled;

--- a/src/MoBi.Presentation/Presenter/SelectFormulaUsablePathPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectFormulaUsablePathPresenter.cs
@@ -9,7 +9,7 @@ namespace MoBi.Presentation.Presenter
 {
    public interface ISelectFormulaUsablePathPresenter : IDisposablePresenter
    {
-      void Init(Func<IObjectBase, bool> predicate, IEntity refObject, IEnumerable<IObjectBase> entities, string caption, ISelectReferencePresenter referencePresenter);
+      void Init(Func<IObjectBase, bool> predicate, IEntity refObject, IReadOnlyList<IObjectBase> entities, string caption, ISelectReferencePresenter referencePresenter);
       FormulaUsablePath GetSelection();
    }
 
@@ -28,7 +28,7 @@ namespace MoBi.Presentation.Presenter
          _view.OkEnabled = _referencePresenter.LegalObjectSelected;
       }
 
-      public void Init(Func<IObjectBase, bool> predicate, IEntity refObject, IEnumerable<IObjectBase> entities, string caption, ISelectReferencePresenter referencePresenter)
+      public void Init(Func<IObjectBase, bool> predicate, IEntity refObject, IReadOnlyList<IObjectBase> entities, string caption, ISelectReferencePresenter referencePresenter)
       {
          _view.Text = caption;
          _referencePresenter = referencePresenter;

--- a/src/MoBi.Presentation/Presenter/SelectReferenceAtEventAssignmentPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferenceAtEventAssignmentPresenter.cs
@@ -32,7 +32,7 @@ namespace MoBi.Presentation.Presenter
          AddSpatialStructures();
       }
 
-      public override void Init(IEntity assignment, IEnumerable<IObjectBase> contextSpecificEntitiesToAddToReferenceTree, IUsingFormula editedObject)
+      public override void Init(IEntity assignment, IReadOnlyList<IObjectBase> contextSpecificEntitiesToAddToReferenceTree, IUsingFormula editedObject)
       {
          base.Init(assignment, contextSpecificEntitiesToAddToReferenceTree, editedObject);
          addEventGroupParameter(assignment.RootContainer);

--- a/src/MoBi.Presentation/Presenter/SelectReferenceAtReactionPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferenceAtReactionPresenter.cs
@@ -11,7 +11,7 @@ namespace MoBi.Presentation.Presenter
 {
    public interface ISelectReferenceAtReactionPresenter : ISelectReferencePresenter
    {
-      void Init(IEntity refObjectBase, IEnumerable<IObjectBase> entities, ReactionBuilder reactionBuilder);
+      void Init(IEntity refObjectBase, IReadOnlyList<IObjectBase> entities, ReactionBuilder reactionBuilder);
    }
    internal class SelectReferenceAtReactionPresenter : SelectReferencePresenterBase, ISelectReferenceAtReactionPresenter
    {
@@ -32,7 +32,7 @@ namespace MoBi.Presentation.Presenter
          _objectPathCreatorAtReaction = objectPathCreator;
       }
 
-      public void Init(IEntity refObjectBase, IEnumerable<IObjectBase> entities, ReactionBuilder reactionBuilder)
+      public void Init(IEntity refObjectBase, IReadOnlyList<IObjectBase> entities, ReactionBuilder reactionBuilder)
       {
          _objectPathCreatorAtReaction.Reaction = reactionBuilder;
          base.Init(refObjectBase, entities, reactionBuilder);

--- a/src/MoBi.Presentation/Presenter/SelectReferenceAtTransportPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferenceAtTransportPresenter.cs
@@ -15,7 +15,7 @@ namespace MoBi.Presentation.Presenter
 {
    public interface ISelectReferenceAtTransportPresenter : ISelectReferencePresenter
    {
-      void Init(IEntity refObjectBase, IEnumerable<IObjectBase> entities, TransportBuilder transportBuilder);
+      void Init(IEntity refObjectBase, IReadOnlyList<IObjectBase> entities, TransportBuilder transportBuilder);
    }
 
    internal class SelectReferenceAtTransportPresenter : SelectReferencePresenterBase, ISelectReferenceAtTransportPresenter
@@ -43,7 +43,7 @@ namespace MoBi.Presentation.Presenter
       }
 
 
-      public void Init(IEntity refObjectBase, IEnumerable<IObjectBase> entities, TransportBuilder transportBuilder)
+      public void Init(IEntity refObjectBase, IReadOnlyList<IObjectBase> entities, TransportBuilder transportBuilder)
       {
          //Necessary to create correct paths
          _objectPathCreatorAtTransport.Transport = transportBuilder; 

--- a/src/MoBi.Presentation/Presenter/SelectReferencePresenterBase.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferencePresenterBase.cs
@@ -28,7 +28,7 @@ namespace MoBi.Presentation.Presenter
    {
       void GetLocalisationReferences();
 
-      void Init(IEntity localReferencePoint, IEnumerable<IObjectBase> contextSpecificEntitiesToAddToReferenceTree, IUsingFormula editedObject);
+      void Init(IEntity localReferencePoint, IReadOnlyList<IObjectBase> contextSpecificEntitiesToAddToReferenceTree, IUsingFormula editedObject);
 
       IEnumerable<ObjectBaseDTO> GetChildObjects(ObjectBaseDTO dto);
       ReferenceDTO GetReferenceObjectFrom(ObjectBaseDTO objectBaseDTO);
@@ -87,13 +87,14 @@ namespace MoBi.Presentation.Presenter
          SelectionPredicate = parameter => true;
       }
 
-      public virtual void Init(IEntity localReferencePoint, IEnumerable<IObjectBase> contextSpecificEntitiesToAddToReferenceTree, IUsingFormula editedObject)
+      public virtual void Init(IEntity localReferencePoint, IReadOnlyList<IObjectBase> contextSpecificEntitiesToAddToReferenceTree, IUsingFormula editedObject)
       {
          if (localReferencePoint != null)
             _refObject = localReferencePoint;
 
-         _view.Show(contextSpecificEntitiesToAddToReferenceTree.MapAllUsing(_referenceMapper));
+         _view.Clear();
          addInitialObjects();
+         _view.Show(contextSpecificEntitiesToAddToReferenceTree.Where(x => !alreadyInView(x)).MapAllUsing(_referenceMapper), false);
 
          if (_refObject != null)
          {
@@ -102,6 +103,11 @@ namespace MoBi.Presentation.Presenter
          }
 
          _editedObject = editedObject;
+      }
+
+      private bool alreadyInView(IObjectBase objectBase)
+      {
+         return _view.GetNodes(objectBase).Any();
       }
 
       private void addInitialObjects()

--- a/src/MoBi.Presentation/Views/ISelectReferenceView.cs
+++ b/src/MoBi.Presentation/Views/ISelectReferenceView.cs
@@ -11,9 +11,9 @@ namespace MoBi.Presentation.Views
    public interface ISelectReferenceView : IView<ISelectReferencePresenter>
    {
       /// <summary>
-      ///    Clear the tree and show the nodes
+      ///    Optionally clear the tree and show the nodes
       /// </summary>
-      void Show(IEnumerable<ITreeNode> nodes);
+      void Show(IEnumerable<ITreeNode> nodes, bool clear = true);
 
       ObjectBaseDTO SelectedDTO { get; }
       ObjectPathType ObjectPathType { get; set; }
@@ -42,5 +42,6 @@ namespace MoBi.Presentation.Views
 
       void Remove(IObjectBase removedObject);
       IReadOnlyList<ITreeNode> GetNodes(IObjectBase objectBase);
+      void Clear();
    }
 }

--- a/src/MoBi.UI/Views/SelectReferenceView.cs
+++ b/src/MoBi.UI/Views/SelectReferenceView.cs
@@ -125,7 +125,12 @@ namespace MoBi.UI.Views
          _presenter = presenter;
       }
 
-      public void Show(IEnumerable<ITreeNode> nodes) => addNodes(nodes, clear: true);
+      public void Show(IEnumerable<ITreeNode> nodes, bool clear = true) => addNodes(nodes, clear);
+
+      public void Clear()
+      {
+         _treeView.Clear();
+      }
 
       private void addNodes(IEnumerable<ITreeNode> nodes, bool clear)
       {

--- a/tests/MoBi.Tests/Presentation/EditTableFormulaWithOffSetFormulaPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditTableFormulaWithOffSetFormulaPresenterSpecs.cs
@@ -69,7 +69,7 @@ namespace MoBi.Presentation
          _selectReferenceAtParameterPresenter = A.Fake<ISelectReferenceAtParameterPresenter>();
          A.CallTo(_selectReferencePresenterFactory).WithReturnType<ISelectReferenceAtParameterPresenter>().Returns(_selectReferenceAtParameterPresenter);
 
-         A.CallTo(() => _selectFormulaUsablePathPresenter.Init(A<Func<IObjectBase, bool>>._, _usingFormula, A<IEnumerable<IObjectBase>>._, A<string>._, _selectReferenceAtParameterPresenter))
+         A.CallTo(() => _selectFormulaUsablePathPresenter.Init(A<Func<IObjectBase, bool>>._, _usingFormula, A<IReadOnlyList<IObjectBase>>._, A<string>._, _selectReferenceAtParameterPresenter))
             .Invokes(x => _predicate = x.GetArgument<Func<IObjectBase, bool>>(0));
       }
    }

--- a/tests/MoBi.Tests/Presentation/SelectReferenceAtParameterPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectReferenceAtParameterPresenterSpecs.cs
@@ -8,6 +8,7 @@ using MoBi.Presentation.Views;
 using OSPSuite.BDDHelper;
 using OSPSuite.Core.Domain;
 using System.Collections.Generic;
+using System.Linq;
 using MoBi.Assets;
 using MoBi.Presentation.DTO;
 using OSPSuite.Presentation.Nodes;
@@ -37,7 +38,7 @@ namespace MoBi.Presentation
    internal class When_time_selection_is_disabled : concern_for_SelectReferenceAtParameterPresenter
    {
       private IEntity _localReferencePoint;
-      private IEnumerable<IObjectBase> _contextSpecificEntitiesToAddToReferenceTree;
+      private IReadOnlyList<IObjectBase> _contextSpecificEntitiesToAddToReferenceTree;
       private IUsingFormula _editedObject;
 
       protected override void Context()
@@ -45,7 +46,7 @@ namespace MoBi.Presentation
          base.Context();
          sut.DisableTimeSelection();
          _localReferencePoint = new Container();
-         _contextSpecificEntitiesToAddToReferenceTree = A.CollectionOfFake<IObjectBase>(3);
+         _contextSpecificEntitiesToAddToReferenceTree = A.CollectionOfFake<IObjectBase>(3).ToList();
          _editedObject = new Parameter();
       }
 

--- a/tests/MoBi.Tests/Presentation/SelectReferenceAtParameterValuePresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectReferenceAtParameterValuePresenterSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using FakeItEasy;
 using FakeItEasy.Core;
 using MoBi.Core.Domain.Model;
@@ -113,14 +114,14 @@ namespace MoBi.Presentation
    internal class When_initializing_parameterValuePresenter : concern_for_SelectReferenceAtParameterValuePresenter
    {
       private IEntity _localReferencePoint;
-      private IEnumerable<IObjectBase> _contextSpecificEntities;
+      private IReadOnlyList<IObjectBase> _contextSpecificEntities;
       private IUsingFormula _editedObject;
 
       protected override void Context()
       {
          base.Context();
          _localReferencePoint = A.Fake<IEntity>();
-         _contextSpecificEntities = A.CollectionOfFake<IObjectBase>(5);
+         _contextSpecificEntities = A.CollectionOfFake<IObjectBase>(5).ToList();
          _editedObject = A.Fake<IUsingFormula>();
       }
 

--- a/tests/MoBi.Tests/Presentation/SelectReferencePresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectReferencePresenterSpecs.cs
@@ -261,12 +261,14 @@ namespace MoBi.Presentation
          base.Context();
          _moBiSpatialStructure = new MoBiSpatialStructure
          {
-            Name = "MoBiSpatialStructure 1", Id = ShortGuid.NewGuid(),
+            Name = "MoBiSpatialStructure 1",
+            Id = ShortGuid.NewGuid(),
             Module = new Module { Name = "Module 1" }
          };
          _unselectedSpatialStructure = new MoBiSpatialStructure
          {
-            Name = "MoBiSpatialStructure 2", Id = ShortGuid.NewGuid(),
+            Name = "MoBiSpatialStructure 2",
+            Id = ShortGuid.NewGuid(),
             Module = new Module { Name = "Module 2" }
          };
          _moBiSpatialStructures = new[] { _unselectedSpatialStructure, _moBiSpatialStructure };
@@ -275,14 +277,21 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.Init(null, new List<IObjectBase>(), A.Fake<IUsingFormula>());
+         sut.Init(null, new List<IObjectBase> { _moBiSpatialStructure }, A.Fake<IUsingFormula>());
+      }
+
+      [Observation]
+      public void do_not_add_nodes_when_already_present()
+      {
+         var moBiSpatialStructureNodes = _view.GetNodes(_moBiSpatialStructure);
+         moBiSpatialStructureNodes.Count.ShouldBeEqualTo(1);
       }
 
       [Observation]
       public void should_return_nodes_with_specific_properties()
       {
-         var moBiSpatialStructureNodes = _view.GetNodes(_moBiSpatialStructure as IObjectBase);
-         var unselectedSpatialStructureNodes = _view.GetNodes(_unselectedSpatialStructure as IObjectBase);
+         var moBiSpatialStructureNodes = _view.GetNodes(_moBiSpatialStructure);
+         var unselectedSpatialStructureNodes = _view.GetNodes(_unselectedSpatialStructure);
 
          var moBiSpatialStructureNode = moBiSpatialStructureNodes.FirstOrDefault();
          var unselectedSpatialStructureNode = unselectedSpatialStructureNodes.FirstOrDefault();


### PR DESCRIPTION
Fixes #1522

# Description

I generalized it by only adding specific nodes if they are not already in the view for all selection presenters

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):