### PR TITLE
Fixes #1633 changed scale divisors are not reflected in the traffic lights of simulation

### DIFF
--- a/src/MoBi.Core/Commands/SetQuantityPropertyInSimulationCommandBase.cs
+++ b/src/MoBi.Core/Commands/SetQuantityPropertyInSimulationCommandBase.cs
@@ -24,7 +24,7 @@ namespace MoBi.Core.Commands
       protected override void ExecuteWith(IMoBiContext context)
       {
          var changeTracker = context.Resolve<IQuantityValueInSimulationChangeTracker>();
-         changeTracker.TrackChanges(_quantity, _simulation, x => base.ExecuteWith(context));
+         changeTracker.TrackQuantityChange(_quantity, _simulation, x => base.ExecuteWith(context));
       }
 
       protected override void ClearReferences()

--- a/src/MoBi.Core/Commands/UpdateMoleculeAmountScaleDivisorsInSimulationCommand.cs
+++ b/src/MoBi.Core/Commands/UpdateMoleculeAmountScaleDivisorsInSimulationCommand.cs
@@ -5,6 +5,7 @@ using MoBi.Core.Domain.Model;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Assets;
+using MoBi.Core.Services;
 
 namespace MoBi.Core.Commands
 {
@@ -32,7 +33,8 @@ namespace MoBi.Core.Commands
       {
          var containerTask = context.Resolve<IContainerTask>();
          var allMoleculeAmounts = containerTask.CacheAllChildren<MoleculeAmount>(_simulation.Model.Root);
-
+         var changeTracker = context.Resolve<IQuantityValueInSimulationChangeTracker>();
+         
          foreach (var scaleDivisor in _scaleFactors)
          {
             var moleculeAmount = allMoleculeAmounts[scaleDivisor.QuantityPath];
@@ -42,7 +44,7 @@ namespace MoBi.Core.Commands
                continue;
 
             _oldScaleFactors.Add(new ScaleDivisor { QuantityPath = scaleDivisor.QuantityPath, Value = moleculeAmount.ScaleDivisor });
-            moleculeAmount.ScaleDivisor = scaleDivisor.Value;
+            changeTracker.TrackScaleChange(moleculeAmount, _simulation, x => x.ScaleDivisor = scaleDivisor.Value);
          }
       }
 

--- a/src/MoBi.Core/Commands/UpdateSimulationCommand.cs
+++ b/src/MoBi.Core/Commands/UpdateSimulationCommand.cs
@@ -80,7 +80,7 @@ namespace MoBi.Core.Commands
          _simulationToUpdate.HasChanged = _hasChanged;
 
          // We need ToList since we are modifying the collection in the loop
-         _simulationToUpdate.OriginalQuantityValues.ToList().Each(x => _simulationToUpdate.RemoveOriginalQuantityValue(x.Path));
+         _simulationToUpdate.OriginalQuantityValues.ToList().Each(x => _simulationToUpdate.RemoveOriginalQuantityValue(x));
          
          context.PublishEvent(new SimulationReloadEvent(_simulationToUpdate));
       }

--- a/src/MoBi.Core/Domain/Model/MoBiSimulation.cs
+++ b/src/MoBi.Core/Domain/Model/MoBiSimulation.cs
@@ -52,13 +52,13 @@ namespace MoBi.Core.Domain.Model
 
       /// <summary>
       ///    Adds an original quantity value so that changes to quantities in the simulation can be tracked.
-      ///    There can only be one original quantity value So, adding a second <paramref name="parameterValue" />
+      ///    There can only be one original quantity value per path, adding a second <paramref name="quantityValue" />
       ///    with identical path has no affect
       /// </summary>
-      void AddOriginalQuantityValue(OriginalQuantityValue parameterValue);
+      void AddOriginalQuantityValue(OriginalQuantityValue quantityValue);
 
