### PR TITLE
Fixes #1529 When loading a simulation, some building block is automatically opened.

### DIFF
--- a/src/MoBi.Core/Services/SimulationLoader.cs
+++ b/src/MoBi.Core/Services/SimulationLoader.cs
@@ -58,8 +58,8 @@ namespace MoBi.Core.Services
 
          renameCollidingEntities(simulation.Modules, project.Modules);
          renameCollidingEntities(simulation.Configuration.ExpressionProfiles, project.ExpressionProfileCollection);
-         
-         if(simulation.Configuration.Individual != null)
+
+         if (simulation.Configuration.Individual != null)
             renameCollidingEntities(new[] { simulation.Configuration.Individual }, project.IndividualsCollection);
 
          if (shouldCloneSimulation)
@@ -112,7 +112,7 @@ namespace MoBi.Core.Services
       private void addSimulationConfigurationToProject(IMoBiSimulation simulation, ICommandCollector commandCollector)
       {
          var cloneForProjectEntities = _cloneManager.CloneSimulationConfiguration(simulation.Configuration);
-         cloneForProjectEntities.ModuleConfigurations.Each(moduleConfiguration => commandCollector.AddCommand(new AddModuleCommand(moduleConfiguration.Module)));
+         cloneForProjectEntities.ModuleConfigurations.Each(moduleConfiguration => commandCollector.AddCommand(new AddModuleCommand(moduleConfiguration.Module) { Silent = true }));
 
          addToProject(commandCollector, cloneForProjectEntities.Individual, individual => new AddIndividualBuildingBlockToProjectCommand(individual));
          cloneForProjectEntities.ExpressionProfiles.Each(expressionProfile => addToProject(commandCollector, expressionProfile, ep => new AddExpressionProfileBuildingBlockToProjectCommand(ep)));

--- a/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
@@ -38,12 +38,15 @@ namespace MoBi.Presentation.Presenter.Main
       IListener<AddedEvent<Module>>,
       IListener<AddedEvent<IndividualBuildingBlock>>,
       IListener<AddedEvent<ExpressionProfileBuildingBlock>>,
-      IListener<ModuleStatusChangedEvent>
+      IListener<ModuleStatusChangedEvent>,
+      IListener<BulkUpdateStartedEvent>,
+      IListener<BulkUpdateFinishedEvent>
 
    {
       private readonly IObservedDataInExplorerPresenter _observedDataInExplorerPresenter;
       private readonly IEditBuildingBlockStarter _editBuildingBlockStarter;
       private readonly IInteractionTasksForModule _interactionTaskForModule;
+      private bool _editSinglesOnLoad = true;
 
       public ModuleExplorerPresenter(IModuleExplorerView view, IRegionResolver regionResolver, ITreeNodeFactory treeNodeFactory,
          IViewItemContextMenuFactory viewItemContextMenuFactory, IMoBiContext context, IClassificationPresenter classificationPresenter,
@@ -175,7 +178,8 @@ namespace MoBi.Presentation.Presenter.Main
             _view.NodeByType(MoBiRootNodeTypes.ModulesFolder)
          });
 
-         editSingleBuildingBlockModule(moduleToAdd);
+         if(_editSinglesOnLoad)
+            editSingleBuildingBlockModule(moduleToAdd);
       }
 
       public void Handle(AddedEvent<IndividualBuildingBlock> eventToHandle)
@@ -372,6 +376,16 @@ namespace MoBi.Presentation.Presenter.Main
       private void refreshModuleIcon(Module module)
       {
          _view.NodeById(module.Id).Icon = ApplicationIcons.IconByName(module.Icon);
+      }
+
+      public void Handle(BulkUpdateStartedEvent eventToHandle)
+      {
+         _editSinglesOnLoad = false;
+      }
+
+      public void Handle(BulkUpdateFinishedEvent eventToHandle)
+      {
+         _editSinglesOnLoad = true;
       }
    }
 }

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -190,6 +190,7 @@ namespace MoBi.Presentation.Tasks.Interaction
             Description = AppConstants.Commands.AddMany(_editTask.ObjectName)
          };
 
+         Context.PublishEvent(new BulkUpdateStartedEvent());
          foreach (var existingItem in itemsToAdd)
          {
             var command = AddTo(existingItem, parent, buildingBlockWithFormulaCache);
@@ -198,6 +199,8 @@ namespace MoBi.Presentation.Tasks.Interaction
 
             macroCommand.Add(command);
          }
+
+         Context.PublishEvent(new BulkUpdateFinishedEvent());
 
          return macroCommand;
       }

--- a/tests/MoBi.Tests/Core/SimulationLoaderSpecs.cs
+++ b/tests/MoBi.Tests/Core/SimulationLoaderSpecs.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using FakeItEasy;
+using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
 using MoBi.Core.Services;
@@ -11,6 +12,8 @@ using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Serialization.Exchange;
 using MoBi.Helpers;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Core
 {
@@ -53,6 +56,7 @@ namespace MoBi.Core
       private Module _clonedModule;
       private IndividualBuildingBlock _clonedIndividual;
       private SimulationConfiguration _clonedSimulationConfiguration;
+      private MoBiMacroCommand _commands;
 
       protected override void Context()
       {
@@ -79,7 +83,13 @@ namespace MoBi.Core
 
       protected override void Because()
       {
-         sut.AddSimulationToProject(_simulation);
+         _commands = sut.AddSimulationToProject(_simulation) as MoBiMacroCommand;
+      }
+
+      [Observation]
+      public void module_add_commands_are_added_silently()
+      {
+         _commands.All().OfType<AddModuleCommand>().All(command => command.Silent).ShouldBeTrue();
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #1529 

# Description
We made the decision at some point to edit modules when they are added to the project if they only have a single building block. This probably should not be done when the modules are being added from PKML though, either when loading a simulation and creating the modules, or just loading the modules from a simulation (without the simulation).


## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):