### PR TITLE
Fixes #1415 Extend PV and IC BB from PKML

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -221,7 +221,7 @@ namespace MoBi.Assets
          public static readonly string RenameCommand = Command.CommandTypeRename;
          public static readonly string SetToDefaultDefaultDescription = "Sets Values to Defaults defined in Molecules and Spatial Structure";
          public static readonly string SetToDefaultDefaultType = "Set To Default";
-         public static readonly string ExtendDescription = "Adding new values from Molecules and Spatial Structure";
+         public static readonly string ExtendDescription = "Adding new values";
          public static readonly string AddManyMoleculesDescription = "Add some Molecules to Reaction Diagram";
          public static readonly string MergeCommand = "Merge";
          public static readonly string AddParameterIdentificationResults = "Add parameter identification results to start values collection";
@@ -1133,6 +1133,7 @@ namespace MoBi.Assets
 
          public static string AddExistingAs(string objectTypeName, string targetTypeName) => $"Load {objectTypeName} as {targetTypeName}...";
          public static string AddExisting(string objectTypeName) => $"Load {objectTypeName}...";
+         public static string ExtendFrom(string objectTypeName) => $"Extend from {objectTypeName}...";
 
          public static string AddExistingFromTemplate(string objectTypeName) => $"Load {objectTypeName} from Template...";
 

--- a/src/MoBi.Core/Commands/AddPathAndValueEntityToBuildingBlockCommand.cs
+++ b/src/MoBi.Core/Commands/AddPathAndValueEntityToBuildingBlockCommand.cs
@@ -12,7 +12,6 @@ namespace MoBi.Core.Commands
    {
       private T _pathAndValueEntity;
       private readonly ObjectPath _objectPath;
-      private byte[] _serializedPathAndValueEntity;
 
       public AddPathAndValueEntityToBuildingBlockCommand(ILookupBuildingBlock<T> buildingBlock, T pathAndValueEntity)
          : base(buildingBlock)
@@ -27,7 +26,7 @@ namespace MoBi.Core.Commands
       public override void RestoreExecutionData(IMoBiContext context)
       {
          base.RestoreExecutionData(context);
-         _pathAndValueEntity = context.Deserialize<T>(_serializedPathAndValueEntity);
+         _pathAndValueEntity = _buildingBlock.ByPath(_objectPath);
       }
 
       protected override void ClearReferences()
@@ -39,7 +38,6 @@ namespace MoBi.Core.Commands
       protected override void ExecuteWith(IMoBiContext context)
       {
          base.ExecuteWith(context);
-         _serializedPathAndValueEntity = context.Serialize(_pathAndValueEntity);
          _buildingBlock.Add(_pathAndValueEntity);
          if (_pathAndValueEntity.Formula != null)
             _buildingBlock.AddFormula(_pathAndValueEntity.Formula);

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForInitialConditionsBuildingBlock.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForInitialConditionsBuildingBlock.cs
@@ -34,6 +34,7 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
             .WithIcon(ApplicationIcons.ExportToExcel)
             .WithCommandFor<ExportInitialConditionsBuildingBlockToExcelUICommand, InitialConditionsBuildingBlock>(buildingBlock, _container));
 
+         _allMenuItems.Add(createExtendBuildingBlockCommand(buildingBlock));
          return this;
       }
 
@@ -42,6 +43,13 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          return CreateMenuButton.WithCaption(AppConstants.MenuNames.Clone.WithEllipsis())
             .WithIcon(ApplicationIcons.Clone)
             .WithCommandFor<ClonePathAndValueEntityBuildingBlockUICommand<InitialConditionsBuildingBlock, InitialCondition, IInitialConditionsTask<InitialConditionsBuildingBlock>>, InitialConditionsBuildingBlock>(buildingBlock, _container);
+      }
+
+      private IMenuBarItem createExtendBuildingBlockCommand(InitialConditionsBuildingBlock buildingBlock)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.ExtendFrom(ObjectTypes.InitialConditionsBuildingBlock))
+            .WithIcon(ApplicationIcons.LoadIconFor(nameof(InitialConditionsBuildingBlock)))
+            .WithCommandFor<ExtendInitialConditionsFromInitialConditionsUICommand, InitialConditionsBuildingBlock>(buildingBlock, _container);
       }
    }
 }

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForParameterValuesBuildingBlock.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForParameterValuesBuildingBlock.cs
@@ -1,17 +1,17 @@
 ﻿using MoBi.Assets;
-using OSPSuite.Presentation.MenuAndBars;
 using MoBi.Core.Domain.Model;
 using MoBi.Presentation.DTO;
+using MoBi.Presentation.Tasks.Interaction;
 using MoBi.Presentation.UICommand;
+using OSPSuite.Assets;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Extensions;
 using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.MenuAndBars;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Presenters.ContextMenus;
-using OSPSuite.Assets;
 using OSPSuite.Utility.Container;
