### PR TITLE
Fixes #1645 Cannot delete an IC BB if it was used in any simulation

### DIFF
--- a/src/MoBi.Core/Domain/Model/MoBiSimulation.cs
+++ b/src/MoBi.Core/Domain/Model/MoBiSimulation.cs
@@ -118,11 +118,21 @@ namespace MoBi.Core.Domain.Model
 
       public IReadOnlyList<IBuildingBlock> BuildingBlocks()
       {
-         var buildingBlocks = Modules.SelectMany(module => module.BuildingBlocks).Concat(Configuration.ExpressionProfiles).ToList();
+         var buildingBlocks = Configuration.ModuleConfigurations.SelectMany(usedBuildingBlocksFrom).Concat(Configuration.ExpressionProfiles).ToList();
 
          if (Configuration.Individual != null)
             buildingBlocks.Add(Configuration.Individual);
          return buildingBlocks;
+      }
+
+      private IReadOnlyList<IBuildingBlock> usedBuildingBlocksFrom(ModuleConfiguration moduleConfiguration)
+      {
+         var module = moduleConfiguration.Module;
+         // Only add used InitialConditions and ParameterValues, not ones that are not used
+         return module.BuildingBlocks
+            .Except(module.ParameterValuesCollection.Concat<IBuildingBlock>(module.InitialConditionsCollection))
+            .Concat(new List<IBuildingBlock> {moduleConfiguration.SelectedInitialConditions, moduleConfiguration.SelectedParameterValues})
+            .Where(x => x != null).ToList();
       }
 
       public IReadOnlyCollection<OriginalQuantityValue> OriginalQuantityValues => _quantityValueCache;

--- a/tests/MoBi.Tests/Core/MoBiSimulationSpecs.cs
+++ b/tests/MoBi.Tests/Core/MoBiSimulationSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using DevExpress.Utils.Extensions;
 using FakeItEasy;
 using MoBi.Core.Domain;
 using MoBi.Core.Domain.Model;
@@ -262,6 +263,96 @@ namespace MoBi.Core
       public void the_observed_data_should_have_been_removed()
       {
          sut.Chart.Curves.ShouldBeEmpty();
+      }
+   }
+
+   public abstract class Using_selectable_building_blocks<TBuildingBlock> : concern_for_MoBiSimulation where TBuildingBlock : BuildingBlock, new()
+   {
+      protected bool _result;
+      protected TBuildingBlock _templateBuildingBlock;
+      protected TBuildingBlock _simulationBuildingBlock;
+      private SimulationConfiguration _simulationConfiguration;
+      protected ModuleConfiguration _moduleConfiguration;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulationConfiguration = new SimulationConfiguration();
+         sut.Configuration = _simulationConfiguration;
+         var simulationModule = new Module().WithName("a Module");
+         _simulationBuildingBlock = new TBuildingBlock().WithName("bb");
+         simulationModule.Add(_simulationBuildingBlock);
+         _moduleConfiguration = new ModuleConfiguration(simulationModule);
+         sut.Configuration.AddModuleConfiguration(_moduleConfiguration);
+
+
+         var templateModule = new Module().WithName("a Module");
+         _templateBuildingBlock = new TBuildingBlock().WithName("bb");
+         templateModule.Add(_templateBuildingBlock);
+         SelectBuildingBlock();
+      }
+
+      public abstract void SelectBuildingBlock();
+
+      protected override void Because()
+      {
+         _result = sut.Uses(_templateBuildingBlock);
+      }
+   }
+
+   public class When_checking_if_a_simulation_uses_an_selected_initial_condition : Using_selectable_building_blocks<InitialConditionsBuildingBlock>
+   {
+      [Observation]
+      public void the_simulation_should_indicate_the_building_block_is_not_used()
+      {
+         _result.ShouldBeTrue();
+      }
+
+      public override void SelectBuildingBlock()
+      {
+         _moduleConfiguration.SelectedInitialConditions = _templateBuildingBlock;
+      }
+   }
+
+   public class When_checking_if_a_simulation_uses_an_selected_parameter_values : Using_selectable_building_blocks<ParameterValuesBuildingBlock>
+   {
+      [Observation]
+      public void the_simulation_should_indicate_the_building_block_is_not_used()
+      {
+         _result.ShouldBeTrue();
+      }
+
+      public override void SelectBuildingBlock()
+      {
+         _moduleConfiguration.SelectedParameterValues = _templateBuildingBlock;
+      }
+   }
+
+   public class When_checking_if_a_simulation_uses_an_unselected_initial_condition : Using_selectable_building_blocks<InitialConditionsBuildingBlock>
+   {
+      [Observation]
+      public void the_simulation_should_indicate_the_building_block_is_not_used()
+      {
+         _result.ShouldBeFalse();
+      }
+
+      public override void SelectBuildingBlock()
+      {
+         _moduleConfiguration.SelectedInitialConditions = null;
+      }
+   }
+
+   public class When_checking_if_a_simulation_uses_an_unselected_parameter_values : Using_selectable_building_blocks<ParameterValuesBuildingBlock>
+   {
+      [Observation]
+      public void the_simulation_should_indicate_the_building_block_is_not_used()
+      {
+         _result.ShouldBeFalse();
+      }
+
+      public override void SelectBuildingBlock()
+      {
+         _moduleConfiguration.SelectedParameterValues = null;
       }
    }
 }


### PR DESCRIPTION
Fixes #1645

# Description
We had considered all building blocks in a module as 'Used' but this doesn't make sense for IC and PV where they need to be selected for use.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):