### PR TITLE
Fixes #1626 Cloning a simulation should rename the Model and the Root

### DIFF
--- a/src/MoBi.Core/Commands/RenameModelCommand.cs
+++ b/src/MoBi.Core/Commands/RenameModelCommand.cs
@@ -47,8 +47,8 @@ namespace MoBi.Core.Commands
          updateFormulasInContainer(root);
          updateFormulasInContainer(_model.Neighborhoods);
 
-         var allEventAssingements = root.GetAllChildren<EventAssignment>();
-         allEventAssingements.Each(ea => updateObjectPath(ea.ObjectPath));
+         var allEventAssignments = root.GetAllChildren<EventAssignment>();
+         allEventAssignments.Each(ea => updateObjectPath(ea.ObjectPath));
       }
 
       private void updateFormulasInContainer(IContainer root)

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
@@ -190,6 +190,8 @@ namespace MoBi.Presentation.Tasks.Interaction
             return null;
 
          var newSimulation = _cloneManager.CloneSimulation(simulationToClone).WithName(newName);
+
+         // during cloning, we don't need to track the rename in history since the simulation is not yet added to the project
          new RenameModelCommand(newSimulation.Model, newName).RunCommand(_interactionTaskContext.Context);
          _interactionTaskContext.Context.AddToHistory(new AddSimulationCommand(newSimulation).RunCommand(_interactionTaskContext.Context));
 

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
@@ -189,6 +189,8 @@ namespace MoBi.Presentation.Tasks.Interaction
             return null;
 
          var newSimulation = _cloneManager.CloneSimulation(simulationToClone).WithName(newName);
+         newSimulation.Model.WithName(newName);
+         newSimulation.Model.Root.WithName(newName);
          
          _interactionTaskContext.Context.AddToHistory(new AddSimulationCommand(newSimulation).RunCommand(_interactionTaskContext.Context));
 

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
@@ -10,6 +10,7 @@ using MoBi.Core.Services;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Edit;
 using OSPSuite.Assets;
+using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
@@ -189,9 +190,7 @@ namespace MoBi.Presentation.Tasks.Interaction
             return null;
 
          var newSimulation = _cloneManager.CloneSimulation(simulationToClone).WithName(newName);
-         newSimulation.Model.WithName(newName);
-         newSimulation.Model.Root.WithName(newName);
-         
+         new RenameModelCommand(newSimulation.Model, newName).RunCommand(_interactionTaskContext.Context);
          _interactionTaskContext.Context.AddToHistory(new AddSimulationCommand(newSimulation).RunCommand(_interactionTaskContext.Context));
 
          return newSimulation;

--- a/tests/MoBi.Tests/Presentation/InteractionTasksForSimulationSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/InteractionTasksForSimulationSpecs.cs
@@ -106,7 +106,11 @@ namespace MoBi.Presentation
          };
          _clonedSimulation = new MoBiSimulation
          {
-            Configuration = new SimulationConfiguration()
+            Configuration = new SimulationConfiguration(),
+            Model = new Model
+            {
+               Root = new Container()
+            }
          };
 
          A.CallTo(() => _interactionTaskContext.InteractionTask.PromptForNewName(A<IMoBiSimulation>._, A<IEnumerable<string>>._)).Returns("new name");
@@ -135,6 +139,8 @@ namespace MoBi.Presentation
       public void the_cloned_simulation_should_be_renamed()
       {
          _clonedSimulation.Name.ShouldBeEqualTo("new name");
+         _clonedSimulation.Model.Name.ShouldBeEqualTo("new name");
+         _clonedSimulation.Model.Root.Name.ShouldBeEqualTo("new name");
       }
    }
 

--- a/tests/MoBi.Tests/Presentation/InteractionTasksForSimulationSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/InteractionTasksForSimulationSpecs.cs
@@ -109,7 +109,8 @@ namespace MoBi.Presentation
             Configuration = new SimulationConfiguration(),
             Model = new Model
             {
-               Root = new Container()
+               Root = new Container(),
+               Neighborhoods = new Container()
             }
          };
 
@@ -141,6 +142,17 @@ namespace MoBi.Presentation
          _clonedSimulation.Name.ShouldBeEqualTo("new name");
          _clonedSimulation.Model.Name.ShouldBeEqualTo("new name");
          _clonedSimulation.Model.Root.Name.ShouldBeEqualTo("new name");
+      }
+
+      [Observation]
+      public void the_model_rename_command_is_used_to_rename_the_model()
+      {
+         A.CallTo(() => _interactionTaskContext.Context.PromptForCancellation(A<ICommand>.That.Matches(x => isModelRenameCommand(x)))).MustHaveHappened();
+      }
+
+      private bool isModelRenameCommand(ICommand command)
+      {
+         return command is RenameModelCommand;
       }
    }
 


### PR DESCRIPTION
Fixes #1626

# Description
Cloning a simulation left the old name on the model and the root container

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):