### PR TITLE
Fixes #1083 Simulation out of synch - show differences

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1128,6 +1128,7 @@ namespace MoBi.Assets
          public static readonly string SettingsAndSchema = "Output Intervals and Solver Settings";
          public static readonly string MergeBehavior = "Merge Behavior";
          public static readonly string ExportToExcel = "Export to Excel®...";
+         public static readonly string ShowDifferences = "Show Differences";
 
          public static string AddNew(string objectTypeName) => $"Create {objectTypeName}...";
 
@@ -1619,7 +1620,10 @@ namespace MoBi.Assets
          public static readonly string NotPresent = "Not Present";
          public static readonly string EditFormula = "Edit Formula";
          public static readonly string AssigningFormulaCreatesCircularReference = "Assigning formula creates circular reference";
-
+         public static readonly string Changes = "Changes";
+         public static readonly string SimulationChangesSinceConfiguration = "Simulation changes since configuration";
+         public static readonly string OriginalValue = "Original Value";
+         public static readonly string CurrentValue = "Current Value";
          public static string SelectTheBuildingBlockWhereEntitiesWillBeAddedOrUpdated(string typeBeingAdded) => $"Select the building block where {typeBeingAdded} will be added or updated";
          public static readonly string SelectBuildingBlock = "Select Building Block";
          public static readonly string MakeDefault = "Make defaults";

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1128,7 +1128,7 @@ namespace MoBi.Assets
          public static readonly string SettingsAndSchema = "Output Intervals and Solver Settings";
          public static readonly string MergeBehavior = "Merge Behavior";
          public static readonly string ExportToExcel = "Export to Excel®...";
-         public static readonly string ShowDifferences = "Show Differences";
+         public static readonly string ShowChanges = "Show Changes";
 
          public static string AddNew(string objectTypeName) => $"Create {objectTypeName}...";
 

--- a/src/MoBi.Core/Commands/UpdateSimulationCommand.cs
+++ b/src/MoBi.Core/Commands/UpdateSimulationCommand.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
@@ -78,7 +79,9 @@ namespace MoBi.Core.Commands
          _wasChanged = _simulationToUpdate.HasChanged;
          _simulationToUpdate.HasChanged = _hasChanged;
 
-
+         // We need ToList since we are modifying the collection in the loop
+         _simulationToUpdate.OriginalQuantityValues.ToList().Each(x => _simulationToUpdate.RemoveOriginalQuantityValue(x.Path));
+         
          context.PublishEvent(new SimulationReloadEvent(_simulationToUpdate));
       }
 

--- a/src/MoBi.Core/Events/ShowSimulationChangesEvent.cs
+++ b/src/MoBi.Core/Events/ShowSimulationChangesEvent.cs
@@ -1,0 +1,14 @@
+﻿using MoBi.Core.Domain.Model;
+
+namespace MoBi.Core.Events
+{
+   public class ShowSimulationChangesEvent
+   {
+      public readonly IMoBiSimulation Simulation;
+
+      public ShowSimulationChangesEvent(IMoBiSimulation simulation)
+      {
+         Simulation = simulation;
+      }
+   }
+}

--- a/src/MoBi.Core/Serialization/Xml/Serializer/OriginalQuantityValueXmlSerializer.cs
+++ b/src/MoBi.Core/Serialization/Xml/Serializer/OriginalQuantityValueXmlSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Xml.Linq;
 using MoBi.Core.Domain;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Serialization.Xml;
 using OSPSuite.Core.Serialization.Xml.Extensions;
 
@@ -18,6 +19,10 @@ namespace MoBi.Core.Serialization.Xml.Serializer
       protected override void TypedDeserialize(OriginalQuantityValue originalQuantityValue, XElement element, SerializationContext serializationContext)
       {
          base.TypedDeserialize(originalQuantityValue, element, serializationContext);
+
+         if (originalQuantityValue.Dimension == null)
+            originalQuantityValue.Dimension = Constants.Dimension.NO_DIMENSION;
+
          element.UpdateDisplayUnit(originalQuantityValue);
       }
 

