### PR TITLE
Fixes #1642

### DIFF
--- a/src/MoBi.Presentation/Presenter/SelectMoleculePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectMoleculePresenter.cs
@@ -17,6 +17,7 @@ namespace MoBi.Presentation.Presenter
       void SelectMolecules(MoleculeBuildingBlock defaultMolecules, Func<MoleculeBuilder, bool> canSelect = null);
       IReadOnlyList<MoleculeSelectionDTO> SelectedMolecules { get; }
       void SelectionChanged();
+      void UpdateValidationsFor(MoleculeSelectionDTO selectedDTO);
    }
 
    public class SelectMoleculesPresenter : AbstractPresenter<ISelectMoleculesView, ISelectMoleculesPresenter>, ISelectMoleculesPresenter
@@ -43,6 +44,8 @@ namespace MoBi.Presentation.Presenter
       }
 
       public void SelectionChanged() => OnStatusChanged();
+      public void UpdateValidationsFor(MoleculeSelectionDTO selectedDTO) => 
+         _dto.Molecules.Where(molecule => string.Equals(molecule.MoleculeName, selectedDTO.MoleculeName)).Each(_view.UpdateValidation);
 
       private void selectDefaultMolecules(MoleculeBuildingBlock defaultMolecules)
       {

--- a/src/MoBi.Presentation/Views/ISelectMoleculeView.cs
+++ b/src/MoBi.Presentation/Views/ISelectMoleculeView.cs
@@ -8,5 +8,6 @@ namespace MoBi.Presentation.Views
    public interface ISelectMoleculesView : IView<ISelectMoleculesPresenter>
    {
       void BindTo(IReadOnlyList<MoleculeSelectionDTO> dtoMolecules);
+      void UpdateValidation(MoleculeSelectionDTO moleculeDTO);
    }
 }

--- a/src/MoBi.UI/Views/SelectMoleculesView.cs
+++ b/src/MoBi.UI/Views/SelectMoleculesView.cs
@@ -63,6 +63,16 @@ namespace MoBi.UI.Views
          _gridViewBinder.BindToSource(dtoMolecules);
       }
 
+      public void UpdateValidation(MoleculeSelectionDTO moleculeDTO)
+      {
+         var rowHandle = _gridViewBinder.RowHandleFor(moleculeDTO);
+
+         if (gridView.IsRowVisible(rowHandle) != RowVisibleState.Visible)
+            return;
+
+         gridView.FocusedRowHandle = rowHandle;
+      }
+
       public override void InitializeBinding()
       {
          base.InitializeBinding();
@@ -84,7 +94,9 @@ namespace MoBi.UI.Views
          // The select/unselect of a molecule will affect the validation of another molecule
          // with the same name. If both were selected, and one is unselected, then the other becomes
          // valid.
-         gridView.RefreshData();
+         var originalFocusRow = gridView.FocusedRowHandle;
+         _presenter.UpdateValidationsFor(_gridViewBinder.FocusedElement);
+         gridView.FocusedRowHandle = originalFocusRow;
          _presenter.SelectionChanged();
       }
 


### PR DESCRIPTION
Fixes #1642

# Description
This way we are much more surgical about how validations on non-focused rows are happening.

Formerly refreshdata expanded all the rows each time you selected/unselected a molecule

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):