-using MoBi.Presentation.Tasks.Interaction;
-using OSPSuite.Core.Extensions;
 
 namespace MoBi.Presentation.MenusAndBars.ContextMenus
 {
@@ -33,6 +33,9 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
             .WithIcon(ApplicationIcons.ExportToExcel)
             .WithCommandFor<ExportParameterValuesBuildingBlockToExcelUICommand, ParameterValuesBuildingBlock>(buildingBlock, _container));
 
+         _allMenuItems.Add(createExtendParameterValueBuildingBlockFromExpression(buildingBlock));
+         _allMenuItems.Add(createExtendParameterValueBuildingBlockFromIndividual(buildingBlock));
+
          return this;
       }
 
@@ -41,6 +44,20 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          return CreateMenuButton.WithCaption(AppConstants.MenuNames.Clone.WithEllipsis())
             .WithIcon(ApplicationIcons.Clone)
             .WithCommandFor<ClonePathAndValueEntityBuildingBlockUICommand<ParameterValuesBuildingBlock, ParameterValue, IParameterValuesTask>, ParameterValuesBuildingBlock>(buildingBlock, _container);
+      }
+
+      private IMenuBarItem createExtendParameterValueBuildingBlockFromExpression(ParameterValuesBuildingBlock buildingBlock)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.ExtendFrom(ObjectTypes.ExpressionProfileBuildingBlock))
+            .WithIcon(ApplicationIcons.LoadIconFor(nameof(ExpressionProfileBuildingBlock)))
+            .WithCommandFor<ExtendParameterValuesFromExpressionUICommand, ParameterValuesBuildingBlock>(buildingBlock, _container);
+      }
+
+      private IMenuBarItem createExtendParameterValueBuildingBlockFromIndividual(ParameterValuesBuildingBlock buildingBlock)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.ExtendFrom(_objectTypeResolver.TypeFor<IndividualBuildingBlock>()))
+            .WithIcon(ApplicationIcons.LoadIconFor(nameof(IndividualBuildingBlock)))
+            .WithCommandFor<ExtendParameterValuesFromIndividualUICommand, ParameterValuesBuildingBlock>(buildingBlock, _container);
       }
    }
 }

