### PR TITLE
Fixes #1659 Removing Initial Conditions or Parameter Valuesfrom PK-Sim module does not ask for changing to extension module

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -939,7 +939,7 @@ namespace MoBi.Assets
 
          public static string Remove(string objectType, string objectName, string parentName)
          {
-            var baseString = $"Do you really want to remove {objectType} '{objectName}' from {parentName}.";
+            var baseString = $"Do you really want to remove {objectType} '{objectName}' from {parentName}?";
             if (string.Equals(objectType, ObjectTypes.Simulation))
                return baseString + $"  {objectName} will also be removed from parameter identifications and sensitivity analyses";
 

--- a/src/MoBi.Core/Commands/AddBuildingBlockToModuleCommand.cs
+++ b/src/MoBi.Core/Commands/AddBuildingBlockToModuleCommand.cs
@@ -23,13 +23,7 @@ namespace MoBi.Core.Commands
          Silent = false;
       }
 
-      protected override void ExecuteWith(IMoBiContext context)
-      {
-         DoExecute(context);
-         RaiseEvents(context);
-      }
-
-      protected virtual void RaiseEvents(IMoBiContext context)
+      protected override void RaiseEvents(IMoBiContext context)
       {
          if (!Silent)
             context.PublishEvent(new AddedEvent<T>(_buildingBlock, _existingModule));
@@ -37,7 +31,7 @@ namespace MoBi.Core.Commands
          PublishSimulationStatusChangedEvents(_existingModule, context);
       }
 
-      protected virtual void DoExecute(IMoBiContext context)
+      protected override void DoExecute(IMoBiContext context)
       {
          context.Register(_buildingBlock);
          _existingModule.Add(_buildingBlock);

--- a/src/MoBi.Core/Commands/BuildingBlockChangeCommandBase.cs
+++ b/src/MoBi.Core/Commands/BuildingBlockChangeCommandBase.cs
@@ -7,12 +7,12 @@ using OSPSuite.Core.Domain.Builder;
 
 namespace MoBi.Core.Commands
 {
-   public abstract class BuildingBlockChangeCommandBase : MoBiReversibleCommand
+   public abstract class BuildingBlockChangeCommandBase : MoBiReversibleCommand, IWillConvertPKSimModuleToExtensionModule
    {
       public abstract bool WillConvertPKSimModuleToExtensionModule { get; }
       public abstract Module Module { get; }
    }
-   
+
    public abstract class BuildingBlockChangeCommandBase<T> : BuildingBlockChangeCommandBase where T :  class, IBuildingBlock
    {
       public bool ShouldIncrementVersion { get; set; }
@@ -41,7 +41,7 @@ namespace MoBi.Core.Commands
 
       protected override void ClearReferences()
       {
-         _buildingBlock = default(T);
+         _buildingBlock = default;
       }
 
       public override void RestoreExecutionData(IMoBiContext context)

--- a/src/MoBi.Core/Commands/IWillConvertPKSimModuleToExtensionModule.cs
+++ b/src/MoBi.Core/Commands/IWillConvertPKSimModuleToExtensionModule.cs
@@ -1,0 +1,10 @@
+using OSPSuite.Core.Domain;
+
+namespace MoBi.Core.Commands
+{
+   public interface IWillConvertPKSimModuleToExtensionModule : IMoBiCommand
+   {
+      bool WillConvertPKSimModuleToExtensionModule { get; }
+      Module Module { get; }
+   }
+}

--- a/src/MoBi.Core/Commands/ModuleContentChangeCommandExtensions.cs
+++ b/src/MoBi.Core/Commands/ModuleContentChangeCommandExtensions.cs
@@ -1,0 +1,15 @@
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain.Builder;
+
+namespace MoBi.Core.Commands
+{
+   static class ModuleContentChangeCommandExtensions
+   {
+      public static ModuleContentChangedCommand<T> AsInverseFor<T>(this ModuleContentChangedCommand<T> inverseCommand, ModuleContentChangedCommand<T> originalCommand) where T : class, IBuildingBlock
+      {
+         CommandExtensions.AsInverseFor(inverseCommand, originalCommand);
+         inverseCommand.WithNewPKSimModuleStateFrom(originalCommand);
+         return inverseCommand;
+      }
+   }
+}

--- a/src/MoBi.Core/Commands/ModuleContentChangedCommand.cs
+++ b/src/MoBi.Core/Commands/ModuleContentChangedCommand.cs
@@ -59,9 +59,9 @@ namespace MoBi.Core.Commands
          _existingModule.IsPKSimModule = _newPkSimModuleState;
       }
 
-      public void WithNewPKSimModuleStateFrom(ModuleContentChangedCommand<T> newPKSimModuleState)
+      public void WithNewPKSimModuleStateFrom(ModuleContentChangedCommand<T> originalContentChangedCommand)
       {
-         _newPkSimModuleState = newPKSimModuleState._oldPKSimModuleState;
+         _newPkSimModuleState = originalContentChangedCommand._oldPKSimModuleState;
       }
    }
 }

