### PR TITLE
Fixes #1611 Weird refresh of events tree view

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditEventGroupBuildingBlockPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditEventGroupBuildingBlockPresenter.cs
@@ -16,9 +16,7 @@ namespace MoBi.Presentation.Presenter
 {
    public interface IEditEventGroupBuildingBlockPresenter :
       ISingleStartPresenter<EventGroupBuildingBlock>,
-      IListener<AddedEvent>,
-      IListener<RemovedEvent>
-
+      IListener<AddedEvent>
    {
    }
 
@@ -214,19 +212,6 @@ namespace MoBi.Presentation.Presenter
                 || addedObject.IsAnImplementationOf<ApplicationMoleculeBuilder>()
                 || addedObject.IsAnImplementationOf<IContainer>()
                 || addedObject.IsAnImplementationOf<TransportBuilder>();
-      }
-
-      public void Handle(RemovedEvent eventToHandle)
-      {
-         if (!eventToHandle.RemovedObjects.Any(isShowableType))
-            return;
-
-         //If only a Application Molecule Builder is removed we do not need to update the edit presenter
-         if (eventToHandle.RemovedObjects.Count() != 1 ||
-             !eventToHandle.RemovedObjects.First().IsAnImplementationOf<ApplicationMoleculeBuilder>())
-         {
-            setupEditPresenterFor(_eventGroupBuildingBlock.FirstOrDefault());
-         }
       }
 
       internal override (bool canHandle, IContainer containerObject) CanHandle(EntitySelectedEvent entitySelectedEvent)

--- a/src/MoBi.Presentation/Views/IEventGroupsListView.cs
+++ b/src/MoBi.Presentation/Views/IEventGroupsListView.cs
@@ -8,8 +8,7 @@ namespace MoBi.Presentation.Views
 {
    public interface IEventGroupsListView : IView<IEventGroupListPresenter>
    {
-      void Show(IEnumerable<EventGroupBuilderDTO> dtoEventGroupBuilders);
-      void AddNode(ITreeNode treeNode);
-      void Clear();
+      void Show(IReadOnlyList<EventGroupBuilderDTO> dtoEventGroupBuilders);
+      void AddFixedNode(ITreeNode treeNode);
    }
 }

--- a/src/MoBi.UI/Views/EventGroupsListView.cs
+++ b/src/MoBi.UI/Views/EventGroupsListView.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
-using OSPSuite.UI;
 using OSPSuite.Presentation.Nodes;
 using OSPSuite.Utility.Extensions;
 using DevExpress.XtraBars;
@@ -8,7 +8,6 @@ using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Views;
-using OSPSuite.Presentation;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.Extensions;
 using OSPSuite.UI.Controls;
@@ -22,6 +21,7 @@ namespace MoBi.UI.Views
       private readonly UxTreeView _treeView;
       private readonly IDTOEventGroupBuilderToEventNodeMapper _dtoEventGroupToEventNodeMapper;
       private IEventGroupListPresenter _presenter;
+      private readonly List<string> _fixedNodeIds = new List<string>();
 
       public EventGroupsListView(IDTOEventGroupBuilderToEventNodeMapper dtoEventGroupToEventNodeMapper,
          IImageListRetriever imageListRetriever)
@@ -64,8 +64,13 @@ namespace MoBi.UI.Views
             {
                _presenter.CreatePopupMenuFor((IViewItem) node.TagAsObject).At(e.Location);
             }
-            _presenter.Select(node.TagAsObject.DowncastTo<ObjectBaseDTO>());
+            _presenter.Select(objectBaseFromNode(node));
          });
+      }
+
+      private static ObjectBaseDTO objectBaseFromNode(ITreeNode node)
+      {
+         return node.TagAsObject.DowncastTo<ObjectBaseDTO>();
       }
 
       public void AttachPresenter(IEventGroupListPresenter presenter)
@@ -73,25 +78,28 @@ namespace MoBi.UI.Views
          _presenter = presenter;
       }
 
-      public void Show(IEnumerable<EventGroupBuilderDTO> dtoEventGroupBuilders)
+      public void Show(IReadOnlyList<EventGroupBuilderDTO> dtoEventGroupBuilders)
       {
-         var nodes = dtoEventGroupBuilders.MapAllUsing(_dtoEventGroupToEventNodeMapper);
-         nodes.Each(node => _treeView.AddNode(node));
+         var nodesToAdd = dtoEventGroupBuilders.MapAllUsing(_dtoEventGroupToEventNodeMapper);
+         nodesToAdd.Each(_treeView.AddNode);
+
+         removeUnusedNodes(nodesToAdd);
+
+         _presenter.Select(objectBaseFromNode(_treeView.SelectedNode));
       }
 
-      public void AddNode(ITreeNode treeNode)
+      private void removeUnusedNodes(IReadOnlyList<ITreeNode> nodesAdded)
       {
+         var allNodeIds = nodesAdded.SelectMany(x => x.AllNodes).Select(x => x.Id).Concat(_fixedNodeIds);
+         _treeView.Nodes.SelectMany(x => _treeView.NodeFrom(x).AllNodes).Where(existingNode => !allNodeIds.Contains(existingNode.Id)).ToList().Each(_treeView.RemoveNode);
+      }
+
+      public void AddFixedNode(ITreeNode treeNode)
+      {
+         _fixedNodeIds.Add(treeNode.Id);
          _treeView.AddNode(treeNode);
       }
 
-      public void Clear()
-      {
-         _treeView.Clear();
-      }
-
-      public BarManager PopupBarManager
-      {
-         get { return barManager; }
-      }
+      public BarManager PopupBarManager => barManager;
    }
 }