--- a/src/MoBi.Presentation/DTO/OriginalQuantityValueDTO.cs
+++ b/src/MoBi.Presentation/DTO/OriginalQuantityValueDTO.cs
@@ -1,0 +1,33 @@
+﻿using MoBi.Core.Domain;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.UnitSystem;
+
+namespace MoBi.Presentation.DTO
+{
+   public class OriginalQuantityValueDTO
+   {
+      public OriginalQuantityValueDTO(OriginalQuantityValue originalQuantityValue)
+      {
+         Dimension = originalQuantityValue.Dimension;
+         Path = originalQuantityValue.Path;
+         OriginalValue = Dimension.BaseUnitValueToUnitValue(originalQuantityValue.DisplayUnit, originalQuantityValue.Value);
+         OriginalDisplayUnit = originalQuantityValue.DisplayUnit;
+      }
+
+      public string Path { get; private set; }
+      public IDimension Dimension {  get; set;}
+
+      public double? CurrentValue { get; private set; }
+      public Unit CurrentDisplayUnit { get; private set; }
+
+      public Unit OriginalDisplayUnit { get; set; }
+      public double? OriginalValue { get; private set; }
+
+      public OriginalQuantityValueDTO WithCurrentQuantity(IQuantity quantity)
+      {
+         CurrentValue = Dimension.BaseUnitValueToUnitValue(quantity.DisplayUnit, quantity.Value);
+         CurrentDisplayUnit = quantity.DisplayUnit;
+         return this;
+      }
+   }
+}

--- a/src/MoBi.Presentation/Formatters/FormatterExtensions.cs
+++ b/src/MoBi.Presentation/Formatters/FormatterExtensions.cs
@@ -1,5 +1,7 @@
+using System;
 using MoBi.Presentation.DTO;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Utility.Format;
 
 namespace MoBi.Presentation.Formatters
@@ -14,6 +16,11 @@ namespace MoBi.Presentation.Formatters
       public static IFormatter<double?> ParameterValueFormatter(this ParameterValueDTO parameterValueDTO)
       {
          return new ValueAllowingNaNFormatter(parameterValueDTO);
+      }
+
+      public static IFormatter<double?> OriginalQuantityValueFormatter(this OriginalQuantityValueDTO originalQuantityValueDTO, Func<OriginalQuantityValueDTO, Unit> displayUnitRetriever)
+      {
+         return new NullableWithRetrievableDisplayUnitFormatter(() => displayUnitRetriever(originalQuantityValueDTO));
       }
 
       public static IFormatter<double?> IndividualParameterFormatter(this IndividualParameterDTO individualParameterDTO)

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForSimulation.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForSimulation.cs
@@ -205,9 +205,9 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
 
       private IMenuBarItem createShowDifferences(IMoBiSimulation simulation)
       {
-         return CreateMenuButton.WithCaption(AppConstants.MenuNames.ShowDifferences)
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.ShowChanges)
             .WithIcon(ApplicationIcons.Comparison)
-            .WithCommandFor<ShowDifferencesUICommand, IMoBiSimulation>(simulation, _container);
+            .WithCommandFor<ShowChangesUICommand, IMoBiSimulation>(simulation, _container);
       }
 
       private IMenuBarItem createCommit(IMoBiSimulation simulation)

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForSimulation.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForSimulation.cs
@@ -52,7 +52,10 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
 
 
          if (simulation.OriginalQuantityValues.Any())
+         {
             _allMenuItems.Add(createCommit(simulation));
+            _allMenuItems.Add(createShowDifferences(simulation));
+         }
 
          _allMenuItems.AddRange(new[]
          {
@@ -198,6 +201,13 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          return CreateMenuButton.WithCaption(AppConstants.MenuNames.Edit)
             .WithIcon(ApplicationIcons.Edit)
             .WithCommandFor<EditSimulationUICommand, IMoBiSimulation>(simulation, _container);
+      }
+
+      private IMenuBarItem createShowDifferences(IMoBiSimulation simulation)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.ShowDifferences)
+            .WithIcon(ApplicationIcons.Comparison)
+            .WithCommandFor<ShowDifferencesUICommand, IMoBiSimulation>(simulation, _container);
       }
 
       private IMenuBarItem createCommit(IMoBiSimulation simulation)

--- a/src/MoBi.Presentation/Presenter/SimulationChangesPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SimulationChangesPresenter.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using MoBi.Core.Domain;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter.BasePresenter;
+using MoBi.Presentation.Views;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Extensions;
+using OSPSuite.Presentation.Presenters;
+
+namespace MoBi.Presentation.Presenter
+{
+   public class SimulationChangesPresenter : AbstractEditPresenter<ISimulationChangesView, ISimulationChangesPresenter, IMoBiSimulation>, ISimulationChangesPresenter
+   {
+      private IMoBiSimulation _simulation;
+
+      public SimulationChangesPresenter(ISimulationChangesView view) : base(view)
+      {
+      }
+
+      public override void Edit(IMoBiSimulation simulation)
+      {
+         _simulation = simulation;
+         _view.BindTo(_simulation.OriginalQuantityValues.OrderBy(x => x.Path).Select(createDTO).ToList());
+      }
+
+      private OriginalQuantityValueDTO createDTO(OriginalQuantityValue originalQuantityValue)
+      {
+         var path = new ObjectPath(originalQuantityValue.Path.ToPathArray());
+         return new OriginalQuantityValueDTO(originalQuantityValue).WithCurrentQuantity(path.TryResolve<IQuantity>(_simulation.Model.Root));
+      }
+
+      public override object Subject => _simulation;
+   }
+
+   public interface ISimulationChangesPresenter : IPresenter<ISimulationChangesView>, IEditPresenter<IMoBiSimulation>
+   {
+   }
+}