-      void RemoveOriginalQuantityValue(string objectPath);
-      OriginalQuantityValue OriginalQuantityValueFor(string objectPath);
+      void RemoveOriginalQuantityValue(OriginalQuantityValue quantityValue);
+      OriginalQuantityValue OriginalQuantityValueFor(OriginalQuantityValue quantityValue);
       void ClearOriginalQuantities();
    }
 
@@ -127,17 +127,17 @@ namespace MoBi.Core.Domain.Model
 
       public IReadOnlyCollection<OriginalQuantityValue> OriginalQuantityValues => _quantityValueCache;
 
-      public void AddOriginalQuantityValue(OriginalQuantityValue parameterValue)
+      public void AddOriginalQuantityValue(OriginalQuantityValue quantityValue)
       {
-         // if there's already a value set for this path, then ignore the add
+         // if there's already a value set for this path and type, then ignore the add
          // we only store the first instance for a path
-         if (_quantityValueCache[parameterValue.Path] == null)
-            _quantityValueCache[parameterValue.Path] = parameterValue;
+         if (_quantityValueCache[quantityValue.Id] == null)
+            _quantityValueCache[quantityValue.Id] = quantityValue;
       }
 
-      public void RemoveOriginalQuantityValue(string objectPath) => _quantityValueCache.Remove(objectPath);
+      public void RemoveOriginalQuantityValue(OriginalQuantityValue quantityValue) => _quantityValueCache.Remove(quantityValue.Id);
 