--- a/src/MoBi.Core/Commands/ModuleContentChangedCommand.cs
+++ b/src/MoBi.Core/Commands/ModuleContentChangedCommand.cs
@@ -6,18 +6,33 @@ using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Core.Commands
 {
-   public abstract class ModuleContentChangedCommand<T> : MoBiReversibleCommand where T : class, IBuildingBlock
+   public abstract class ModuleContentChangedCommand<T> : MoBiReversibleCommand, IWillConvertPKSimModuleToExtensionModule where T : class, IBuildingBlock
    {
       protected Module _existingModule;
       private readonly string _existingModuleId;
       protected T _buildingBlock;
+      protected bool _newPkSimModuleState;
+      private readonly bool _oldPKSimModuleState;
 
       protected ModuleContentChangedCommand(T buildingBlock, Module existingModule)
       {
          _existingModule = existingModule;
          _existingModuleId = existingModule.Id;
          _buildingBlock = buildingBlock;
+         _oldPKSimModuleState = _existingModule.IsPKSimModule;
+         _newPkSimModuleState = false;
       }
+
+      protected override void ExecuteWith(IMoBiContext context)
+      {
+         DoExecute(context);
+         SetPKSimModuleState();
+         RaiseEvents(context);
+      }
+
+      protected abstract void RaiseEvents(IMoBiContext context);
+
+      protected abstract void DoExecute(IMoBiContext context);
 
       public override void RestoreExecutionData(IMoBiContext context)
       {
@@ -34,6 +49,19 @@ namespace MoBi.Core.Commands
       {
          _buildingBlock = null;
          _existingModule = null;
+      }
+
+      public bool WillConvertPKSimModuleToExtensionModule => Module.IsPKSimModule;
+      public Module Module => _existingModule;
+
+      protected void SetPKSimModuleState()
+      {
+         _existingModule.IsPKSimModule = _newPkSimModuleState;
+      }
+
+      public void WithNewPKSimModuleStateFrom(ModuleContentChangedCommand<T> newPKSimModuleState)
+      {
+         _newPkSimModuleState = newPKSimModuleState._oldPKSimModuleState;
       }
    }
 }

--- a/src/MoBi.Core/Commands/RemoveBuildingBlockFromModuleCommand.cs
+++ b/src/MoBi.Core/Commands/RemoveBuildingBlockFromModuleCommand.cs
@@ -23,23 +23,16 @@ namespace MoBi.Core.Commands
          Description = AppConstants.Commands.RemoveFromDescription(ObjectType, buildingBlock.Name, _existingModule.Name);
       }
 
-      protected override void ExecuteWith(IMoBiContext context)
-      {
-         DoExecute(context);
-         RaiseEvents(context);
-      }
-
-      protected virtual void RaiseEvents(IMoBiContext context)
+      protected override void RaiseEvents(IMoBiContext context)
       {
          context.PublishEvent(new RemovedEvent(_buildingBlock, _existingModule));
       }
 
-      protected virtual void DoExecute(IMoBiContext context)
+      protected override void DoExecute(IMoBiContext context)
       {
          removeBuildingBlockFromModule();
          context.Unregister(_buildingBlock);
          _serializationStream = context.Serialize(_buildingBlock);
-         
          PublishSimulationStatusChangedEvents(_existingModule, context);
       }
 
@@ -51,7 +44,7 @@ namespace MoBi.Core.Commands
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
       {
-         return new AddBuildingBlockToModuleCommand<IBuildingBlock>(_buildingBlock, _existingModule).AsInverseFor(this);
+         return new AddBuildingBlockToModuleCommand<T>(_buildingBlock, _existingModule).AsInverseFor(this);
       }
 
       private void removeBuildingBlockFromModule()

