### PR TITLE
Fixes #1579 Create a neighborhood: "OK" button should be enabled as soon as both paths are specified

### DIFF
--- a/tests/MoBi.Tests/Presentation/SelectNeighborPathPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectNeighborPathPresenterSpecs.cs
@@ -122,20 +122,28 @@ namespace MoBi.Presentation
    public class When_notify_that_the_selected_entity_was_changed : concern_for_SelectNeighborPathPresenter
    {
       [Observation]
+      public void should_allow_the_close_no_matter_if_selection_is_container()
+      {
+         sut.CanClose.ShouldBeTrue();
+      }
+
+      [Observation]
       public void should_not_update_the_path_if_the_selected_entity_is_not_a_container()
       {
          _selectedPathDTO.Path = "A|B";
          _selectContainerInTreePresenter.OnSelectedEntityChanged += Raise.With(new SelectedEntityChangedArgs(new Parameter()));
          _selectedPathDTO.Path.ShouldBeEqualTo("A|B");
-         sut.CanClose.ShouldBeFalse();
       }
 
       [Observation]
-      public void should_not_update_the_path_if_the_selected_entity_is_not_a_physical_container()
+      public void should_update_the_path_if_the_selected_entity_even_though_selection_is_not_a_physical_container()
       {
          _selectedPathDTO.Path = "A|B";
-         _selectContainerInTreePresenter.OnSelectedEntityChanged += Raise.With(new SelectedEntityChangedArgs(new Container().WithMode(ContainerMode.Logical)));
-         _selectedPathDTO.Path.ShouldBeEqualTo("A|B");
+         var container = new Container().WithMode(ContainerMode.Logical);
+         container.ParentPath = new ObjectPath("A");
+         container.Name = "C";
+         _selectContainerInTreePresenter.OnSelectedEntityChanged += Raise.With(new SelectedEntityChangedArgs(container));
+         _selectedPathDTO.Path.ShouldBeEqualTo("A|C");
       }
 
       [Observation]
@@ -211,9 +219,9 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void can_close_should_be_false()
+      public void can_close_should_be_true()
       {
-         sut.CanClose.ShouldBeFalse();
+         sut.CanClose.ShouldBeTrue();
       }
    }
 }


### PR DESCRIPTION
Fixes #1579

# Description
Formerly you could only select existing physical containers in this view, but now you can select any container, and as well, you can hand edit the paths and still create the neighborhood

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/6c3c3a36-662d-4076-9333-02a7f6ddb336)

# Questions (if appropriate):