### PR TITLE
Fixes #1607 Changes for non-model properties cause simulation to crash

### DIFF
--- a/tests/MoBi.Tests/Presentation/SimulationChangesPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SimulationChangesPresenterSpecs.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using MoBi.Core.Domain;
+using MoBi.Core.Domain.Model;
+using MoBi.Helpers;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.UnitSystem;
+
+namespace MoBi.Presentation
+{
+   public class concern_for_SimulationChangesPresenter : ContextSpecification<SimulationChangesPresenter>
+   {
+      protected ISimulationChangesView _view;
+
+      protected override void Context()
+      {
+         _view = A.Fake<ISimulationChangesView>();
+         sut = new SimulationChangesPresenter(_view);
+      }
+   }
+
+   public class when_editing_a_simulation : concern_for_SimulationChangesPresenter
+   {
+      private IMoBiSimulation _simulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = new MoBiSimulation();
+         var container = new Container().WithName("top");
+         container.Add(new Parameter().WithName("Parameter"));
+         _simulation.Model = new Model{Root = new Container()};
+         
+         _simulation.Model.Root.Add(container);
+         _simulation.AddOriginalQuantityValue(new OriginalQuantityValue {Path = "top|Parameter"}.WithDimension(A.Fake<IDimension>()));
+         _simulation.AddOriginalQuantityValue(new OriginalQuantityValue {Path = "top|second"}.WithDimension(A.Fake<IDimension>()));
+      }
+
+      protected override void Because()
+      {
+         sut.Edit(_simulation);
+      }
+
+      [Observation]
+      public void should_bind_the_view_to_the_simulation_original_quantity_values()
+      {
+         A.CallTo(() => _view.BindTo(A<IReadOnlyList<OriginalQuantityValueDTO>>.That.Matches(x => hasMatchingQuantitiesOnly(x)))).MustHaveHappened();
+      }
+
+      private bool hasMatchingQuantitiesOnly(IReadOnlyList<OriginalQuantityValueDTO> originalQuantityValueDTOs)
+      {
+         return originalQuantityValueDTOs.Count == 1 && originalQuantityValueDTOs.SingleOrDefault(x => Equals(x.Path, "top|Parameter")) != null;
+      }
+   }
+}


### PR DESCRIPTION
Fixes #1607

# Description
We can't resolve entities that have been changed outside the model root. When the user is shown the simulation changes, we can show only the changes from the model (not changes in output selections or schema)

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):