### PR TITLE
#221 show project file name in the title bar

### DIFF
--- a/src/MoBi.Presentation/Presenter/MoBiMainViewPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/MoBiMainViewPresenter.cs
@@ -42,9 +42,7 @@ namespace MoBi.Presentation.Presenter
       private readonly IUserSettings _userSettings;
       private readonly IMoBiConfiguration _configuration;
       private readonly IWatermarkStatusChecker _watermarkStatusChecker;
-
-      private string _currentProjectName;
-
+        
       public MoBiMainViewPresenter(
          IMoBiMainView view,
          IRepository<IMainViewItemPresenter> allMainViewItemPresenters,
@@ -148,24 +146,15 @@ namespace MoBi.Presentation.Presenter
          View.AllowChildActivation = true;
       }
 
-      private void updateWindowTitle()
-      {
+      private void updateWindowTitle(string projectName = null)
+        {
          View.Caption = 
-            string.IsNullOrEmpty(_currentProjectName) 
+            string.IsNullOrEmpty(projectName) 
                ? _configuration.ProductDisplayName 
-               : $"{_configuration.ProductDisplayName} | {_currentProjectName}";
+               : $"{_configuration.ProductDisplayName} | {projectName}";
       }
 
-      public void Handle(ProjectLoadedEvent eventToHandle)
-      {
-         _currentProjectName = eventToHandle.Project.Name;
-         updateWindowTitle();
-      }
-
-      public void Handle(ProjectClosedEvent eventToHandle)
-      {
-         _currentProjectName = null;
-         updateWindowTitle();
-      }
+      public void Handle(ProjectLoadedEvent eventToHandle) => updateWindowTitle(eventToHandle.Project.Name);
+      public void Handle(ProjectClosedEvent eventToHandle) => updateWindowTitle();
    }
 }

--- a/src/MoBi.Presentation/Presenter/MoBiMainViewPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/MoBiMainViewPresenter.cs
@@ -24,7 +24,8 @@ namespace MoBi.Presentation.Presenter
       IListener<ReportCreationStartedEvent>,
       IListener<ReportCreationFinishedEvent>,
       IListener<ProjectLoadedEvent>,
-      IListener<ProjectClosedEvent>
+      IListener<ProjectClosedEvent>,
+      IListener<ProjectSavedEvent>
 
     {
       void Run(StartOptions startOptions);
@@ -156,5 +157,6 @@ namespace MoBi.Presentation.Presenter
 
       public void Handle(ProjectLoadedEvent eventToHandle) => updateWindowTitle(eventToHandle.Project.Name);
       public void Handle(ProjectClosedEvent eventToHandle) => updateWindowTitle();
-   }
+      public void Handle(ProjectSavedEvent eventToHandle) => updateWindowTitle(eventToHandle.Project.Name);
+    }
 }

--- a/src/MoBi.Presentation/Presenter/MoBiMainViewPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/MoBiMainViewPresenter.cs
@@ -71,7 +71,7 @@ namespace MoBi.Presentation.Presenter
       public override void Initialize()
       {
          _view.Initialize();
-         UpdateWindowTitle();
+         updateWindowTitle();
 
          Thread.Sleep(10000);
          _allMainViewItemPresenters.All().Each(x => x.Initialize());
@@ -148,24 +148,24 @@ namespace MoBi.Presentation.Presenter
          View.AllowChildActivation = true;
       }
 
-      private void UpdateWindowTitle()
+      private void updateWindowTitle()
       {
-         if (string.IsNullOrEmpty(_currentProjectName))
-            View.Caption = _configuration.ProductDisplayName;
-         else
-            View.Caption = $"{_configuration.ProductDisplayName} | {_currentProjectName}";
+         View.Caption = 
+            string.IsNullOrEmpty(_currentProjectName) 
+               ? _configuration.ProductDisplayName 
+               : $"{_configuration.ProductDisplayName} | {_currentProjectName}";
       }
 
       public void Handle(ProjectLoadedEvent eventToHandle)
       {
          _currentProjectName = eventToHandle.Project.Name;
-         UpdateWindowTitle();
+         updateWindowTitle();
       }
 
       public void Handle(ProjectClosedEvent eventToHandle)
       {
          _currentProjectName = null;
-         UpdateWindowTitle();
+         updateWindowTitle();
       }
    }
 }


### PR DESCRIPTION
Fixes #221 

# Description

Implements feature request to show the active project name in the application title bar. This helps users identify the correct MoBi instance when multiple projects are open.

## Changes
- Added ProjectLoadedEvent and ProjectClosedEvent handlers to IMoBiMainViewPresenter
- Implemented window title updates on project load/close
- Uses format: "MoBi® 12 | ProjectName" when project is loaded
- Maintains default title "MoBi® 12" when no project is open

## Testing
- Verified title updates when loading a project
- Verified title reverts when closing a project
- Verified correct display in Windows taskbar

- multiple windows open: 
![image](https://github.com/user-attachments/assets/20d4cc2b-e145-4160-b42c-1676e10de504)



## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):