### PR TITLE
Fixes #1585 Possible to load a PV BB with the same name as an existing

### DIFF
--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForInitialConditionsFolder.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForInitialConditionsFolder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using MoBi.Assets;
+using MoBi.Core.Domain.Extensions;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.UICommand;
 using OSPSuite.Assets;
@@ -24,11 +25,25 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          _allMenuItems = new List<IMenuBarItem>();
       }
 
+      public override IContextMenu InitializeWith(ObjectBaseDTO dto, IPresenter presenter)
+      {
+         var cm = base.InitializeWith(dto, presenter);
+         _allMenuItems.Add(createAddBuildingBlock(ModuleFor(dto)));
+         return cm;
+      }
+
       protected override IMenuBarItem AddNewBuildingBlock(Module module)
       {
          return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddNew(ObjectTypes.InitialConditionsBuildingBlock))
             .WithIcon(ApplicationIcons.LoadIconFor(nameof(InitialConditionsBuildingBlock)))
             .WithCommandFor<AddNewInitialConditionsBuildingBlockUICommand, Module>(module, _container);
+      }
+
+      private IMenuBarItem createAddBuildingBlock(Module module)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddExisting(ObjectTypes.InitialConditionsBuildingBlock))
+            .WithIcon(ApplicationIcons.LoadIconFor(nameof(ParameterValuesBuildingBlock)))
+            .WithCommandFor<AddInitialConditionsBuildingBlockCommand, Module>(module, _container);
       }
    }
 

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForParameterValuesFolder.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForParameterValuesFolder.cs
@@ -32,6 +32,7 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          base.InitializeWith(dto, presenter);
          _allMenuItems.Add(createAddExpressionAsParameterValueBuildingBlock(ModuleFor(dto)));
          _allMenuItems.Add(createAddIndividualAsParameterValueBuildingBlock(ModuleFor(dto)));
+         _allMenuItems.Add(createAddParameterValueBuildingBlock(ModuleFor(dto)));
          return this;
       }
 
@@ -47,6 +48,13 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddExisting(ObjectTypes.ExpressionProfileBuildingBlock))
             .WithIcon(ApplicationIcons.LoadIconFor(nameof(ExpressionProfileBuildingBlock)))
             .WithCommandFor<AddExpressionAsParameterValuesCommand, Module>(module, _container);
+      }
+
+      private IMenuBarItem createAddParameterValueBuildingBlock(Module module)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddExisting(_objectTypeResolver.TypeFor<ParameterValuesBuildingBlock>()))
+            .WithIcon(ApplicationIcons.LoadIconFor(nameof(ParameterValuesBuildingBlock)))
+            .WithCommandFor<AddParameterValuesBuildingBlockCommand, Module>(module, _container);
       }
 
       private IMenuBarItem createAddIndividualAsParameterValueBuildingBlock(Module module)

--- a/src/MoBi.Presentation/Tasks/Interaction/InitialConditionsTask.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InitialConditionsTask.cs
@@ -41,6 +41,8 @@ namespace MoBi.Presentation.Tasks.Interaction
       IMoBiCommand UpdateInitialConditionScaleDivisor(TBuildingBlock buildingBlock, InitialCondition initialCondition, double newScaleDivisor, double oldScaleDivisor);
 
       IMoBiCommand RefreshInitialConditionsFromBuildingBlocks(TBuildingBlock buildingBlock, IReadOnlyList<InitialCondition> initialConditions);
+
+      bool CorrectName(TBuildingBlock buildingBlock, Module module);
    }
 
    public class InitialConditionsTask<TBuildingBlock> : InteractionTasksForExtendablePathAndValueEntity<TBuildingBlock, InitialCondition>, IInitialConditionsTask<TBuildingBlock> where TBuildingBlock : class, ILookupBuildingBlock<InitialCondition>, new()
@@ -117,7 +119,7 @@ namespace MoBi.Presentation.Tasks.Interaction
          return macroCommand;
       }
 
