### PR TITLE
Fixes #1640 Cannot load a simulation after renaming any simulation

### DIFF
--- a/src/MoBi.Core/Services/SimulationLoader.cs
+++ b/src/MoBi.Core/Services/SimulationLoader.cs
@@ -56,13 +56,16 @@ namespace MoBi.Core.Services
          var moBiSimulation = simulation;
 
          var project = _context.CurrentProject;
-         renameCollidingEntities(simulation.Configuration.ExpressionProfiles, project.ExpressionProfileCollection);
-
-         if (simulation.Configuration.Individual != null)
-            renameCollidingEntities(new[] { simulation.Configuration.Individual }, project.IndividualsCollection);
 
          if (shouldCloneSimulation)
             moBiSimulation = cloneSimulation(moBiSimulation);
+
+         renameCollidingEntities(moBiSimulation.Configuration.ExpressionProfiles, project.ExpressionProfileCollection);
+
+         if (moBiSimulation.Configuration.Individual != null)
+            renameCollidingEntities(new[] { moBiSimulation.Configuration.Individual }, project.IndividualsCollection);
+
+         renameCollidingEntities(moBiSimulation.Modules, project.Modules);
 
          moBiSimulation.ResultsDataRepository = simulation.ResultsDataRepository;
 
@@ -97,7 +100,7 @@ namespace MoBi.Core.Services
             module.Name = module.Name.Replace(originalSimulationName, simulationName);
       }
       
-      private void renameCollidingEntities(IEnumerable<IObjectBase> entitiesToRename, IReadOnlyList<IWithName> existingEntities)
+      private void renameCollidingEntities<T>(IEnumerable<T> entitiesToRename, IReadOnlyList<IWithName> existingEntities) where T : IObjectBase
       {
          var takenNames = existingEntities.AllNames();
          entitiesToRename.Where(x => takenNames.Contains(x.Name)).Each(x => _nameCorrector.AutoCorrectName(takenNames, x));

--- a/tests/MoBi.Tests/Core/SimulationLoaderSpecs.cs
+++ b/tests/MoBi.Tests/Core/SimulationLoaderSpecs.cs
@@ -47,7 +47,30 @@ namespace MoBi.Core
       }
    }
 
-   public class When_adding_a_simulation_to_project_that_contains_a_module_with_the_same_name : concern_for_SimulationLoader
+   public class When_adding_a_simulation_to_project_where_the_simulation_name_is_unique_but_module_names_collide : concern_for_SimulationLoader
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _project.AddModule(new Module().WithName("moduleName"));
+         _simulation.Name = "Sim1";
+
+         A.CallTo(() => _cloneManager.CloneSimulationConfiguration(A<SimulationConfiguration>._)).Returns(_simulationConfiguration);
+      }
+
+      protected override void Because()
+      {
+         sut.AddSimulationToProject(_simulation);
+      }
+
+      [Observation]
+      public void the_added_module_should_have_been_renamed()
+      {
+         A.CallTo(() => _nameCorrector.AutoCorrectName(A<IEnumerable<string>>._, _simulation.Modules.First())).MustHaveHappened();
+      }
+   }
+
+   public class When_adding_a_simulation_to_project_that_contains_a_simulation_with_the_same_name : concern_for_SimulationLoader
    {
       private ObserverBuildingBlock _clonedBuildingBlock;
 


### PR DESCRIPTION
Fixes #1640

# Description
This covers the case where you load a simulation and there are colliding modules, but no colliding simulation to trigger a rename of the modules

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):