--- a/src/MoBi.Core/Domain/Model/MoBiContext.cs
+++ b/src/MoBi.Core/Domain/Model/MoBiContext.cs
@@ -272,7 +272,7 @@ namespace MoBi.Core.Domain.Model
          if(command is IMacroCommand macroCommand)
             macroCommand.All().Each(x => promptForCancellation(x, confirmedModuleConversions));
 
-         if (!(command is BuildingBlockChangeCommandBase changeCommand))
+         if (!(command is IWillConvertPKSimModuleToExtensionModule changeCommand))
             return;
 
          if (!changeCommand.WillConvertPKSimModuleToExtensionModule)

--- a/src/MoBi.Core/Services/BuildingBlockVersionUpdater.cs
+++ b/src/MoBi.Core/Services/BuildingBlockVersionUpdater.cs
@@ -49,7 +49,7 @@ namespace MoBi.Core.Services
       }
 
       private bool shouldConvertToExtensionModule(IBuildingBlock buildingBlock, PKSimModuleConversion conversionOption) =>
-         (buildingBlock.IsPkSimModule()) && conversionOption == PKSimModuleConversion.SetAsExtensionModule;
+         buildingBlock.IsPkSimModule() && conversionOption == PKSimModuleConversion.SetAsExtensionModule;
 
       private bool shouldConvertToPKSimModule(IBuildingBlock buildingBlock, PKSimModuleConversion conversionOption) =>
          buildingBlock.Module != null && conversionOption == PKSimModuleConversion.SetAsPKSimModule;

--- a/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
@@ -382,10 +382,10 @@ namespace MoBi.Presentation.Presenter.Main
          }
       }
 
-      private void removeFolderNode(ITreeNode initialConditionsFolderNode)
+      private void removeFolderNode(ITreeNode folderNode)
       {
-         RemoveNode(initialConditionsFolderNode);
-         initialConditionsFolderNode.ParentNode.RemoveChild(initialConditionsFolderNode);
+         RemoveNode(folderNode);
+         folderNode.ParentNode.RemoveChild(folderNode);
       }
 
       public void Handle(RemovedEvent eventToHandle)

--- a/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
@@ -369,17 +369,23 @@ namespace MoBi.Presentation.Presenter.Main
          {
             case InitialConditionsFolderNode initialConditionsFolderNode:
             {
-               if (!initialConditionsFolderNode.HasChildren)
-                  RemoveNode(initialConditionsFolderNode);
+               if (!initialConditionsFolderNode.HasChildren) 
+                  removeFolderNode(initialConditionsFolderNode);
                break;
             }
             case ParameterValuesFolderNode parameterValuesFolderNode:
             {
                if (!parameterValuesFolderNode.HasChildren)
-                  RemoveNode(parameterValuesFolderNode);
+                  removeFolderNode(parameterValuesFolderNode);
                break;
             }
          }
+      }
+
+      private void removeFolderNode(ITreeNode initialConditionsFolderNode)
+      {
+         RemoveNode(initialConditionsFolderNode);
+         initialConditionsFolderNode.ParentNode.RemoveChild(initialConditionsFolderNode);
       }
 
       public void Handle(RemovedEvent eventToHandle)

--- a/tests/MoBi.Tests/Core/Commands/AddBuildingBlockToModuleCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/AddBuildingBlockToModuleCommandSpecs.cs
@@ -22,6 +22,7 @@ namespace MoBi.Core.Commands
          _affectedSimulation.Configuration = new SimulationConfiguration();
          _project = new MoBiProject();
          _existingModule = new Module().WithId("existingModuleId");
+         _existingModule.IsPKSimModule = true;
          _affectedSimulation.Configuration.AddModuleConfiguration(new ModuleConfiguration(_existingModule));
          _context = A.Fake<IMoBiContext>();
          _project.AddSimulation(_affectedSimulation);
@@ -62,6 +63,12 @@ namespace MoBi.Core.Commands
       }
 
       [Observation]