-      public OriginalQuantityValue OriginalQuantityValueFor(string objectPath) => _quantityValueCache[objectPath];
+      public OriginalQuantityValue OriginalQuantityValueFor(OriginalQuantityValue quantityValue) => _quantityValueCache[quantityValue.Id];
 
       public void ClearOriginalQuantities()
       {

--- a/src/MoBi.Core/Domain/OriginalQuantityValue.cs
+++ b/src/MoBi.Core/Domain/OriginalQuantityValue.cs
@@ -1,16 +1,28 @@
-﻿using OSPSuite.Core.Domain;
+﻿using System.Linq;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.UnitSystem;
+using OSPSuite.Core.Extensions;
 
 namespace MoBi.Core.Domain
 {
    public class OriginalQuantityValue : IWithValueOrigin, IWithDisplayUnit
    {
+      public enum Types
+      {
+         Quantity,
+         ScaleDivisor
+      }
+
       public string Path { get; set; }
       public double Value { get; set; }
       public ValueOrigin ValueOrigin { get; } = new ValueOrigin();
       public Unit DisplayUnit { get; set; }
       public IDimension Dimension { get; set; }
-      
+      public Types Type { get; set; }
+      public string Id => new ObjectPath(Path.ToPathArray().Append(Type.ToString()));
+      public bool IsQuantityChange => Type == Types.Quantity;
+      public bool IsScaleChange => Type == Types.ScaleDivisor;
+
       public OriginalQuantityValue WithPropertiesFrom(OriginalQuantityValue sourceOriginalQuantityValue)
       {
          Path = sourceOriginalQuantityValue.Path;
@@ -18,6 +30,7 @@ namespace MoBi.Core.Domain
          ValueOrigin.UpdateFrom(sourceOriginalQuantityValue.ValueOrigin);
          DisplayUnit = sourceOriginalQuantityValue.DisplayUnit;
          Dimension = sourceOriginalQuantityValue.Dimension;
+         Type = sourceOriginalQuantityValue.Type;
          return this;
       }
 

--- a/src/MoBi.Core/Serialization/Xml/Serializer/OriginalQuantityValueXmlSerializer.cs
+++ b/src/MoBi.Core/Serialization/Xml/Serializer/OriginalQuantityValueXmlSerializer.cs
@@ -14,6 +14,7 @@ namespace MoBi.Core.Serialization.Xml.Serializer
          Map(x => x.Value);
          Map(x => x.ValueOrigin);
          Map(x => x.Dimension);
+         Map(x => x.Type);
       }
 
       protected override void TypedDeserialize(OriginalQuantityValue originalQuantityValue, XElement element, SerializationContext serializationContext)

--- a/src/MoBi.Core/Services/QuantityToOriginalQuantityValueMapper.cs
+++ b/src/MoBi.Core/Services/QuantityToOriginalQuantityValueMapper.cs
@@ -5,7 +5,7 @@ using OSPSuite.Utility;
 
 namespace MoBi.Core.Services
 {
-   public interface IQuantityToOriginalQuantityValueMapper : IMapper<IQuantity, OriginalQuantityValue>
+   public interface IQuantityToOriginalQuantityValueMapper : IMapper<IQuantity, OriginalQuantityValue>, IMapper<MoleculeAmount, OriginalQuantityValue>
    {
    }
    
@@ -20,16 +20,29 @@ namespace MoBi.Core.Services
 
       public OriginalQuantityValue MapFrom(IQuantity quantity)
       {
-         var parameterValue = new OriginalQuantityValue
+         var quantityValue = new OriginalQuantityValue
          {
             Path = _entityPathResolver.ObjectPathFor(quantity),
             Value = quantity.Value,
             Dimension = quantity.Dimension,
-            DisplayUnit = quantity.DisplayUnit
+            DisplayUnit = quantity.DisplayUnit,
+            Type = OriginalQuantityValue.Types.Quantity
          };
 
-         parameterValue.UpdateValueOriginFrom(quantity.ValueOrigin);
-         return parameterValue;
+         quantityValue.UpdateValueOriginFrom(quantity.ValueOrigin);
+         return quantityValue;
+      }
+
+      public OriginalQuantityValue MapFrom(MoleculeAmount moleculeAmount)
+      {
+         return new OriginalQuantityValue
+         {
+            Value = moleculeAmount.ScaleDivisor,
+            Path = _entityPathResolver.ObjectPathFor(moleculeAmount),
+            Type = OriginalQuantityValue.Types.ScaleDivisor,
+            Dimension = Constants.Dimension.NO_DIMENSION,
+            DisplayUnit = Constants.Dimension.NO_DIMENSION.DefaultUnit
+         };
       }
    }
 }

--- a/src/MoBi.Presentation/DTO/OriginalQuantityValueDTO.cs
+++ b/src/MoBi.Presentation/DTO/OriginalQuantityValueDTO.cs
@@ -1,33 +1,28 @@
 ﻿using MoBi.Core.Domain;
-using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.UnitSystem;
+using OSPSuite.Core.Extensions;
 
 namespace MoBi.Presentation.DTO
 {
    public class OriginalQuantityValueDTO
    {
-      public OriginalQuantityValueDTO(OriginalQuantityValue originalQuantityValue)
+      public OriginalQuantityValueDTO(OriginalQuantityValue originalQuantityValue, double currentBaseValue)
       {
          Dimension = originalQuantityValue.Dimension;
          Path = originalQuantityValue.Path;
          OriginalValue = Dimension.BaseUnitValueToUnitValue(originalQuantityValue.DisplayUnit, originalQuantityValue.Value);
-         OriginalDisplayUnit = originalQuantityValue.DisplayUnit;
+         DisplayUnit = originalQuantityValue.DisplayUnit;
+         Type = originalQuantityValue.Type.ToString().SplitToUpperCase();
+         CurrentValue = Dimension.BaseUnitValueToUnitValue(DisplayUnit, currentBaseValue);
       }
 
+      public string Type { get; private set; }
       public string Path { get; private set; }
       public IDimension Dimension {  get; set;}
 
       public double? CurrentValue { get; private set; }
-      public Unit CurrentDisplayUnit { get; private set; }
 
-      public Unit OriginalDisplayUnit { get; set; }
+      public Unit DisplayUnit { get; set; }
       public double? OriginalValue { get; private set; }
-
-      public OriginalQuantityValueDTO WithCurrentQuantity(IQuantity quantity)
-      {
-         CurrentValue = Dimension.BaseUnitValueToUnitValue(quantity.DisplayUnit, quantity.Value);
-         CurrentDisplayUnit = quantity.DisplayUnit;
-         return this;
-      }
    }
 }

--- a/src/MoBi.Presentation/Serialization/Xml/Serializer/MoBiXmlSerializerRepository.cs
+++ b/src/MoBi.Presentation/Serialization/Xml/Serializer/MoBiXmlSerializerRepository.cs
@@ -1,3 +1,4 @@
+using MoBi.Core.Domain;
 using MoBi.Core.Serialization.Xml.Services;
 using OSPSuite.Core.Diagram;
 using OSPSuite.Core.Domain;
@@ -52,6 +53,7 @@ namespace MoBi.Presentation.Serialization.Xml.Serializer
          base.AddInitialMappers();
          AttributeMapperRepository.AddAttributeMapper(new EnumAttributeMapper<NodeSize, SerializationContext>());
          AttributeMapperRepository.AddAttributeMapper(new EnumAttributeMapper<NotificationType, SerializationContext>());
+         AttributeMapperRepository.AddAttributeMapper(new EnumAttributeMapper<OriginalQuantityValue.Types, SerializationContext>());
       }
    }
 }

