### PR TITLE
Fixes #1624 Do not automatically create the "Volume" parameter for ph…

### DIFF
--- a/src/MoBi.Core/Commands/SetContainerModeCommand.cs
+++ b/src/MoBi.Core/Commands/SetContainerModeCommand.cs
@@ -1,7 +1,6 @@
 ﻿using MoBi.Assets;
 using OSPSuite.Core.Commands.Core;
 using MoBi.Core.Domain.Model;
-using MoBi.Core.Events;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Assets;
@@ -31,36 +30,7 @@ namespace MoBi.Core.Commands
       {
          base.ExecuteWith(context);
          _container.Mode = _newContainerMode;
-         addContainerVolumeParameter(context);
          Description = AppConstants.Commands.EditDescription(ObjectTypes.Container, AppConstants.Captions.ContainerMode, _oldContainerMode.ToString(), _newContainerMode.ToString(), _container.Name);
-      }
-
-      private void addContainerVolumeParameter(IMoBiContext context)
-      {
-         var volume = _container.GetSingleChildByName<IParameter>(Constants.Parameters.VOLUME);
-
-         //switch from physical to logical. If volume was created here, this command is an inverse and volume should be removed
-         if (_newContainerMode == ContainerMode.Logical)
-         {
-            if (_volumeParameterCreatedHere && volume != null)
-            {
-               _container.RemoveChild(volume);
-               context.Unregister(volume);
-               context.PublishEvent(new RemovedEvent(volume, _container));
-            }
-         }
-         //we switched from Logical to physical. Add volume parameter if not available
-         else
-         {
-            if (volume != null) return;
-            var parameterFactory = context.Resolve<IParameterFactory>();
-            volume = parameterFactory.CreateVolumeParameter();
-
-            _container.Add(volume);
-            context.Register(volume);
-            _volumeParameterCreatedHere = true;
-            context.PublishEvent(new AddedEvent<IParameter>(volume, _container));
-         }
       }
 
       protected override void ClearReferences()

--- a/src/MoBi.Presentation/Presenter/MoBiMainViewPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/MoBiMainViewPresenter.cs
@@ -9,6 +9,7 @@ using MoBi.Core.Events;
 using MoBi.Presentation.Settings;
 using MoBi.Presentation.UICommand;
 using MoBi.Presentation.Views;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters.ContextMenus;
@@ -150,7 +151,7 @@ namespace MoBi.Presentation.Presenter
       private void updateWindowTitle(string projectName = null)
         {
          View.Caption = 
-            string.IsNullOrEmpty(projectName) 
+            string.IsNullOrEmpty(projectName) || string.Equals(Constants.PROJECT_UNDEFINED, projectName)
                ? _configuration.ProductDisplayName 
                : $"{_configuration.ProductDisplayName} | {projectName}";
       }

--- a/tests/MoBi.Tests/Core/Commands/SetContainerModeCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/SetContainerModeCommandSpecs.cs
@@ -2,7 +2,6 @@
 using OSPSuite.BDDHelper.Extensions;
 using FakeItEasy;
 using MoBi.Core.Domain.Model;
-using MoBi.Core.Services;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 
@@ -28,36 +27,6 @@ namespace MoBi.Core.Commands
          A.CallTo(() => parameterFactory.CreateVolumeParameter()).Returns(_volumeParameter);
          A.CallTo(() => _context.Resolve<IParameterFactory>()).Returns(parameterFactory);
          sut = new SetContainerModeCommand(_buildingBlock, _container, _newContainerMode);
-      }
-   }
-
-   public class When_setting_the_container_mode_from_logical_to_physical_in_a_container_that_does_not_have_a_volume_parameter : concern_for_SetContainerModeCommand
-   {
-      protected override void Context()
-      {
-         _newContainerMode = ContainerMode.Physical;
-         _oldContainerMode = ContainerMode.Logical;
-         base.Context();
-      }
-
-      protected override void Because()
-      {
-         sut.Execute(_context);
-      }
-
-      [Observation]
-      public void should_add_the_volume_parameter_and_register_the_volume_parameter()
-      {
-         _container.EntityAt<IParameter>(Constants.Parameters.VOLUME).ShouldBeEqualTo(_volumeParameter);
-         A.CallTo(() => _context.Register(_volumeParameter)).MustHaveHappened();
-      }
-
-      [Observation]
-      public void the_inverse_of_the_resulting_command_should_remove_the_volume_parameter_and_unregister_the_parameter()
-      {
-         sut.InvokeInverse(_context);
-         _container.EntityAt<IParameter>(Constants.Parameters.VOLUME).ShouldBeNull();
-         A.CallTo(() => _context.Unregister(_volumeParameter)).MustHaveHappened();
       }
    }
 


### PR DESCRIPTION
Fixes #1624

# Description
don't automatically add a volume parameter to physical containers when creating the container

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):