--- a/src/MoBi.Presentation/UICommand/ShowChangesUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/ShowChangesUICommand.cs
@@ -5,12 +5,12 @@ using OSPSuite.Presentation.UICommands;
 
 namespace MoBi.Presentation.UICommand
 {
-   internal class ShowDifferencesUICommand : ObjectUICommand<IMoBiSimulation>
+   internal class ShowChangesUICommand : ObjectUICommand<IMoBiSimulation>
    {
       private readonly IMoBiContext _context;
       private readonly IEditTasksForSimulation _simulationTasks;
 
-      public ShowDifferencesUICommand(IMoBiContext context, IEditTasksForSimulation simulationTasks)
+      public ShowChangesUICommand(IMoBiContext context, IEditTasksForSimulation simulationTasks)
       {
          _context = context;
          _simulationTasks = simulationTasks;

--- a/src/MoBi.Presentation/UICommand/ShowDifferencesUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/ShowDifferencesUICommand.cs
@@ -1,0 +1,25 @@
+﻿using MoBi.Core.Domain.Model;
+using MoBi.Core.Events;
+using MoBi.Presentation.Tasks.Edit;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   internal class ShowDifferencesUICommand : ObjectUICommand<IMoBiSimulation>
+   {
+      private readonly IMoBiContext _context;
+      private readonly IEditTasksForSimulation _simulationTasks;
+
+      public ShowDifferencesUICommand(IMoBiContext context, IEditTasksForSimulation simulationTasks)
+      {
+         _context = context;
+         _simulationTasks = simulationTasks;
+      }
+
+      protected override void PerformExecute()
+      {
+         _simulationTasks.Edit(Subject);
+         _context.PublishEvent(new ShowSimulationChangesEvent(Subject));
+      }
+   }
+}

--- a/src/MoBi.Presentation/Views/IEditSimulationView.cs
+++ b/src/MoBi.Presentation/Views/IEditSimulationView.cs
@@ -12,7 +12,7 @@ namespace MoBi.Presentation.Views
       void SetModelDiagram(ISimulationDiagramView subView);
 
       /// <summary>
-      ///    Indicates whether or not the current view is the results view
+      ///    Indicates whether the current view is the results view
       /// </summary>
       bool ShowsResults { get; }
 
@@ -28,5 +28,7 @@ namespace MoBi.Presentation.Views
 
       void SetPredictedVsObservedView(ISimulationVsObservedDataView view);
       void SetResidualsVsTimeView(ISimulationVsObservedDataView view);
+      void ShowChangesTab();
+      void SetChangesView(ISimulationChangesView view);
    }
 }

--- a/src/MoBi.Presentation/Views/ISimulationChangesView.cs
+++ b/src/MoBi.Presentation/Views/ISimulationChangesView.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+using OSPSuite.Presentation.Views;
+
+namespace MoBi.Presentation.Views
+{
+   public interface ISimulationChangesView : IView<ISimulationChangesPresenter>
+   {
+      void BindTo(IReadOnlyList<OriginalQuantityValueDTO> originalQuantityValues);
+   }
+}

