### PR TITLE
Fixes #1508 PV BB -> New Parameter Value: also show parameters from ExpProfiles and Individuals

### DIFF
--- a/src/MoBi.Presentation/Presenter/CreateObjectPathsFromReferencesPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/CreateObjectPathsFromReferencesPresenter.cs
@@ -29,7 +29,8 @@ namespace MoBi.Presentation.Presenter
 
       private void enableDisableButtons() => _view.CanAdd(_selectReferencePresenter.CanClose);
 
-      public void Init(IEntity localReferencePoint, IReadOnlyList<IObjectBase> contextSpecificEntitiesToAddToReferenceTree, IUsingFormula editedObject) => _selectReferencePresenter.Init(localReferencePoint, contextSpecificEntitiesToAddToReferenceTree, editedObject);
+      public void Init(IEntity localReferencePoint, IReadOnlyList<IObjectBase> contextSpecificEntitiesToAddToReferenceTree, IUsingFormula editedObject) => 
+         _selectReferencePresenter.Init(localReferencePoint, contextSpecificEntitiesToAddToReferenceTree, editedObject);
 
       public IReadOnlyList<ObjectPath> GetAllSelections() => convertTextToObjectPaths(_view.AllPaths.Where(x => !string.IsNullOrWhiteSpace(x)).ToList());
 

--- a/src/MoBi.Presentation/Presenter/SelectReferenceAtParameterValuePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferenceAtParameterValuePresenter.cs
@@ -1,10 +1,16 @@
+using System.Collections.Generic;
 using System.Linq;
+using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Repository;
+using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Settings;
 using MoBi.Presentation.Views;
 using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Utility.Collections;