--- a/src/MoBi.Presentation/Tasks/Interaction/IInteractionTasksForExtendablePathAndValueEntity.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/IInteractionTasksForExtendablePathAndValueEntity.cs
@@ -9,11 +9,13 @@ using OSPSuite.Core.Domain.UnitSystem;
 
 namespace MoBi.Presentation.Tasks.Interaction
 {
-   public interface IInteractionTasksForExtendablePathAndValueEntity<TBuildingBlock, in TPathAndValueEntity> : IInteractionTasksForBuildingBlock<Module, TBuildingBlock>, IInteractionTasksForPathAndValueEntity<TBuildingBlock, TPathAndValueEntity>
+   public interface IInteractionTasksForExtendablePathAndValueEntity<TBuildingBlock, TPathAndValueEntity> : IInteractionTasksForBuildingBlock<Module, TBuildingBlock>, IInteractionTasksForPathAndValueEntity<TBuildingBlock, TPathAndValueEntity>
       where TBuildingBlock : class, IBuildingBlock<TPathAndValueEntity>
       where TPathAndValueEntity : PathAndValueEntity
    {
       void ExtendPathAndValueEntityBuildingBlock(TBuildingBlock buildingBlock);
+
+      IMoBiCommand Extend(IReadOnlyList<TPathAndValueEntity> pathAndValueEntities, ILookupBuildingBlock<TPathAndValueEntity> buildingBlockToExtend, bool retainConflictingEntities = true);
 
       /// <summary>
       ///    Generates a command that will add the pathAndValueEntity to the building block

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExtendablePathAndValueEntity.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExtendablePathAndValueEntity.cs
@@ -173,7 +173,7 @@ namespace MoBi.Presentation.Tasks.Interaction
          return moBiMacroCommand;
       }
 
-      protected IMoBiCommand Extend(IReadOnlyList<TPathAndValueEntity> pathAndValueEntities, ILookupBuildingBlock<TPathAndValueEntity> buildingBlockToExtend, bool retainConflictingEntities = true)
+      public IMoBiCommand Extend(IReadOnlyList<TPathAndValueEntity> pathAndValueEntities, ILookupBuildingBlock<TPathAndValueEntity> buildingBlockToExtend, bool retainConflictingEntities = true)
       {
          var macro = CreateExtendMacroCommand(_interactionTaskContext.GetTypeFor(buildingBlockToExtend));
 

--- a/src/MoBi.Presentation/UICommand/ExtendParameterValuesFromPathAndValuesUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/ExtendParameterValuesFromPathAndValuesUICommand.cs
@@ -1,0 +1,91 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Presentation.UICommands;
+using OSPSuite.Utility;
+using OSPSuite.Utility.Extensions;
+
+namespace MoBi.Presentation.UICommand
+{
+   public abstract class ExtendBuildingBlockFromPathAndValuesUICommand<TSource, TSourceParent, TTarget, TTargetBuilder> : ObjectUICommand<TTarget> where TSource : BuildingBlock where TTarget : PathAndValueEntityBuildingBlock<TTargetBuilder> where TTargetBuilder : PathAndValueEntity where TSourceParent : class
+   {
+      private readonly IInteractionTasksForBuildingBlock<TSourceParent, TSource> _interactionTasksForSource;
+      private readonly IInteractionTasksForExtendablePathAndValueEntity<TTarget, TTargetBuilder> _taskForExtendingTarget;
+      private readonly IMoBiContext _context;
+
+      protected ExtendBuildingBlockFromPathAndValuesUICommand(
+         IInteractionTasksForBuildingBlock<TSourceParent, TSource> interactionTasksForSource,
+         IInteractionTasksForExtendablePathAndValueEntity<TTarget, TTargetBuilder> taskForExtendingTarget,
+         IMoBiContext context)
+      {
+         _interactionTasksForSource = interactionTasksForSource;
+         _taskForExtendingTarget = taskForExtendingTarget;
+         _context = context;
+      }
+
+      protected override void PerformExecute()
+      {
+         var buildingBlocks = _interactionTasksForSource.LoadFromPKML();
+         _context.AddToHistory(_taskForExtendingTarget.Extend(MapAll(buildingBlocks), Subject));
+      }
+
+      protected abstract IReadOnlyList<TTargetBuilder> MapAll(IReadOnlyList<TSource> buildingBlocks);
+   }
+
+   public abstract class ExtendParameterValuesFromPathAndValuesUICommand<TBuildingBlock> : ExtendBuildingBlockFromPathAndValuesUICommand<TBuildingBlock, MoBiProject, ParameterValuesBuildingBlock, ParameterValue> where TBuildingBlock : BuildingBlock
+   {
+      private readonly IMapper<TBuildingBlock, ParameterValuesBuildingBlock> _mapper;
+
+      protected ExtendParameterValuesFromPathAndValuesUICommand(
+         IInteractionTasksForBuildingBlock<MoBiProject, TBuildingBlock> interactionTasksForSource,
+         IMapper<TBuildingBlock, ParameterValuesBuildingBlock> mapper,
+         IParameterValuesTask parameterValuesTask,
+         IMoBiContext context) : base(interactionTasksForSource, parameterValuesTask, context)
+      {
+         _mapper = mapper;
+      }
+
+      protected override IReadOnlyList<ParameterValue> MapAll(IReadOnlyList<TBuildingBlock> buildingBlocks)
+      {
+         return buildingBlocks.MapAllUsing(_mapper).SelectMany(x => x).ToList();
+      }
+   }
+
+   public class ExtendParameterValuesFromIndividualUICommand : ExtendParameterValuesFromPathAndValuesUICommand<IndividualBuildingBlock>
+   {
+      public ExtendParameterValuesFromIndividualUICommand(
+         IInteractionTasksForIndividualBuildingBlock interactionTask,
+         IIndividualToParameterValuesMapper mapper,
+         IParameterValuesTask parameterValuesTask,
+         IMoBiContext context) : base(interactionTask, mapper, parameterValuesTask, context)
+      {
+      }
+   }
+
+   public class ExtendParameterValuesFromExpressionUICommand : ExtendParameterValuesFromPathAndValuesUICommand<ExpressionProfileBuildingBlock>
+   {
+      public ExtendParameterValuesFromExpressionUICommand(
+         IInteractionTasksForExpressionProfileBuildingBlock interactionTask,
+         IExpressionProfileToParameterValuesMapper mapper,
+         IParameterValuesTask parameterValuesTask,
+         IMoBiContext context) : base(interactionTask, mapper, parameterValuesTask, context)
+      {
+      }
+   }
+
+   public class ExtendInitialConditionsFromInitialConditionsUICommand : ExtendBuildingBlockFromPathAndValuesUICommand<InitialConditionsBuildingBlock, Module, InitialConditionsBuildingBlock, InitialCondition>
+   {
+      public ExtendInitialConditionsFromInitialConditionsUICommand(IInitialConditionsTask<InitialConditionsBuildingBlock> interactionTasksForSource, IMoBiContext context) : base(interactionTasksForSource, interactionTasksForSource, context)
+      {
+      }
+
+      protected override IReadOnlyList<InitialCondition> MapAll(IReadOnlyList<InitialConditionsBuildingBlock> buildingBlocks)
+      {
+         return buildingBlocks.SelectMany(x => x).ToList();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #1415

# Description
Add a convenient way for users to import path and values into various building blocks.

- Import individual pkml into pvbb
- Import expression pkml into pvbb
- Import ic pkml into ic

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/b63bf4bc-df16-4b3d-bbdd-be8aa3882dda)
![image](https://github.com/user-attachments/assets/ed386487-7401-4884-8a22-ac55720e63cb)

# Questions (if appropriate):