### PR TITLE
Fixes #1600 Cannot select a protein from expression panel when only one expression is available

### DIFF
--- a/src/MoBi.UI/Views/EditIndividualAndExpressionConfigurationsView.cs
+++ b/src/MoBi.UI/Views/EditIndividualAndExpressionConfigurationsView.cs
@@ -156,6 +156,11 @@ namespace MoBi.UI.Views
       public void BindTo(IndividualSelectionDTO individualSelectionDTO)
       {
          _screenBinder.BindToSource(individualSelectionDTO);
+
+         // The selected expression may have changed due to binding but the event does not fire.
+         // This forces a UI update to acknowledge changing selections
+         projectTreeSelectionChanged();
+         simulationTreeSelectionChanged();
       }
 
       public void AddUnusedExpression(ITreeNode treeNodeToAdd)

--- a/src/MoBi.UI/Views/EditIndividualAndExpressionConfigurationsView.cs
+++ b/src/MoBi.UI/Views/EditIndividualAndExpressionConfigurationsView.cs
@@ -156,23 +156,27 @@ namespace MoBi.UI.Views
       public void BindTo(IndividualSelectionDTO individualSelectionDTO)
       {
          _screenBinder.BindToSource(individualSelectionDTO);
-
-         // The selected expression may have changed due to binding but the event does not fire.
-         // This forces a UI update to acknowledge changing selections
-         projectTreeSelectionChanged();
-         simulationTreeSelectionChanged();
       }
 
       public void AddUnusedExpression(ITreeNode treeNodeToAdd)
       {
          projectExpressionsTree.TreeView.AddNode(treeNodeToAdd);
          projectExpressionsTree.TreeView.Selection.Add(projectExpressionsTree.TreeView.NodeFrom(treeNodeToAdd));
+
+         // The selected expression may have changed due to binding but the event does not fire.
+         // This forces a UI update to acknowledge changing selections
+         projectTreeSelectionChanged();
+         
       }
 
       public void AddUsedExpression(ITreeNode treeNodeToAdd)
       {
          simulationExpressionsTree.AddNode(treeNodeToAdd);
          simulationExpressionsTree.Selection.Add(simulationExpressionsTree.NodeFrom(treeNodeToAdd));
+
+         // The selected expression may have changed due to binding but the event does not fire.
+         // This forces a UI update to acknowledge changing selections
+         simulationTreeSelectionChanged();
       }
 
       private void disposeBinders()


### PR DESCRIPTION
Fixes #1600

# Description
UI does not update selected nodes when first binding. If you have more than one expression, then click on one, then the other forces the UI update, but if you have only one, there is no opportunity to force the event to fire.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):