--- a/src/MoBi.UI/Views/SimulationChangesView.Designer.cs
+++ b/src/MoBi.UI/Views/SimulationChangesView.Designer.cs
@@ -1,0 +1,129 @@
+﻿namespace MoBi.UI.Views
+{
+   partial class SimulationChangesView
+   {
+      /// <summary> 
+      /// Required designer variable.
+      /// </summary>
+      private System.ComponentModel.IContainer components = null;
+
+      /// <summary> 
+      /// Clean up any resources being used.
+      /// </summary>
+      /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+      protected override void Dispose(bool disposing)
+      {
+         if (disposing && (components != null))
+         {
+            components.Dispose();
+         }
+
+         disposeBinders();
+         base.Dispose(disposing);
+      }
+
+      #region Component Designer generated code
+
+      /// <summary> 
+      /// Required method for Designer support - do not modify 
+      /// the contents of this method with the code editor.
+      /// </summary>
+      private void InitializeComponent()
+      {
+         this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.Root = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.gridControl = new OSPSuite.UI.Controls.UxGridControl();
+         this.gridView = new OSPSuite.UI.Controls.UxGridView();
+         this.gridLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
+         this.layoutControl.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.Root)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.gridControl)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.gridView)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.gridLayoutControlItem)).BeginInit();
+         this.SuspendLayout();
+         // 
+         // layoutControl
+         // 
+         this.layoutControl.AllowCustomization = false;
+         this.layoutControl.Controls.Add(this.gridControl);
+         this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.layoutControl.Location = new System.Drawing.Point(0, 0);
+         this.layoutControl.Name = "layoutControl";
+         this.layoutControl.Root = this.Root;
+         this.layoutControl.Size = new System.Drawing.Size(638, 502);
+         this.layoutControl.TabIndex = 0;
+         this.layoutControl.Text = "uxLayoutControl1";
+         // 
+         // Root
+         // 
+         this.Root.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
+         this.Root.GroupBordersVisible = false;
+         this.Root.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.gridLayoutControlItem});
+         this.Root.Name = "Root";
+         this.Root.Size = new System.Drawing.Size(638, 502);
+         this.Root.TextVisible = false;
+         // 
+         // gridControl
+         // 
+         this.gridControl.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.gridControl.Location = new System.Drawing.Point(12, 12);
+         this.gridControl.MainView = this.gridView;
+         this.gridControl.Name = "gridControl";
+         this.gridControl.Size = new System.Drawing.Size(614, 478);
+         this.gridControl.TabIndex = 4;
+         this.gridControl.ViewCollection.AddRange(new DevExpress.XtraGrid.Views.Base.BaseView[] {
+            this.gridView});
+         // 
+         // uxGridView1
+         // 
+         this.gridView.AllowsFiltering = true;
+         this.gridView.EnableColumnContextMenu = true;
+         this.gridView.GridControl = this.gridControl;
+         this.gridView.MultiSelect = true;
+         this.gridView.Name = "gridView";
+         this.gridView.OptionsBehavior.EditorShowMode = DevExpress.Utils.EditorShowMode.MouseDown;
+         this.gridView.OptionsNavigation.AutoFocusNewRow = true;
+         this.gridView.OptionsSelection.EnableAppearanceFocusedCell = false;
+         this.gridView.OptionsSelection.EnableAppearanceFocusedRow = false;
+         this.gridView.OptionsSelection.MultiSelect = true;
+         this.gridView.OptionsSelection.MultiSelectMode = DevExpress.XtraGrid.Views.Grid.GridMultiSelectMode.CellSelect;
+         // 
+         // layoutControlItem1
+         // 
+         this.gridLayoutControlItem.Control = this.gridControl;
+         this.gridLayoutControlItem.Location = new System.Drawing.Point(0, 0);
+         this.gridLayoutControlItem.Name = "gridLayoutControlItem";
+         this.gridLayoutControlItem.Size = new System.Drawing.Size(618, 482);
+         this.gridLayoutControlItem.TextSize = new System.Drawing.Size(0, 0);
+         this.gridLayoutControlItem.TextVisible = false;
+         // 
+         // SimulationChangesView
+         // 
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.Controls.Add(this.layoutControl);
+         this.Name = "SimulationChangesView";
+         this.Size = new System.Drawing.Size(638, 502);
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
+         this.layoutControl.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.Root)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.gridControl)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.gridView)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.gridLayoutControlItem)).EndInit();
+         this.ResumeLayout(false);
+
+      }
+
+      #endregion
+
+      private OSPSuite.UI.Controls.UxLayoutControl layoutControl;
+      private DevExpress.XtraLayout.LayoutControlGroup Root;
+      private OSPSuite.UI.Controls.UxGridControl gridControl;
+      private OSPSuite.UI.Controls.UxGridView gridView;
+      private DevExpress.XtraLayout.LayoutControlItem gridLayoutControlItem;
+   }
+}