--- a/tests/MoBi.Tests/Presentation/EventGroupListPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EventGroupListPresenterSpecs.cs
@@ -1,0 +1,152 @@
+﻿using System.Collections.Generic;
+using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Events;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Nodes;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+
+namespace MoBi.Presentation
+{
+   public class concern_for_EventGroupListPresenter : ContextSpecification<EventGroupListPresenter>
+   {
+      protected ITreeNodeFactory _treeNodeFactory;
+      protected IEventGroupsListView _view;
+      protected IViewItemContextMenuFactory _viewItemContextMenuFactory;
+      protected IApplicationBuilderToApplicationBuilderDTOMapper _applicationBuilderToDTOApplicationBuilderMapper;
+      protected IMoBiContext _context;
+      protected IEventGroupBuilderToEventGroupBuilderDTOMapper _eventGroupBuilderDTOMapper;
+
+      protected override void Context()
+      {
+         _treeNodeFactory = A.Fake<ITreeNodeFactory>();
+         _view = A.Fake<IEventGroupsListView>();
+         _viewItemContextMenuFactory = A.Fake<IViewItemContextMenuFactory>();
+         _applicationBuilderToDTOApplicationBuilderMapper = A.Fake<IApplicationBuilderToApplicationBuilderDTOMapper>();
+         _context = A.Fake<IMoBiContext>();
+         _eventGroupBuilderDTOMapper = A.Fake<IEventGroupBuilderToEventGroupBuilderDTOMapper>();
+
+         sut = new EventGroupListPresenter(_view, _eventGroupBuilderDTOMapper, _viewItemContextMenuFactory, _applicationBuilderToDTOApplicationBuilderMapper, _context, _treeNodeFactory);
+      }
+   }
+
+   public class When_handling_a_remove_event_for_the_edited_building_block : concern_for_EventGroupListPresenter
+   {
+      private RemovedEvent _removedEvent;
+      private EventGroupBuildingBlock _editedBuildingBlock;
+
+      protected override void Context()
+      {
+         base.Context();
+         IObjectBase removedObject = new EventGroup();
+         _editedBuildingBlock = new EventGroupBuildingBlock();
+         _removedEvent = new RemovedEvent(removedObject, _editedBuildingBlock);
+         sut.Edit(_editedBuildingBlock);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(_removedEvent);
+      }
+
+      [Observation]
+      public void should_edit_the_building_block_a_second_time()
+      {
+         A.CallTo(() => _view.Show(A<IReadOnlyList<EventGroupBuilderDTO>>._)).MustHaveHappenedTwiceExactly();
+      }
+   }
+
+   public class When_handling_a_remove_event_for_another_building_block : concern_for_EventGroupListPresenter
+   {
+      private RemovedEvent _removedEvent;
+      private EventGroupBuildingBlock _eventGroupBuildingBlock;
+      private EventGroupBuildingBlock _editedBuildingBlock;
+
+      protected override void Context()
+      {
+         base.Context();
+         IObjectBase removedObject = new EventGroup();
+         _eventGroupBuildingBlock = new EventGroupBuildingBlock();
+         _removedEvent = new RemovedEvent(removedObject, _eventGroupBuildingBlock);
+         _editedBuildingBlock = new EventGroupBuildingBlock();
+         sut.Edit(_editedBuildingBlock);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(_removedEvent);
+      }
+
+      [Observation]
+      public void should_not_edit_the_building_block_a_second_time()
+      {
+         A.CallTo(() => _view.Show(A<IReadOnlyList<EventGroupBuilderDTO>>._)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+
+
+   public class When_handling_an_add_event_for_the_edited_building_block : concern_for_EventGroupListPresenter
+   {
+      private AddedEvent _addedEvent;
+      private EventGroupBuildingBlock _editedBuildingBlock;
+
+      protected override void Context()
+      {
+         base.Context();
+         var eventGroup = new EventGroupBuilder();
+         var addedObject = new EventBuilder();
+         eventGroup.Add(addedObject);
+         _editedBuildingBlock = new EventGroupBuildingBlock { eventGroup };
+         _addedEvent = new AddedEvent<EventBuilder>(addedObject, eventGroup);
+         sut.Edit(_editedBuildingBlock);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(_addedEvent);
+      }
+
+      [Observation]
+      public void should_edit_the_building_block_a_second_time()
+      {
+         A.CallTo(() => _view.Show(A<IReadOnlyList<EventGroupBuilderDTO>>._)).MustHaveHappenedTwiceExactly();
+      }
+   }
+
+   public class When_handling_an_add_event_for_another_building_block : concern_for_EventGroupListPresenter
+   {
+      private AddedEvent _addedEvent;
+      private EventGroupBuildingBlock _eventGroupBuildingBlock;
+      private EventGroupBuildingBlock _editedBuildingBlock;
+
+      protected override void Context()
+      {
+         base.Context();
+         var eventGroup = new EventGroupBuilder();
+         var addedObject = new EventBuilder();
+         eventGroup.Add(addedObject);
+         _eventGroupBuildingBlock = new EventGroupBuildingBlock { eventGroup };
+         _addedEvent = new AddedEvent<EventBuilder>(addedObject, eventGroup);
+         _editedBuildingBlock = new EventGroupBuildingBlock();
+         sut.Edit(_editedBuildingBlock);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(_addedEvent);
+      }
+
+      [Observation]
+      public void should_not_edit_the_building_block_a_second_time()
+      {
+         A.CallTo(() => _view.Show(A<IReadOnlyList<EventGroupBuilderDTO>>._)).MustHaveHappenedOnceExactly();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #1611

# Description
Previously there was no selectivity for which events building block was being edited so all editors would refresh on removing an event builder. So selectivity is added here.

Also added - we don't re-edit the whole building block on event response, but selectively add/remove items in the tree view in response.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):