### PR TITLE
Two individual in MoBi: Keep switching between them #1568

### DIFF
--- a/src/MoBi.UI/Views/IndividualBuildingBlockView.cs
+++ b/src/MoBi.UI/Views/IndividualBuildingBlockView.cs
@@ -42,6 +42,7 @@ namespace MoBi.UI.Views
 
       private readonly PopupContainerControl _popupControl = new PopupContainerControl();
       private readonly RepositoryItemPopupContainerEdit _repositoryItemPopupContainerEdit = new RepositoryItemPopupContainerEdit();
+      private LayoutControlGroup _flowGroup;
 
       public IndividualBuildingBlockView(ValueOriginBinder<IndividualParameterDTO> valueOriginBinder)
       {
@@ -211,14 +212,20 @@ namespace MoBi.UI.Views
 
       private void createNameValuePairs(IndividualBuildingBlockDTO buildingBlock)
       {
-         var flowGroup = uxLayoutControl.AddGroup();
-         flowGroup.Text = OriginData;
-         flowGroup.LayoutMode = LayoutMode.Flow;
-         flowGroup.Move(gridGroup, InsertType.Top);
+         if (_flowGroup != null)
+         {
+            uxLayoutControl.Remove(_flowGroup);
+            _flowGroup.Dispose();
+         }
+
+         _flowGroup = uxLayoutControl.AddGroup();
+         _flowGroup.Text = OriginData;
+         _flowGroup.LayoutMode = LayoutMode.Flow;
+         _flowGroup.Move(gridGroup, InsertType.Top);
          var extendedProperties = buildingBlock.OriginData;
 
-         extendedProperties.Each(x => addOriginDataToView(x, flowGroup));
-         addPKSimVersionToView(buildingBlock.PKSimVersion, flowGroup);
+         extendedProperties.Each(x => addOriginDataToView(x, _flowGroup));
+         addPKSimVersionToView(buildingBlock.PKSimVersion, _flowGroup);
          resizeTextBoxesToBestFit();
          uxLayoutControl.BestFit();
       }


### PR DESCRIPTION
Fixes #1568

# Description
We have to remove the old controls for origindata when editing an individual. The view is sometimes already visible when the item is double clicked or edited.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):