### PR TITLE
Fixes #1666 V12: Cannot create new parameter value

### DIFF
--- a/src/MoBi.Core/Extensions/PathAndValueEntityExtensions.cs
+++ b/src/MoBi.Core/Extensions/PathAndValueEntityExtensions.cs
@@ -9,6 +9,11 @@ namespace MoBi.Core.Extensions
       public static string GetValueAsDisplayString(this PathAndValueEntity pathAndValueEntity)
       {
          return $"{pathAndValueEntity.ConvertToDisplayUnit(pathAndValueEntity.Value).ToString(CultureInfo.InvariantCulture)} {pathAndValueEntity.DisplayUnit}";
-      }   
+      }
+
+      public static bool IsDirectSubParameterOf(this PathAndValueEntity builder, PathAndValueEntity distributedBuilder)
+      {
+         return builder.Path.StartsWith(distributedBuilder.Path) && builder.Path.Count - distributedBuilder.Path.Count == 1;
+      }
    }
 }

--- a/src/MoBi.Presentation/Mappers/PathAndValueEntityBuildingBlockToPathAndValueEntityBuildingBlockDTOMapper.cs
+++ b/src/MoBi.Presentation/Mappers/PathAndValueEntityBuildingBlockToPathAndValueEntityBuildingBlockDTOMapper.cs
@@ -4,6 +4,7 @@ using MoBi.Presentation.DTO;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Utility;
 using OSPSuite.Utility.Extensions;
+using MoBi.Core.Extensions;
 
 namespace MoBi.Presentation.Mappers
 {
@@ -40,14 +41,10 @@ namespace MoBi.Presentation.Mappers
 
       protected abstract TBuildingBlockDTO MapBuildingBlockDTO(TBuildingBlock buildingBlock, List<TBuilderDTO> parameterDTOs);
 
-      private IEnumerable<TBuilderDTO> subParametersFor(TBuilderDTO distributedParameter, IEnumerable<TBuilderDTO> parameterList)
-      {
-         return parameterList.Where(x => isDirectSubParameterOf(distributedParameter, x));
-      }
+      private IEnumerable<TBuilderDTO> subParametersFor(TBuilderDTO distributedParameter, IEnumerable<TBuilderDTO> parameterList) => 
+         parameterList.Where(x => isDirectSubParameterOf(distributedParameter, x));
 
-      private bool isDirectSubParameterOf(TBuilderDTO distributedParameter, TBuilderDTO builderDTO)
-      {
-         return builderDTO.Path.StartsWith(distributedParameter.Path) && builderDTO.Path.Count - distributedParameter.Path.Count == 1;
-      }
+      private bool isDirectSubParameterOf(TBuilderDTO distributedParameter, TBuilderDTO builderDTO) => 
+         builderDTO.PathWithValueObject.IsDirectSubParameterOf(distributedParameter.PathWithValueObject);
    }
 }

--- a/tests/MoBi.Tests/Presentation/SelectReferenceAtParameterValuePresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectReferenceAtParameterValuePresenterSpecs.cs
@@ -13,6 +13,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Presentation.Nodes;
 
 namespace MoBi.Presentation
@@ -220,6 +221,52 @@ namespace MoBi.Presentation
          _children[0].ObjectBase.Name.ShouldBeEqualTo("Container");
          var entity = (_children[0].ObjectBase as Container).Single();
          entity.Name.ShouldBeEqualTo("named parameter");
+      }
+   }
+
+   public class When_getting_child_objects_with_a_distributed_parameter : concern_for_SelectReferenceAtParameterValuePresenter
+   {
+      private ObjectBaseDTO _objectBaseDTO;
+      private List<ObjectBaseDTO> _children;
+      private IndividualBuildingBlock _individualBuildingBlock;
+
+      protected override void Context()
+      {
+         base.Context();
+         _individualBuildingBlock = new IndividualBuildingBlock().WithId("1");
+         var pathAndValueEntity = new IndividualParameter().WithId("2");
+         pathAndValueEntity.Path = new ObjectPath("Root", "Container", "distributed parameter");
+         
+         pathAndValueEntity.DistributionType = DistributionType.Normal;
+         _individualBuildingBlock.Add(pathAndValueEntity);
+
+         pathAndValueEntity = new IndividualParameter().WithId("3");
+         pathAndValueEntity.Path = new ObjectPath("Root", "Container", "distributed parameter", "mean");
+         _individualBuildingBlock.Add(pathAndValueEntity);
+
+         _objectBaseDTO = new ObjectBaseDTO(_individualBuildingBlock);
+
+         A.CallTo(() => _context.ObjectRepository.ContainsObjectWithId(_individualBuildingBlock.Id)).Returns(true);
+         A.CallTo(() => _context.Get<IndividualBuildingBlock>(_individualBuildingBlock.Id)).Returns(_individualBuildingBlock);
+         A.CallTo(() => _context.Get<ExpressionProfileBuildingBlock>(A<string>._)).Returns(null);
+         A.CallTo(() => _objectBaseDTOMapper.MapFrom(A<IObjectBase>._)).ReturnsLazily(x => new ObjectBaseDTO(x.Arguments.Get<IObjectBase>(0)));
+      }
+
+      protected override void Because()
+      {
+         _children = sut.GetChildObjects(_objectBaseDTO).ToList();
+      }
+
+      [Observation]
+      public void the_child_objects_added_to_the_view_should_contain_the_individual_parameters()
+      {
+         _children.Count.ShouldBeEqualTo(1);
+         _children[0].ObjectBase.Name.ShouldBeEqualTo("Root");
+         var root = _children[0].ObjectBase as Container;
+         var container = root.Single() as Container;
+         container.Name.ShouldBeEqualTo("Container");
+         var distributedParameterContainer = container.Single() as IndividualParameter;
+         distributedParameterContainer.Name.ShouldBeEqualTo("distributed parameter");
       }
    }
 }


### PR DESCRIPTION
Fixes #1668
Fixes #1666

# Description
Same fix for both. The problem in 1666 was that the parameter had been converted from a distributed parameter to non-distributed. Then when trying to show a sub-parameter like `Mean` we could not add a container for it because it would have been called `Volume`, however, there's already an object with that name.

So, by hiding sub-parameters we fix both these issues.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):