--- a/src/MoBi.UI/Views/SimulationChangesView.cs
+++ b/src/MoBi.UI/Views/SimulationChangesView.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using DevExpress.Utils;
+using DevExpress.XtraGrid.Views.Grid;
+using MoBi.Assets;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Formatters;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+using OSPSuite.DataBinding;
+using OSPSuite.DataBinding.DevExpress;
+using OSPSuite.DataBinding.DevExpress.XtraGrid;
+using OSPSuite.UI.Controls;
+
+namespace MoBi.UI.Views
+{
+   public partial class SimulationChangesView : BaseUserControl, ISimulationChangesView
+   {
+      private readonly GridViewBinder<OriginalQuantityValueDTO> _gridViewBinder;
+      private IGridViewBoundColumn<OriginalQuantityValueDTO, double?> _currentValueColumn;
+      private IGridViewBoundColumn<OriginalQuantityValueDTO, double?> _originalValueColumn;
+
+      public SimulationChangesView()
+      {
+         InitializeComponent();
+         gridLayoutControlItem.TextVisible = true;
+         gridLayoutControlItem.TextLocation = Locations.Top;
+         gridLayoutControlItem.Text = AppConstants.Captions.SimulationChangesSinceConfiguration;
+         _gridViewBinder = new GridViewBinder<OriginalQuantityValueDTO>(gridView);
+         _gridViewBinder.BindingMode = BindingMode.OneWay;
+         gridView.RowCellStyle += gridViewRowCellStyle;
+      }
+
+      private void gridViewRowCellStyle(object sender, RowCellStyleEventArgs e)
+      {
+         if (e.Column == _currentValueColumn.XtraColumn || e.Column == _originalValueColumn.XtraColumn)
+            e.Appearance.TextOptions.HAlignment = HorzAlignment.Far;
+      }
+
+      public override void InitializeBinding()
+      {
+         _gridViewBinder.Bind(x => x.Path).AsReadOnly();
+         _originalValueColumn = _gridViewBinder.Bind(x => x.OriginalValue).WithFormat(dto => dto.OriginalQuantityValueFormatter(x => x.OriginalDisplayUnit)).WithCaption(AppConstants.Captions.OriginalValue).AsReadOnly();
+         _currentValueColumn = _gridViewBinder.Bind(x => x.CurrentValue).WithFormat(dto => dto.OriginalQuantityValueFormatter(x => x.CurrentDisplayUnit)).WithCaption(AppConstants.Captions.CurrentValue).AsReadOnly();
+         _gridViewBinder.Bind(x => x.Dimension).AsReadOnly();
+      }
+
+      public void AttachPresenter(ISimulationChangesPresenter presenter)
+      {
+         // No need for a presenter in this readonly view
+      }
+
+      public void BindTo(IReadOnlyList<OriginalQuantityValueDTO> originalQuantityValues)
+      {
+         _gridViewBinder.BindToSource(originalQuantityValues);
+      }
+
+      private void disposeBinders()
+      {
+         _gridViewBinder.Dispose();
+      }
+   }
+}

--- a/src/MoBi.UI/Views/SimulationChangesView.resx
+++ b/src/MoBi.UI/Views/SimulationChangesView.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="errorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/src/MoBi.UI/Views/SimulationView/EditSimulationView.Designer.cs
+++ b/src/MoBi.UI/Views/SimulationView/EditSimulationView.Designer.cs
@@ -40,14 +40,15 @@ namespace MoBi.UI.Views.SimulationView
          this.tabDiagram = new DevExpress.XtraTab.XtraTabPage();
          this.spliterDiagram = new DevExpress.XtraEditors.SplitContainerControl();
          this.modelOverview = new Northwoods.Go.GoOverview();
+         this.tabData = new DevExpress.XtraTab.XtraTabPage();
          this.tabResults = new DevExpress.XtraTab.XtraTabPage();
          this.plotTabs = new DevExpress.XtraTab.XtraTabControl();
-         this.tabData = new DevExpress.XtraTab.XtraTabPage();
          this.tabPredVsObs = new DevExpress.XtraTab.XtraTabPage();
          this.tabResidVsTime = new DevExpress.XtraTab.XtraTabPage();
          this.xtraTabPage2 = new DevExpress.XtraTab.XtraTabPage();
          this.xtraTabPage1 = new DevExpress.XtraTab.XtraTabPage();
          this.xtraTabControl1 = new DevExpress.XtraTab.XtraTabControl();
+         this.tabChanges = new DevExpress.XtraTab.XtraTabPage();
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.tabs)).BeginInit();
          this.tabs.SuspendLayout();
@@ -75,24 +76,23 @@ namespace MoBi.UI.Views.SimulationView
          // 
          this.tabs.Dock = System.Windows.Forms.DockStyle.Fill;
          this.tabs.Location = new System.Drawing.Point(0, 0);
-         this.tabs.Margin = new System.Windows.Forms.Padding(8);
          this.tabs.Name = "tabs";
          this.tabs.SelectedTabPage = this.tabSimulation;
-         this.tabs.Size = new System.Drawing.Size(1290, 987);
+         this.tabs.Size = new System.Drawing.Size(516, 389);
          this.tabs.TabIndex = 0;
          this.tabs.TabPages.AddRange(new DevExpress.XtraTab.XtraTabPage[] {
             this.tabSimulation,
             this.tabData,
             this.tabResults,
             this.tabPredVsObs,
-            this.tabResidVsTime});
+            this.tabResidVsTime,
+            this.tabChanges});
          // 
          // tabSimulation
          // 
          this.tabSimulation.Controls.Add(this.splitSimulationParameters);
