### PR TITLE
Exception when trying to rename a simulation #1563

### DIFF
--- a/src/MoBi.Core/Commands/BuildingBlockChangeCommandBase.cs
+++ b/src/MoBi.Core/Commands/BuildingBlockChangeCommandBase.cs
@@ -57,7 +57,7 @@ namespace MoBi.Core.Commands
          get
          {
             // not a module building block
-            if (_buildingBlock.Module == null)
+            if (_buildingBlock?.Module == null)
                return false;
 
             // already an extension module

--- a/tests/MoBi.Tests/Core/MoBiContextSpecs.cs
+++ b/tests/MoBi.Tests/Core/MoBiContextSpecs.cs
@@ -290,6 +290,31 @@ namespace MoBi.Core
       }
    }
 
+   public class When_running_module_commands_that_uses_rename_object_base_without_building_block : concern_for_MoBiContext
+   {
+      private RenameObjectBaseCommand _command;
+      private MoBiSimulation _simulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = new MoBiSimulation().WithName("oldname");
+         _command = new RenameObjectBaseCommand(_simulation, "newname", null);
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).Returns(ViewResult.Yes);
+      }
+
+      protected override void Because()
+      {
+         sut.PromptForCancellation(_command);
+      }
+
+      [Observation]
+      public void the_user_should_be_prompted()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).MustNotHaveHappened();
+      }
+   }
+
    public class When_canceling_the_conversion : concern_for_MoBiContext
    {
       private MoBiMacroCommand _command;


### PR DESCRIPTION
Fixes #1563

# Description
Renaming uses commands for building blocks, but when renaming non-building block items, the property is left null. 

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):