### PR TITLE
Fixes #1679 v12: "Rename related entities" always applied for neighborhoods?

### DIFF
--- a/tests/MoBi.Tests/Core/Commands/RenameContainerCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/RenameContainerCommandSpecs.cs
@@ -93,13 +93,6 @@ namespace MoBi.Core.Commands
       }
 
       [Observation]
-      public void should_rename_the_path_in_the_neighborhoods_not_referencing_this_container()
-      {
-         _neighborhood1.FirstNeighborPath.PathAsString.ShouldBeEqualTo("A|NEW_NAME|A");
-         _neighborhood1.SecondNeighborPath.PathAsString.ShouldBeEqualTo("A|NEW_NAME|B");
-      }
-
-      [Observation]
       public void should_not_rename_the_path_in_the_neighborhoods_not_referencing_this_container()
       {
          _neighborhood2.FirstNeighborPath.PathAsString.ShouldBeEqualTo("A|B|A");


### PR DESCRIPTION
Fixes #1679

# Description
There are now separate commands to change the related neighborhood paths that the user can select when renaming a container. The neighborhood paths should not be updated by the container rename command now.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):