### PR TITLE
Fixes #1653 "Convert to extension module" prompt comes 2 times

### DIFF
--- a/src/MoBi.Core/Domain/Model/MoBiContext.cs
+++ b/src/MoBi.Core/Domain/Model/MoBiContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Services;
@@ -276,6 +277,9 @@ namespace MoBi.Core.Domain.Model
             return;
 
          if (!changeCommand.WillConvertPKSimModuleToExtensionModule)
+            return;
+
+         if (!CurrentProject.Modules.Contains(changeCommand.Module))
             return;
 
          if (confirmedModuleConversions.Contains(changeCommand.Module))

--- a/tests/MoBi.Tests/Core/MoBiContextSpecs.cs
+++ b/tests/MoBi.Tests/Core/MoBiContextSpecs.cs
@@ -266,6 +266,7 @@ namespace MoBi.Core
       protected override void Context()
       {
          base.Context();
+         sut.CurrentProject = new MoBiProject();
          _command = new MoBiMacroCommand();
          _parameterValue = new ParameterValue();
          _buildingBlock = new ParameterValuesBuildingBlock();
@@ -274,6 +275,7 @@ namespace MoBi.Core
             IsPKSimModule = true
          };
          _module.Add(_buildingBlock);
+         sut.CurrentProject.AddModule(_module);
          _command.Add(new AddParameterValueToBuildingBlockCommand(_buildingBlock, _parameterValue));
          _command.Add(new AddParameterValueToBuildingBlockCommand(_buildingBlock, _parameterValue));
          A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).Returns(ViewResult.Yes);
@@ -327,12 +329,14 @@ namespace MoBi.Core
       {
          base.Context();
          _command = new MoBiMacroCommand();
+         sut.CurrentProject = new MoBiProject();
          _parameterValue = new ParameterValue();
          _buildingBlock = new ParameterValuesBuildingBlock();
          _module = new Module
          {
             IsPKSimModule = true
          };
+         sut.CurrentProject.AddModule(_module);
          _module.Add(_buildingBlock);
          _command.Add(new AddParameterValueToBuildingBlockCommand(_buildingBlock, _parameterValue));
          A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).Returns(ViewResult.No);
@@ -361,6 +365,41 @@ namespace MoBi.Core
          _module = new Module
          {
             IsPKSimModule = false
+         };
+         _module.Add(_buildingBlock);
+         _command.Add(new AddParameterValueToBuildingBlockCommand(_buildingBlock, _parameterValue));
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).Returns(ViewResult.Yes);
+      }
+
+      protected override void Because()
+      {
+         sut.PromptForCancellation(_command);
+      }
+
+      [Observation]
+      public void the_user_should_not_be_prompted()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).MustNotHaveHappened();
+      }
+   }
+
+   public class When_running_module_commands_that_converts_a_module_not_in_the_project : concern_for_MoBiContext
+   {
+      private MoBiMacroCommand _command;
+      private ParameterValue _parameterValue;
+      private ParameterValuesBuildingBlock _buildingBlock;
+      private Module _module;
+
+      protected override void Context()
+      {
+         base.Context();
+         _command = new MoBiMacroCommand();
+         sut.CurrentProject = new MoBiProject();
+         _parameterValue = new ParameterValue();
+         _buildingBlock = new ParameterValuesBuildingBlock();
+         _module = new Module
+         {
+            IsPKSimModule = true
          };
          _module.Add(_buildingBlock);
          _command.Add(new AddParameterValueToBuildingBlockCommand(_buildingBlock, _parameterValue));


### PR DESCRIPTION
Fixes #1653

# Description
For modules not contained by the project, a prompt will not be shown when a command is used to modify them. This is probably only the case when we are adding/removing ic/pv during commit/update operations

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):