### PR TITLE
#1554 rename module

### DIFF
--- a/src/MoBi.Core/Services/SimulationLoader.cs
+++ b/src/MoBi.Core/Services/SimulationLoader.cs
@@ -64,8 +64,6 @@ namespace MoBi.Core.Services
          if (shouldCloneSimulation)
             moBiSimulation = cloneSimulation(moBiSimulation);
 
-         addSimulationConfigurationToProject(moBiSimulation, loadCommand);
-
          moBiSimulation.ResultsDataRepository = simulation.ResultsDataRepository;
 
          var originalSimulationName = moBiSimulation.Name;
@@ -73,7 +71,9 @@ namespace MoBi.Core.Services
             return;
 
          if (originalSimulationName != moBiSimulation.Name) //has been renamed
-            correctModuleNames(simulation.Modules, moBiSimulation.Name, project.Modules, originalSimulationName);
+            correctModuleNames(moBiSimulation.Modules, moBiSimulation.Name, project.Modules, originalSimulationName);
+
+         addSimulationConfigurationToProject(moBiSimulation, loadCommand);
 
          moBiSimulation.HasChanged = true;
          loadCommand.AddCommand(new AddSimulationCommand(moBiSimulation));
@@ -94,7 +94,7 @@ namespace MoBi.Core.Services
       private void renameModulesAfterSimulation(Module module, string simulationName, string originalSimulationName)
       {
          if (module.Name.StartsWith(originalSimulationName))
-            module.Name.Replace(originalSimulationName, simulationName);
+            module.Name = module.Name.Replace(originalSimulationName, simulationName);
       }
       
       private void renameCollidingEntities(IEnumerable<IObjectBase> entitiesToRename, IReadOnlyList<IWithName> existingEntities)

--- a/tests/MoBi.Tests/Core/SimulationLoaderSpecs.cs
+++ b/tests/MoBi.Tests/Core/SimulationLoaderSpecs.cs
@@ -62,7 +62,6 @@ namespace MoBi.Core
          _project.AddModule(new Module().WithName("moduleName"));
          _project.AddModule(new Module().WithName("newModuleName"));
 
-
          _clonedBuildingBlock = new ObserverBuildingBlock().WithId("SP2");
          _clonedModule = new Module
          {
@@ -73,8 +72,6 @@ namespace MoBi.Core
          _clonedSimulationConfiguration = new SimulationConfiguration();
          _clonedSimulationConfiguration.AddModuleConfiguration(new ModuleConfiguration(_clonedModule));
          _clonedSimulationConfiguration.Individual = _clonedIndividual;
-         _simulation.Configuration.AddModuleConfiguration(new ModuleConfiguration(new Module().WithName("newModuleName")));
-         _simulation.Configuration.AddModuleConfiguration(new ModuleConfiguration(new Module().WithName("Unique moduleName")));
          _simulation.Configuration.AddModuleConfiguration(new ModuleConfiguration(new Module().WithName("Sim1 1")));
          _simulation.Configuration.AddModuleConfiguration(new ModuleConfiguration(new Module().WithName("Sim1 2")));
          _simulation.Name = "Sim1";
@@ -86,10 +83,6 @@ namespace MoBi.Core
 
          A.CallTo(() => _nameCorrector.CorrectName(A<IEnumerable<IObjectBase>>.Ignored, _simulation))
             .Returns(true);
-
-         //I need this invocation to provide a unique name for the modules.
-         A.CallTo(() => _nameCorrector.AutoCorrectName(A<IEnumerable<string>>.Ignored, A<Module>.Ignored))
-            .Invokes((IEnumerable<string> takenNames, Module module) => { module.Name = $"{module.Name} has been renamed"; });
       }
 
       protected override void Because()
@@ -128,23 +121,10 @@ namespace MoBi.Core
       }
 
       [Observation]
-      public void the_module_in_the_simulation_with_conflicting_names_should_be_renamed()
-      {
-         _simulation.Modules[0].Name.ShouldContain("has been renamed".ToCharArray());
-         _simulation.Modules[1].Name.ShouldContain("has been renamed".ToCharArray());
-      }
-
-      [Observation]
-      public void the_module_in_the_simulation_with_no_conflicting_name_should_not_be_renamed()
-      {
-         _simulation.Modules[2].Name.ShouldBeEqualTo("Unique moduleName");
-      }
-
-      [Observation]
       public void the_modules_in_the_simulation_named_after_simulation_have_been_changed()
       {
-         _simulation.Modules[3].Name.ShouldBeEqualTo($"Sim1 1");
-         _simulation.Modules[4].Name.ShouldBeEqualTo($"Sim1 2");
+         _simulation.Modules[1].Name.ShouldBeEqualTo($"new SimName 1");
+         _simulation.Modules[2].Name.ShouldBeEqualTo($"new SimName 2");
       }
    }
 


### PR DESCRIPTION
Fixes #1554 

# Description

 When importing a simulation from pkml, whose name already exists in the project: MoBi asks to rename the simulation and suggests <old simulation name> N as the new default name:
However, if I enter another name for the simulation: the module of the imported simulation still has the default name

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):