-         this.tabSimulation.Margin = new System.Windows.Forms.Padding(8);
          this.tabSimulation.Name = "tabSimulation";
-         this.tabSimulation.Size = new System.Drawing.Size(1286, 926);
+         this.tabSimulation.Size = new System.Drawing.Size(514, 364);
          this.tabSimulation.Text = "Simulation";
          // 
          // splitSimulationParameters
@@ -100,7 +100,6 @@ namespace MoBi.UI.Views.SimulationView
          this.splitSimulationParameters.Dock = System.Windows.Forms.DockStyle.Fill;
          this.splitSimulationParameters.FixedPanel = DevExpress.XtraEditors.SplitFixedPanel.None;
          this.splitSimulationParameters.Location = new System.Drawing.Point(0, 0);
-         this.splitSimulationParameters.Margin = new System.Windows.Forms.Padding(8);
          this.splitSimulationParameters.Name = "splitSimulationParameters";
          // 
          // splitSimulationParameters.Panel1
@@ -111,8 +110,8 @@ namespace MoBi.UI.Views.SimulationView
          // splitSimulationParameters.Panel2
          // 
          this.splitSimulationParameters.Panel2.Text = "Panel2";
-         this.splitSimulationParameters.Size = new System.Drawing.Size(1286, 926);
-         this.splitSimulationParameters.SplitterPosition = 643;
+         this.splitSimulationParameters.Size = new System.Drawing.Size(514, 364);
+         this.splitSimulationParameters.SplitterPosition = 257;
          this.splitSimulationParameters.TabIndex = 0;
          this.splitSimulationParameters.Text = "splitContainerControl1";
          // 
@@ -120,10 +119,9 @@ namespace MoBi.UI.Views.SimulationView
          // 
          this.tabsNavigation.Dock = System.Windows.Forms.DockStyle.Fill;
          this.tabsNavigation.Location = new System.Drawing.Point(0, 0);
-         this.tabsNavigation.Margin = new System.Windows.Forms.Padding(8);
          this.tabsNavigation.Name = "tabsNavigation";
          this.tabsNavigation.SelectedTabPage = this.tabTree;
