### PR TITLE
Fixes #1562 PV BB: right clicking on a column name shows two context menus

### DIFF
--- a/src/MoBi.UI/Views/BasePathAndValueEntityView.cs
+++ b/src/MoBi.UI/Views/BasePathAndValueEntityView.cs
@@ -111,6 +111,8 @@ namespace MoBi.UI.Views
          layoutItemRibbon.SizeConstraintsType = SizeConstraintsType.Custom;
          layoutItemRibbon.MaxSize = new Size(0, ribbonControl.Size.Height);
          layoutItemRibbon.MinSize = new Size(0, ribbonControl.Size.Height);
+
+         gridView.ShowColumnChooser = true;
       }
 
       private void hideEditor() => _unitControl.Hide();

--- a/src/MoBi.UI/Views/ParameterValuesView.cs
+++ b/src/MoBi.UI/Views/ParameterValuesView.cs
@@ -1,7 +1,7 @@
 ﻿using System.Windows.Forms;
 using DevExpress.Utils;
 using DevExpress.XtraBars;
-using DevExpress.XtraBars.Ribbon;
+using DevExpress.XtraGrid.Views.Grid.ViewInfo;
 using MoBi.Assets;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Formatters;
@@ -19,6 +19,7 @@ using OSPSuite.UI.RepositoryItems;
 using OSPSuite.UI.Services;
 using OSPSuite.UI.Views;
 using OSPSuite.Utility.Extensions;
+using Unit = OSPSuite.Core.Domain.UnitSystem.Unit;
 
 namespace MoBi.UI.Views
 {
@@ -97,7 +98,12 @@ namespace MoBi.UI.Views
 
       private void onGridViewMouseDown(MouseEventArgs e)
       {
-         if (e.Button != MouseButtons.Right) return;
+         if (e.Button != MouseButtons.Right) 
+            return;
+
+         if (gridView.CalcHitInfo(e.Location).HitTest != GridHitTest.EmptyRow)
+            return;
+
          ((ParameterValuesPresenter)_presenter).ShowContextMenu(null, this.CalculateRelativeOffset(e.Location, gridControl));
       }
 


### PR DESCRIPTION
Fixes #1562

# Description
Show column chooser and only allow context menu for empty context (not when clicking in headers or cells)

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):