### PR TITLE
Fixes #1649 Cannot import Expressions from PK-Sim more than once

### DIFF
--- a/src/MoBi.Presentation/UICommand/AddNewBuildingBlockCommand.cs
+++ b/src/MoBi.Presentation/UICommand/AddNewBuildingBlockCommand.cs
@@ -20,6 +20,7 @@ namespace MoBi.Presentation.UICommand
          _interactionTask = interactionTask;
       }
 
+      // Override this because the base class clears the Subject property after completion
       public override void Execute() => PerformExecute();
 
       protected override void PerformExecute()

--- a/src/MoBi.Presentation/UICommand/AddNewBuildingBlockCommand.cs
+++ b/src/MoBi.Presentation/UICommand/AddNewBuildingBlockCommand.cs
@@ -20,9 +20,11 @@ namespace MoBi.Presentation.UICommand
          _interactionTask = interactionTask;
       }
 
+      public override void Execute() => PerformExecute();
+
       protected override void PerformExecute()
       {
-         var buildingBlockFromPKSim = createBuildingBlockFromPKSim();
+         var buildingBlockFromPKSim = CreateBuildingBlockFromPKSim();
 
          if (buildingBlockFromPKSim == null)
             return;
@@ -30,6 +32,6 @@ namespace MoBi.Presentation.UICommand
          _context.AddToHistory(_interactionTask.AddToProject(buildingBlockFromPKSim));
       }
 
-      protected abstract IBuildingBlock createBuildingBlockFromPKSim();
+      protected abstract IBuildingBlock CreateBuildingBlockFromPKSim();
    }
 }

--- a/src/MoBi.Presentation/UICommand/AddNewExpressionProfileBuildingBlock.cs
+++ b/src/MoBi.Presentation/UICommand/AddNewExpressionProfileBuildingBlock.cs
@@ -12,7 +12,7 @@ namespace MoBi.Presentation.UICommand
       {
       }
 
-      protected override IBuildingBlock createBuildingBlockFromPKSim()
+      protected override IBuildingBlock CreateBuildingBlockFromPKSim()
       {
          return _pkSimStarter.CreateProfileExpression(Subject);
       }

--- a/src/MoBi.Presentation/UICommand/AddNewIndividualCommand.cs
+++ b/src/MoBi.Presentation/UICommand/AddNewIndividualCommand.cs
@@ -12,7 +12,7 @@ namespace MoBi.Presentation.UICommand
       {
       }
 
-      protected override IBuildingBlock createBuildingBlockFromPKSim()
+      protected override IBuildingBlock CreateBuildingBlockFromPKSim()
       {
          return _pkSimStarter.CreateIndividual();
       }


### PR DESCRIPTION
Fixes #1649

# Description
Most UI commands clear the `Subject` after they complete. These particular ones use a static subject to outline what type of object should be imported

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):