--- a/src/MoBi.UI/Views/SimulationChangesView.cs
+++ b/src/MoBi.UI/Views/SimulationChangesView.cs
@@ -39,8 +39,9 @@ namespace MoBi.UI.Views
       public override void InitializeBinding()
       {
          _gridViewBinder.Bind(x => x.Path).AsReadOnly();
-         _originalValueColumn = _gridViewBinder.Bind(x => x.OriginalValue).WithFormat(dto => dto.OriginalQuantityValueFormatter(x => x.OriginalDisplayUnit)).WithCaption(AppConstants.Captions.OriginalValue).AsReadOnly();
-         _currentValueColumn = _gridViewBinder.Bind(x => x.CurrentValue).WithFormat(dto => dto.OriginalQuantityValueFormatter(x => x.CurrentDisplayUnit)).WithCaption(AppConstants.Captions.CurrentValue).AsReadOnly();
+         _gridViewBinder.Bind(x => x.Type).AsReadOnly();
+         _originalValueColumn = _gridViewBinder.Bind(x => x.OriginalValue).WithFormat(dto => dto.OriginalQuantityValueFormatter(x => x.DisplayUnit)).WithCaption(AppConstants.Captions.OriginalValue).AsReadOnly();
+         _currentValueColumn = _gridViewBinder.Bind(x => x.CurrentValue).WithFormat(dto => dto.OriginalQuantityValueFormatter(x => x.DisplayUnit)).WithCaption(AppConstants.Captions.CurrentValue).AsReadOnly();
          _gridViewBinder.Bind(x => x.Dimension).AsReadOnly();
       }
 

--- a/tests/MoBi.Tests/Helpers/DomainHelperForSpecs.cs
+++ b/tests/MoBi.Tests/Helpers/DomainHelperForSpecs.cs
@@ -31,24 +31,24 @@ namespace MoBi.Helpers
          return Path.Combine(dataFolder, fileName);
       }
 
-      public static IDimension AmountDimension { get; } = new Dimension(new BaseDimensionRepresentation {AmountExponent = 1}, Constants.Dimension.MOLAR_AMOUNT, "µmol");
+      public static IDimension AmountDimension { get; } = new Dimension(new BaseDimensionRepresentation { AmountExponent = 1 }, Constants.Dimension.MOLAR_AMOUNT, "µmol");
 
-      public static ParameterValue ParameterValue { get; } = new ParameterValue {Name = "_name", Value = 1.0, Formula = null, Dimension = AmountDimension};
+      public static ParameterValue ParameterValue { get; } = new ParameterValue { Name = "_name", Value = 1.0, Formula = null, Dimension = AmountDimension };
 