+      public void the_module_should_not_be_pksim_module()
+      {
+         _existingModule.IsPKSimModule.ShouldBeFalse();
+      }
+
+      [Observation]
       public void event_to_refresh_simulation_should_be_published()
       {
          A.CallTo(() => _context.PublishEvent(A<SimulationStatusChangedEvent>.That.Matches(x => x.Simulation.Equals(_affectedSimulation)))).MustHaveHappened(1, Times.Exactly);
@@ -92,6 +99,12 @@ namespace MoBi.Core.Commands
       public void event_to_refresh_simulation_should_be_published()
       {
          A.CallTo(() => _context.PublishEvent(A<SimulationStatusChangedEvent>.That.Matches(x => x.Simulation.Equals(_affectedSimulation)))).MustHaveHappened(2, Times.Exactly);
+      }
+
+      [Observation]
+      public void the_module_should_be_pksim_module()
+      {
+         _existingModule.IsPKSimModule.ShouldBeTrue();
       }
    }
 }

--- a/tests/MoBi.Tests/Core/Commands/MoveBuildingBlockToModuleCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/MoveBuildingBlockToModuleCommandSpecs.cs
@@ -28,6 +28,10 @@ namespace MoBi.Core.Commands
          
          _withIdRepository = new WithIdRepository();
          _registrationTask = new RegisterTask(_withIdRepository);
+
+         _targetModule.IsPKSimModule = true;
+         _sourceModule.IsPKSimModule = true;
+
          sut = new MoveBuildingBlockToModuleCommand(_newReactionBuildingBlock, _targetModule);
          _project = new MoBiProject();
          _context = A.Fake<IMoBiContext>();
@@ -35,6 +39,8 @@ namespace MoBi.Core.Commands
 
          _targetModule.Add(new SpatialStructure().WithId("SpatialStructure"));
          _targetModule.Add(new MoleculeBuildingBlock().WithId("Molecule"));
+
+
       }
    }
 
@@ -50,6 +56,13 @@ namespace MoBi.Core.Commands
       {
          _targetModule.Reactions.ShouldBeEqualTo(_newReactionBuildingBlock);
          _sourceModule.Reactions.ShouldBeNull();
+      }
+
+      [Observation]
+      public void the_module_should_not_be_pksim_module()
+      {
+         _targetModule.IsPKSimModule.ShouldBeFalse();
+         _sourceModule.IsPKSimModule.ShouldBeFalse();
       }
    }
    
@@ -74,6 +87,13 @@ namespace MoBi.Core.Commands
       {
          _targetModule.Reactions.ShouldBeNull();
          _sourceModule.Reactions.ShouldBeEqualTo(_newReactionBuildingBlock);
+      }
+
+      [Observation]
+      public void the_module_should_be_pksim_module()
+      {
+         _sourceModule.IsPKSimModule.ShouldBeTrue();
+         _targetModule.IsPKSimModule.ShouldBeTrue();
       }
    }
 }

--- a/tests/MoBi.Tests/Core/Commands/RemoveBuildingBlockFromModuleCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/RemoveBuildingBlockFromModuleCommandSpecs.cs
@@ -17,7 +17,10 @@ namespace MoBi.Core.Commands
       protected override void Context()
       {
          _context = A.Fake<IMoBiContext>();
-         _existingModule = new Module();
+         _existingModule = new Module
+         {
+            IsPKSimModule = true
+         };
          _bb = new SpatialStructure().WithId("newSpatialStructureBuildingBlockId");
          sut = new RemoveBuildingBlockFromModuleCommand<IBuildingBlock>(_bb, _existingModule);
       }
@@ -48,6 +51,12 @@ namespace MoBi.Core.Commands
       {
          _existingModule.BuildingBlocks.ShouldContain(_deserializedBB);
       }
+
+      [Observation]
+      public void the_module_should_be_pksim_module()
+      {
+         _existingModule.IsPKSimModule.ShouldBeTrue();
+      }
    }
 
    internal class When_removing_spatial_structure_from_module : concern_for_RemoveBuildingBlockFromModuleCommand
@@ -66,6 +75,12 @@ namespace MoBi.Core.Commands
       protected override void Because()
       {
          sut.Execute(_context);
+      }
+
+      [Observation]
+      public void the_module_should_not_be_pksim_module()
+      {
+         _existingModule.IsPKSimModule.ShouldBeFalse();
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #1659

# Description


## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):