-         this.tabsNavigation.Size = new System.Drawing.Size(643, 926);
+         this.tabsNavigation.Size = new System.Drawing.Size(257, 364);
          this.tabsNavigation.TabIndex = 0;
          this.tabsNavigation.TabPages.AddRange(new DevExpress.XtraTab.XtraTabPage[] {
             this.tabTree,
@@ -131,24 +129,21 @@ namespace MoBi.UI.Views.SimulationView
          // 
          // tabTree
          // 
-         this.tabTree.Margin = new System.Windows.Forms.Padding(8);
          this.tabTree.Name = "tabTree";
-         this.tabTree.Size = new System.Drawing.Size(639, 865);
+         this.tabTree.Size = new System.Drawing.Size(255, 339);
          this.tabTree.Text = "tabTree";
          // 
          // tabDiagram
          // 
          this.tabDiagram.Controls.Add(this.spliterDiagram);
-         this.tabDiagram.Margin = new System.Windows.Forms.Padding(8);
          this.tabDiagram.Name = "tabDiagram";
-         this.tabDiagram.Size = new System.Drawing.Size(639, 865);
+         this.tabDiagram.Size = new System.Drawing.Size(255, 340);
          this.tabDiagram.Text = "tabDiagram";
          // 
          // spliterDiagram
          // 
          this.spliterDiagram.Dock = System.Windows.Forms.DockStyle.Fill;
          this.spliterDiagram.Location = new System.Drawing.Point(0, 0);
-         this.spliterDiagram.Margin = new System.Windows.Forms.Padding(8);
          this.spliterDiagram.Name = "spliterDiagram";
          // 
          // spliterDiagram.Panel1
@@ -159,8 +154,8 @@ namespace MoBi.UI.Views.SimulationView
          // spliterDiagram.Panel2
          // 
          this.spliterDiagram.Panel2.Text = "Panel2";
-         this.spliterDiagram.Size = new System.Drawing.Size(639, 865);
-         this.spliterDiagram.SplitterPosition = 307;
+         this.spliterDiagram.Size = new System.Drawing.Size(255, 340);
+         this.spliterDiagram.SplitterPosition = 123;
          this.spliterDiagram.TabIndex = 1;
          this.spliterDiagram.Text = "splitContainerControl2";
          // 
@@ -180,45 +175,47 @@ namespace MoBi.UI.Views.SimulationView
          this.modelOverview.DocScale = 0.125F;
          this.modelOverview.DragsRealtime = true;
          this.modelOverview.Location = new System.Drawing.Point(0, 0);
-         this.modelOverview.Margin = new System.Windows.Forms.Padding(8);
          this.modelOverview.Name = "modelOverview";
          this.modelOverview.ShowsNegativeCoordinates = false;
-         this.modelOverview.Size = new System.Drawing.Size(307, 865);
+         this.modelOverview.Size = new System.Drawing.Size(123, 340);
          this.modelOverview.TabIndex = 0;
          this.modelOverview.Text = "modelOverview";
+         // 
+         // tabData
+         // 
+         this.tabData.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
+         this.tabData.Name = "tabData";
+         this.tabData.Size = new System.Drawing.Size(514, 364);
+         this.tabData.Text = "tabData";
          // 
          // tabResults
          // 
          this.tabResults.Controls.Add(this.plotTabs);
-         this.tabResults.Margin = new System.Windows.Forms.Padding(8);
          this.tabResults.Name = "tabResults";
-         this.tabResults.Size = new System.Drawing.Size(1286, 926);
+         this.tabResults.Size = new System.Drawing.Size(514, 364);
          this.tabResults.Text = "tabResults";
          // 
          // plotTabs
          // 
          this.plotTabs.Dock = System.Windows.Forms.DockStyle.Fill;
          this.plotTabs.Location = new System.Drawing.Point(0, 0);
+         this.plotTabs.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
          this.plotTabs.Name = "plotTabs";
-         this.plotTabs.Size = new System.Drawing.Size(1286, 926);
+         this.plotTabs.Size = new System.Drawing.Size(514, 364);
          this.plotTabs.TabIndex = 0;
-         // 
-         // tabData
-         // 
-         this.tabData.Name = "tabData";
-         this.tabData.Size = new System.Drawing.Size(1286, 926);
-         this.tabData.Text = "tabData";
          // 
          // tabPredVsObs
          // 
+         this.tabPredVsObs.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
          this.tabPredVsObs.Name = "tabPredVsObs";
-         this.tabPredVsObs.Size = new System.Drawing.Size(1286, 926);
+         this.tabPredVsObs.Size = new System.Drawing.Size(514, 364);
          this.tabPredVsObs.Text = "tabPredVsObs";
          // 
          // tabResidVsTime
          // 
+         this.tabResidVsTime.Margin = new System.Windows.Forms.Padding(1, 1, 1, 1);
          this.tabResidVsTime.Name = "tabResidVsTime";
-         this.tabResidVsTime.Size = new System.Drawing.Size(1286, 926);
+         this.tabResidVsTime.Size = new System.Drawing.Size(514, 364);
          this.tabResidVsTime.Text = "tabResidVsTime";
          // 
          // xtraTabPage2
@@ -244,13 +241,19 @@ namespace MoBi.UI.Views.SimulationView
             this.xtraTabPage1,
             this.xtraTabPage2});
          // 
+         // tabDifferences
+         // 
+         this.tabChanges.Name = "tabChanges";
+         this.tabChanges.Size = new System.Drawing.Size(514, 364);
+         this.tabChanges.Text = "tabChanges";
+         // 
          // EditSimulationView
          // 
-         this.AutoScaleDimensions = new System.Drawing.SizeF(15F, 33F);
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-         this.ClientSize = new System.Drawing.Size(1290, 987);
+         this.ClientSize = new System.Drawing.Size(516, 389);
          this.Controls.Add(this.tabs);
-         this.Margin = new System.Windows.Forms.Padding(20);
+         this.Margin = new System.Windows.Forms.Padding(8, 8, 8, 8);
          this.Name = "EditSimulationView";
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.tabs)).EndInit();
@@ -295,5 +298,6 @@ namespace MoBi.UI.Views.SimulationView
       private DevExpress.XtraTab.XtraTabPage tabData;
       private DevExpress.XtraTab.XtraTabPage tabPredVsObs;
       private DevExpress.XtraTab.XtraTabPage tabResidVsTime;
+      private DevExpress.XtraTab.XtraTabPage tabChanges;
    }
 }

--- a/src/MoBi.UI/Views/SimulationView/EditSimulationView.cs
+++ b/src/MoBi.UI/Views/SimulationView/EditSimulationView.cs
@@ -41,6 +41,7 @@ namespace MoBi.UI.Views.SimulationView
          tabData.InitWith(AppConstants.Captions.SimulationObservedData, ApplicationIcons.ObservedData);
          tabPredVsObs.InitWith(Captions.SimulationUI.PredictedVsObservedSimulation, ApplicationIcons.PredictedVsObservedAnalysis);
          tabResidVsTime.InitWith(Captions.SimulationUI.ResidualsVsTimeSimulation, ApplicationIcons.ResidualVsTimeAnalysis);