-      protected override bool CorrectName(TBuildingBlock buildingBlock, Module module)
+      public override bool CorrectName(TBuildingBlock buildingBlock, Module module)
       {
          // If this is an ExpressionProfileBuildingBlock, then the names of existing
          // building blocks in the module InitialConditionsCollection are not forbidden.

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -269,7 +269,7 @@ namespace MoBi.Presentation.Tasks.Interaction
          Context.PublishEvent(new AddedEvent<TChild>(newObjectBase, parent));
       }
 
-      protected virtual bool CorrectName(TChild child, TParent parent)
+      public virtual bool CorrectName(TChild child, TParent parent)
       {
          var parentContainer = parent as IEnumerable<IObjectBase> ?? Enumerable.Empty<IObjectBase>();
          var forbiddenNames = _editTask.GetForbiddenNames(child, parentContainer);

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExpressionProfileBuildingBlock.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExpressionProfileBuildingBlock.cs
@@ -93,7 +93,7 @@ namespace MoBi.Presentation.Tasks.Interaction
          return new RemoveExpressionProfileBuildingBlockFromProjectCommand(expressionProfileToRemove);
       }
 
-      protected override bool CorrectName(ExpressionProfileBuildingBlock expressionProfile, MoBiProject project)
+      public override bool CorrectName(ExpressionProfileBuildingBlock expressionProfile, MoBiProject project)
       {
          var forbiddenNames = project.ExpressionProfileCollection.AllNames();
          if (!forbiddenNames.Contains(expressionProfile.Name))

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForModule.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForModule.cs
@@ -212,7 +212,7 @@ namespace MoBi.Presentation.Tasks.Interaction
             if (filename.IsNullOrEmpty())
                return;
 
-            var listOfNewBuildingBlocks = loadBuildingBlock(buildingBlockType, filename);
+            var listOfNewBuildingBlocks = loadBuildingBlocks(buildingBlockType, filename);
 
             if (!listOfNewBuildingBlocks.Any())
                return;
@@ -232,7 +232,7 @@ namespace MoBi.Presentation.Tasks.Interaction
             Constants.Filter.PKML_FILE_FILTER, Constants.DirectoryKey.TEMPLATE);
       }
 
-      private List<IBuildingBlock> loadBuildingBlock(BuildingBlockType buildingBlockType, string filename)
+      private List<IBuildingBlock> loadBuildingBlocks(BuildingBlockType buildingBlockType, string filename)
       {
          var items = new List<IBuildingBlock>();
 

--- a/src/MoBi.Presentation/Tasks/Interaction/ParameterValuesTask.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/ParameterValuesTask.cs
@@ -25,6 +25,7 @@ namespace MoBi.Presentation.Tasks.Interaction
       void AddStartValueExpression(ParameterValuesBuildingBlock buildingBlock);
       IMoBiCommand SetFullPath(ParameterValue parameterValue, ObjectPath entityPath, ParameterValuesBuildingBlock buildingBlock);
       IReadOnlyList<ObjectPath> GetNewPaths();
+      bool CorrectName(ParameterValuesBuildingBlock buildingBlock, Module module);
    }
 
    public class ParameterValuesTask : InteractionTasksForExtendablePathAndValueEntity<ParameterValuesBuildingBlock, ParameterValue>, IParameterValuesTask
@@ -156,7 +157,7 @@ namespace MoBi.Presentation.Tasks.Interaction
          }
       }
 
