### PR TITLE
Fixes #1526 PV BB: New parameter value - required columns are not added

### DIFF
--- a/src/MoBi.Presentation/Presenter/ParameterValuesPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ParameterValuesPresenter.cs
@@ -94,12 +94,10 @@ namespace MoBi.Presentation.Presenter
       public void AddNewParameterValues()
       {
          var allSelected = _parameterValuesTask.GetNewPaths();
-         var buildingBlockWasEmpty = !_buildingBlock.Any();
          _context.AddToHistory(addParameterValuesForObjectPaths(allSelected, _buildingBlock));
-
-         if (buildingBlockWasEmpty)
-            _view.InitializePathColumns();
       }
+
+      private int longestPathLength(ParameterValuesBuildingBlock buildingBlock) => buildingBlock.Any() ? buildingBlock.Max(x => x.Path.Count) : 0;
 
       private IMoBiCommand addParameterValuesForObjectPaths(IReadOnlyList<ObjectPath> objectPaths, ParameterValuesBuildingBlock buildingBlockToAddTo)
       {
@@ -114,7 +112,12 @@ namespace MoBi.Presentation.Presenter
             Description = AppConstants.Commands.AddNewParameterValues(buildingBlockToAddTo.DisplayName)
          };
 
+         var maxPathLengthBeforeAdd = longestPathLength(_buildingBlock);
          macroCommand.AddRange(objectPathsToAdd.Select(entityPath => addAndUpdatePath(buildingBlockToAddTo, entityPath)));
+
+         var maxPathLengthAfterAdd = longestPathLength(_buildingBlock);
+         if (maxPathLengthAfterAdd > maxPathLengthBeforeAdd)
+            _view.InitializePathColumns();
 
          if (allSkipped.Any())
             _dialogCreator.MessageBoxInfo(AppConstants.Captions.BuildingBlockAlreadyContains(allSkipped.Select(x => x.PathAsString).ToList()));

--- a/tests/MoBi.Tests/Presentation/ParameterValuesPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ParameterValuesPresenterSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using FakeItEasy;
+using FakeItEasy.Core;
 using MoBi.Assets;
 using MoBi.Core.Domain.Model;
 using MoBi.Presentation.Mappers;
@@ -84,12 +85,29 @@ namespace MoBi.Presentation
 
    internal class When_creating_parameter_values_and_none_are_in_the_building_block : When_creating_new_parameter_values
    {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _parameterValuesTask.SetFullPath(A<ParameterValue>._, _path1, _parameterValuesBuildingBlock)).Invokes(() => addPVToBuildingBlock(_path1));
+      }
+
+      private void addPVToBuildingBlock(ObjectPath path)
+      {
+         _parameterValuesBuildingBlock.Add(new ParameterValue(){Path = path});
+      }
+
       [Observation]
       public void parameters_should_be_added_for_all_selected_paths()
       {
          A.CallTo(() => _parameterValuesTask.SetFullPath(A<ParameterValue>._, _path1, _parameterValuesBuildingBlock)).MustHaveHappened();
          A.CallTo(() => _parameterValuesTask.SetFullPath(A<ParameterValue>._, _path2, _parameterValuesBuildingBlock)).MustHaveHappened();
          A.CallTo(() => _parameterValuesTask.SetFullPath(A<ParameterValue>._, _path3, _parameterValuesBuildingBlock)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_view_should_have_columns_initialized()
+      {
+         A.CallTo(() => _parameterValuesView.InitializePathColumns()).MustHaveHappenedTwiceExactly();
       }
    }
 


### PR DESCRIPTION
Fixes #1526

# Description
Always reinitialize columns if the user adds a new PV with a longer path length

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):