-      public static IDimension ConcentrationDimension { get; } = new Dimension(new BaseDimensionRepresentation {LengthExponent = -3, MassExponent = 1, TimeExponent = -1}, Constants.Dimension.MOLAR_CONCENTRATION, "µmol/l");
+      public static IDimension ConcentrationDimension { get; } = new Dimension(new BaseDimensionRepresentation { LengthExponent = -3, MassExponent = 1, TimeExponent = -1 }, Constants.Dimension.MOLAR_CONCENTRATION, "µmol/l");
 
       public static IDimension FractionDimension { get; } = new Dimension(new BaseDimensionRepresentation(), Constants.Dimension.FRACTION, "");
 
-      public static IDimension ConcentrationPerTimeDimension { get; } = new Dimension(new BaseDimensionRepresentation {LengthExponent = -3, AmountExponent = 1, TimeExponent = -1}, Constants.Dimension.MOLAR_CONCENTRATION_PER_TIME, "µmol/l/min");
+      public static IDimension ConcentrationPerTimeDimension { get; } = new Dimension(new BaseDimensionRepresentation { LengthExponent = -3, AmountExponent = 1, TimeExponent = -1 }, Constants.Dimension.MOLAR_CONCENTRATION_PER_TIME, "µmol/l/min");
 
-      public static IDimension AmountPerTimeDimension { get; } = new Dimension(new BaseDimensionRepresentation {AmountExponent = 1, TimeExponent = -1}, Constants.Dimension.AMOUNT_PER_TIME, "µmol/min");
+      public static IDimension AmountPerTimeDimension { get; } = new Dimension(new BaseDimensionRepresentation { AmountExponent = 1, TimeExponent = -1 }, Constants.Dimension.AMOUNT_PER_TIME, "µmol/min");
 
-      public static IDimension TimeDimension { get; } = new Dimension(new BaseDimensionRepresentation {TimeExponent = 1}, Constants.Dimension.TIME, "min");
+      public static IDimension TimeDimension { get; } = new Dimension(new BaseDimensionRepresentation { TimeExponent = 1 }, Constants.Dimension.TIME, "min");
 
-      public static IQuantityValueInSimulationChangeTracker QuantityValueChangeTracker(IEventPublisher eventPublisher)
+      public static QuantityValueInSimulationChangeTracker QuantityValueChangeTracker(IEventPublisher eventPublisher)
       {
          var entityPathResolver = new EntityPathResolver(new ObjectPathFactoryForSpecs());
-         return new QuantityValueInSimulationChangeTracker(new QuantityToOriginalQuantityValueMapper(entityPathResolver), eventPublisher, entityPathResolver);
+         return new QuantityValueInSimulationChangeTracker(new QuantityToOriginalQuantityValueMapper(entityPathResolver), eventPublisher);
       }
 
       public static DataRepository ObservedData(string id = "TestData", IDimension timeDimension = null, IDimension concentrationDimension = null, string obsDataColumnName = null)
@@ -56,7 +56,7 @@ namespace MoBi.Helpers
          var observedData = new DataRepository(id).WithName(id);
          var baseGrid = new BaseGrid("Time", timeDimension ?? TimeDimension)
          {
-            Values = new[] {1.0f, 2.0f, 3.0f}
+            Values = new[] { 1.0f, 2.0f, 3.0f }
          };
          observedData.Add(baseGrid);
 
@@ -70,8 +70,8 @@ namespace MoBi.Helpers
       {
          var data = new DataColumn(obsDataColumnName ?? "Col", concentrationDimension ?? ConcentrationDimension, baseGrid)
          {
-            Values = new[] {10f, 20f, 30f},
-            DataInfo = {Origin = ColumnOrigins.Observation}
+            Values = new[] { 10f, 20f, 30f },
+            DataInfo = { Origin = ColumnOrigins.Observation }
          };
          return data;
       }
@@ -91,7 +91,7 @@ namespace MoBi.Helpers
 
       public static MoBiProject NewProject()
       {
-         return new MoBiProject {SimulationSettings = new SimulationSettings()};
+         return new MoBiProject { SimulationSettings = new SimulationSettings() };
       }
    }
 


### PR DESCRIPTION
Fixes #1633

# Description
Tracking changes was limited to quantity changes, but this adds scale factor changes to that and allows users to commit the scale factor changes back to a module.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):