-      protected override bool CorrectName(ParameterValuesBuildingBlock buildingBlock, Module module)
+      public override bool CorrectName(ParameterValuesBuildingBlock buildingBlock, Module module)
       {
          var forbiddenNames = _editTask.GetForbiddenNames(buildingBlock, module.ParameterValuesCollection);
          return InteractionTask.CorrectName(buildingBlock, forbiddenNames);

--- a/src/MoBi.Presentation/UICommand/AddInitialConditionsBuildingBlockCommand.cs
+++ b/src/MoBi.Presentation/UICommand/AddInitialConditionsBuildingBlockCommand.cs
@@ -1,0 +1,43 @@
+﻿using MoBi.Assets;
+using MoBi.Core.Commands;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class AddInitialConditionsBuildingBlockCommand : ObjectUICommand<Module>
+   {
+      private readonly IMoBiContext _context;
+      private readonly IInitialConditionsTask<InitialConditionsBuildingBlock> _initialConditionsTask;
+
+      public AddInitialConditionsBuildingBlockCommand(IMoBiContext context,
+         IInitialConditionsTask<InitialConditionsBuildingBlock> initialConditionsTask)
+      {
+         _context = context;
+         _initialConditionsTask = initialConditionsTask;
+      }
+
+      protected override void PerformExecute()
+      {
+         var initialConditionsBuildingBlocks = _initialConditionsTask.LoadFromPKML();
+
+         var macroCommand = new MoBiMacroCommand
+         {
+            CommandType = AppConstants.Commands.AddCommand,
+            ObjectType = ObjectTypes.InitialConditionsBuildingBlock,
+            Description = AppConstants.Commands.AddMany(ObjectTypes.InitialConditionsBuildingBlock)
+         };
+
+         foreach (var buildingBlock in initialConditionsBuildingBlocks)
+         {
+            macroCommand.AddCommand(_initialConditionsTask.AddTo(buildingBlock, Subject, null));
+         }
+
+         _context.AddToHistory(macroCommand);
+      }
+   }
+}

--- a/src/MoBi.Presentation/UICommand/AddParameterValuesBuildingBlockCommand.cs
+++ b/src/MoBi.Presentation/UICommand/AddParameterValuesBuildingBlockCommand.cs
@@ -1,0 +1,45 @@
+﻿using MoBi.Assets;
+using MoBi.Core.Commands;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.Tasks.Edit;
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class AddParameterValuesBuildingBlockCommand : ObjectUICommand<Module>
+   {
+      private readonly IMoBiContext _context;
+      private readonly IParameterValuesTask _parameterValuesTask;
+
+      public AddParameterValuesBuildingBlockCommand(IMoBiContext context,
+         IParameterValuesTask parameterValuesTask,
+         IEditTasksForBuildingBlock<IndividualBuildingBlock> editTask)
+      {
+         _context = context;
+         _parameterValuesTask = parameterValuesTask;
+      }
+
+      protected override void PerformExecute()
+      {
+         var parameterValuesBuildingBlocks = _parameterValuesTask.LoadFromPKML();
+
+         var macroCommand = new MoBiMacroCommand
+         {
+            CommandType = AppConstants.Commands.AddCommand,
+            ObjectType = ObjectTypes.ParameterValuesBuildingBlock,
+            Description = AppConstants.Commands.AddMany(ObjectTypes.ParameterValuesBuildingBlock)
+         };
+
+         foreach (var buildingBlock in parameterValuesBuildingBlocks)
+         {
+            macroCommand.AddCommand(_parameterValuesTask.AddTo(buildingBlock, Subject, null));
+         }
+
+         _context.AddToHistory(macroCommand);
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForModuleSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForModuleSpecs.cs
@@ -18,11 +18,15 @@ namespace MoBi.Presentation.Tasks
    public class concern_for_InteractionTasksForModule : ContextSpecification<InteractionTasksForModule>
    {
       protected IInteractionTaskContext _context;
+      private IInitialConditionsTask<InitialConditionsBuildingBlock> _initialConditionsTask;
+      private IParameterValuesTask _parameterValuesTask;
 
       protected override void Context()
       {
          _context = A.Fake<IInteractionTaskContext>();
-         sut = new InteractionTasksForModule(_context, new EditTaskForModule(_context));
+         _initialConditionsTask = A.Fake<IInitialConditionsTask<InitialConditionsBuildingBlock>>();
+         _parameterValuesTask = A.Fake<IParameterValuesTask>();
+         sut = new InteractionTasksForModule(_context, new EditTaskForModule(_context), _parameterValuesTask, _initialConditionsTask);
       }
    }
 


### PR DESCRIPTION
Fixes #1585

# Description
We don't need to check all the imports for name uniqueness because most imported building blocks are only allowed to be present once in a module.

That's not the case for initial conditions and parameter values. The names have to be checked before adding

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):