+using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation.Presenter
 {
@@ -14,6 +20,8 @@ namespace MoBi.Presentation.Presenter
 
    public class SelectReferenceAtParameterValuePresenter : SelectReferencePresenterBase, ISelectReferenceAtParameterValuePresenter
    {
+      private readonly Cache<IBuildingBlock, IContainer> _containers;
+
       public SelectReferenceAtParameterValuePresenter(ISelectReferenceView view,
          IObjectBaseToObjectBaseDTOMapper objectBaseDTOMapper,
          IMoBiContext context,
@@ -27,12 +35,124 @@ namespace MoBi.Presentation.Presenter
             objectBaseToMoleculeDummyMapper, dummyParameterDTOMapper, referenceMapper, objectPathCreator, Localisations.ContainerOnly, buildingBlockRepository)
       {
          view.EnableMultiSelect = true;
+         _containers = new Cache<IBuildingBlock, IContainer>();
+      }
+
+      public override IEnumerable<ObjectBaseDTO> GetChildObjects(ObjectBaseDTO dto)
+      {
+         var children = base.GetChildObjects(dto).ToList();
+
+         var container = containerFrom(dto);
+         if (_context.ObjectRepository.ContainsObjectWithId(dto.Id))
+         {
+            addExpressionChildren(dto, children);
+            addIndividualChildren(dto, children);
+         }
+         else
+         {
+            container?.Children.Each(x => children.Add(_objectBaseDTOMapper.MapFrom(x)));
+         }
+
+         return children;
+      }
+
+      private IContainer containerFrom(ObjectBaseDTO dto)
+      {
+         if (dto.ObjectBase is IContainer container && _containers.Any(x => x.GetAllContainersAndSelf<IContainer>().Contains(container)))
+            return container;
+
+         return null;
+      }
+
+      private void addIndividualChildren(ObjectBaseDTO dto, List<ObjectBaseDTO> children)
+      {
+         var buildingBlock = _context.Get<IndividualBuildingBlock>(dto.Id);
+         addChildrenFromPathAndValueBuildingBlock<IndividualBuildingBlock, IndividualParameter>(children, buildingBlock);
+      }
+
+      private void addExpressionChildren(ObjectBaseDTO dto, List<ObjectBaseDTO> children)
+      {
+         var buildingBlock = _context.Get<ExpressionProfileBuildingBlock>(dto.Id);
+         // We need the TBuilder type because ExpressionProfileBuildingBlock contains two types of PathAndValueEntity, and we only want to map ExpressionParameters
+         addChildrenFromPathAndValueBuildingBlock<ExpressionProfileBuildingBlock, ExpressionParameter>(children, buildingBlock);
+      }
+
+      private void addChildrenFromPathAndValueBuildingBlock<TBuildingBlock, TEntity>(List<ObjectBaseDTO> children, TBuildingBlock pathAndValueEntities) where TBuildingBlock : PathAndValueEntityBuildingBlock<TEntity> where TEntity : PathAndValueEntity
+      {
+         if (pathAndValueEntities == null)
+            return;
+
+         _containers[pathAndValueEntities] = getGroups<TBuildingBlock, TEntity>(pathAndValueEntities);
+
+         pathAndValueEntities.Where(x => x.DistributionType == null).Each(x => addToContainer(x, _containers[pathAndValueEntities]));
+
+         addPathAndValuesFromContainer(children, _containers[pathAndValueEntities]);
+      }
+
+      private void addPathAndValuesFromContainer(List<ObjectBaseDTO> children, IContainer container)
+      {
+         // first containers
+         children.AddRange(
+            container.GetChildrenSortedByName<IContainer>()
+               .MapAllUsing(_objectBaseDTOMapper));
+
+         //then parameters
+         children.AddRange(container.GetChildrenSortedByName<PathAndValueEntity>()
+            .MapAllUsing(_objectBaseDTOMapper));
+      }
+
+      private static void addToContainer(PathAndValueEntity x, IContainer container)
+      {
+         var parentContainer = x.ContainerPath.TryResolve<IContainer>(container);
+         if (parentContainer != null)
+         {
+            parentContainer.Add(x);
+         }
+      }
+
+      private IContainer getGroups<TBuildingBlock, TEntity>(TBuildingBlock pathAndValueEntities) where TBuildingBlock : PathAndValueEntityBuildingBlock<TEntity> where TEntity : PathAndValueEntity
+      {
+         var rootContainer = new Container();
+
+         // construct a new object path to avoid changing the original object path
+         pathAndValueEntities.Select(x => new ObjectPath(x.ContainerPath)).ToList().Where(x => x.Any()).GroupBy(x => x.First()).Each(x => addContainersFor(x, rootContainer));
+
+         return rootContainer;
+      }
+
+      private void addContainersFor(IGrouping<string, ObjectPath> group, Container rootContainer)
+      {
+         if (string.IsNullOrEmpty(group.Key))
+            return;
+
+         var groupContainer = new Container().WithName(group.Key);
+         group.Each(x => x.RemoveFirst());
+         group.Where(x => x.Any()).GroupBy(x => x.First()).Each(x => addContainersFor(x, groupContainer));
+         rootContainer.Add(groupContainer);
       }
 
       protected override void AddSpecificInitialObjects()
       {
          AddSpatialStructures();
+         addIndividuals();
+         addExpressions();
          _view.ChangeLocalisationAllowed = false;
+      }
+
+      private void addExpressions()
+      {
+         var expressions = _buildingBlockRepository.ExpressionProfileCollection;
+         var nodes = expressions.Select(x => _referenceMapper.MapFrom(x));
+
+         View.AddNodes(nodes);
+      }
+
+      private void addIndividuals()
+      {
+         var individuals = _buildingBlockRepository.IndividualsCollection;
+         var nodes = individuals.Select(x => _referenceMapper.MapFrom(x)).ToList();
+
+         View.AddNodes(nodes);
       }
 
       public override void SelectionChanged()
@@ -46,8 +166,13 @@ namespace MoBi.Presentation.Presenter
       private bool isSelectionParameterType()
       {
          var allSelected = GetAllSelected<IObjectBase>().ToList();
-         var allSelectedAreParameters = allSelected.All(x => x is IParameter);
+         var allSelectedAreParameters = allSelected.All(isSelectable);
          return allSelectedAreParameters && allSelected.Any();
+      }
+
+      private static bool isSelectable(IObjectBase objectBase)
+      {
+         return objectBase is IParameter || objectBase is PathAndValueEntity;
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/SelectReferencePresenterBase.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferencePresenterBase.cs
@@ -53,7 +53,7 @@ namespace MoBi.Presentation.Presenter
       protected IEntity _refObject;
       private readonly IObjectPathCreator _objectPathCreator;
       private readonly Localisations _localisation;
-      private readonly IBuildingBlockRepository _buildingBlockRepository;
+      protected readonly IBuildingBlockRepository _buildingBlockRepository;
       private IUsingFormula _editedObject;
       public Func<IObjectBase, bool> SelectionPredicate { get; set; }
       public event Action SelectionChangedEvent = delegate { };
@@ -199,7 +199,7 @@ namespace MoBi.Presentation.Presenter
       protected T GetSelected<T>() where T : class, IObjectBase
       {
          var dto = _view.SelectedDTO;
-         
+
          return dto == null ? null : _context.Get<T>(dto.Id);
       }
 
@@ -323,7 +323,7 @@ namespace MoBi.Presentation.Presenter
          }
          else
          {
-            //This is a local molecule container . We add local Molecules Properties defined in Molecule BB only if container is defined in a physical cotnainer
+            //This is a local molecule container . We add local Molecules Properties defined in Molecule BB only if container is defined in a physical container
             if (moleculePropertiesContainer.ParentContainer.Mode == ContainerMode.Physical)
             {
                parameterDTOs.AddRange(getAllMoleculeChildren<IParameter>(dummyMolecule)
@@ -387,7 +387,7 @@ namespace MoBi.Presentation.Presenter
 
          if (container.IsNamed(Constants.MOLECULE_PROPERTIES))
          {
-            //Improve a "generic" Moelcule Layer
+            //Improve a "generic" Molecule Layer
             var molecules = allMolecules
                .Distinct(new NameComparer<MoleculeBuilder>())
                .ToEnumerable<MoleculeBuilder, IObjectBase>();

--- a/src/MoBi.UI/Views/CreateObjectPathsFromReferencesView.cs
+++ b/src/MoBi.UI/Views/CreateObjectPathsFromReferencesView.cs
@@ -47,8 +47,12 @@ namespace MoBi.UI.Views
 
       public void AddSelectedPaths(IReadOnlyList<string> pathsToAdd)
       {
-         var pathsSkipped = pathsToAdd.Where(x => memoEditObjectPaths.Lines.Contains(x));
-         memoEditObjectPaths.AppendText(string.Join(Environment.NewLine, pathsToAdd.Except(pathsSkipped)));
+         var allLines = pathsToAdd.Where(x => !memoEditObjectPaths.Lines.Contains(x));
+         
+         if (!string.IsNullOrEmpty(memoEditObjectPaths.Text))
+            allLines = allLines.Prepend(memoEditObjectPaths.Text);
+
+         memoEditObjectPaths.Text = string.Join(Environment.NewLine, allLines);
       }
    }
 }

--- a/tests/MoBi.Tests/Presentation/CreateObjectPathsFromReferencesPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/CreateObjectPathsFromReferencesPresenterSpecs.cs
@@ -8,11 +8,9 @@ using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Settings;
 using MoBi.Presentation.Views;
-using NHibernate.Util;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
-using OSPSuite.Serializer.Attributes;
 
 namespace MoBi.Presentation
 {


### PR DESCRIPTION
Fixes #1508 

# Description
Adding expressions and individuals as selectable elements in the New PathAndValueEntity object path selection dialog.

See the screenshot. The tree nodes relating to individuals and expressions do not have icons because these are reconstructed from paths. There's no other context for icons.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/286cb48d-c614-4471-87e4-7b8b9b9aa510)


# Questions (if appropriate):