+         tabChanges.InitWith(AppConstants.Captions.Changes, ApplicationIcons.Comparison);
 
          tabsNavigation.SelectedPageChanging += (o, e) => OnEvent(tabSelectionChanged, e);
          tabs.SelectedPageChanging += (o, e) => OnEvent(tabSelectionChanged, e);
@@ -53,6 +54,8 @@ namespace MoBi.UI.Views.SimulationView
       {
          if (e.Page.Equals(tabDiagram))
             simulationPresenter.LoadDiagram();
+         else if (e.Page.Equals(tabChanges))
+            simulationPresenter.LoadChanges();
       }
 
       public void SetEditView(IView view)
@@ -97,6 +100,16 @@ namespace MoBi.UI.Views.SimulationView
       public void SetResidualsVsTimeView(ISimulationVsObservedDataView view)
       {
          tabResidVsTime.FillWith(view);
+      }
+
+      public void ShowChangesTab()
+      {
+         tabs.SelectedTabPage = tabChanges;
+      }
+
+      public void SetChangesView(ISimulationChangesView view)
+      {
+         tabChanges.FillWith(view);
       }
    }
 }

--- a/tests/MoBi.Tests/Core/Service/SimulationUpdateTaskSpecs.cs
+++ b/tests/MoBi.Tests/Core/Service/SimulationUpdateTaskSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using FakeItEasy;
+using MoBi.Core.Domain;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
 using MoBi.Core.Events;
@@ -125,6 +126,7 @@ namespace MoBi.Core.Service
       {
          base.Context();
          _simulationToConfigure = new MoBiSimulation { Model = new Model { Root = new Container() }.WithName("OLD_MODEL") };
+         _simulationToConfigure.AddOriginalQuantityValue(new OriginalQuantityValue {Path = "a path"});
          _simulationToConfigure.Configuration = new SimulationConfiguration();
          _model = new Model().WithName("NEW MODEL");
          _model.Root = new Container();
@@ -146,6 +148,12 @@ namespace MoBi.Core.Service
       public void should_start_the_configure_workflow_for_the_user()
       {
          A.CallTo(() => _configurePresenter.CreateBasedOn(_simulationToConfigure, false)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_original_quantities_should_be_cleared()
+      {
+         _simulationToConfigure.OriginalQuantityValues.ShouldBeEmpty();
       }
 
       [Observation]

--- a/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
@@ -16,7 +16,6 @@ using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Views;
-using OSPSuite.SimModel;
 
 namespace MoBi.Presentation
 {
@@ -37,6 +36,7 @@ namespace MoBi.Presentation
       protected ISimulationOutputMappingPresenter _simulationOutputMappingPresenter;
       protected IMoBiContext _context;
       protected IOutputMappingMatchingTask _outputMappingMatchingTask;
+      private ISimulationChangesPresenter _simulationChangesPresenter;
 
       protected override void Context()
       {
@@ -54,12 +54,13 @@ namespace MoBi.Presentation
          _simulationOutputMappingPresenter = A.Fake<ISimulationOutputMappingPresenter>();
          _userDefinedParametersPresenter = A.Fake<IUserDefinedParametersPresenter>();
          _context = A.Fake<IMoBiContext>();
+         _simulationChangesPresenter = A.Fake<ISimulationChangesPresenter>();
          _outputMappingMatchingTask = A.Fake<IOutputMappingMatchingTask>();
 
          sut = new EditSimulationPresenter(_view, _chartPresenter, _hierarchicalSimulationPresenter, _diagramPresenter,
             _solverSettings, _outputSchemaPresenter, _presenterFactory, new HeavyWorkManagerForSpecs(),
             A.Fake<IChartFactory>(), _editFavoritePresenter, _chartTasks, _userDefinedParametersPresenter, _simulationOutputMappingPresenter,
-            _simulationPredictedVsObservedChartPresenter, _simulationResidualVsTimeChartPresenter, _context, _outputMappingMatchingTask);
+            _simulationPredictedVsObservedChartPresenter, _simulationResidualVsTimeChartPresenter, _context, _outputMappingMatchingTask, _simulationChangesPresenter);
       }
 
 


### PR DESCRIPTION
Fixes #1083

# Description
There is very little new interaction in this fix. A context menu was added to show the differences tab. The tab is also updated when it is selected by the user. There is no edits that can occur in the view, it's readonly

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/9a6bb763-fcbb-4be0-b5fc-8ae38d28fe94)

![image](https://github.com/user-attachments/assets/f1612031-7a1c-491f-90a6-75197f27e7c0)
# Questions (if appropriate):