### PR TITLE
#1619 Creation of reference path for passive is not woring as expected

### DIFF
--- a/src/MoBi.Presentation/Presenter/ObjectPathCreatorAtTransport.cs
+++ b/src/MoBi.Presentation/Presenter/ObjectPathCreatorAtTransport.cs
@@ -46,10 +46,12 @@ namespace MoBi.Presentation.Presenter
             return dto;
          }
 
-         return new ReferenceDTO
+         var newDto = new ReferenceDTO
          {
             Path = CreateFormulaUsablePathFrom(new[] { firstPathElement, dtoDummyParameter.ModelParentName, dtoDummyParameter.Name }, dtoDummyParameter.Parameter)
          };
+         newDto.Path.Replace(dtoDummyParameter.ModelParentName, ObjectPathKeywords.MOLECULE);
+         return newDto;
       }
 
       public override ReferenceDTO CreateMoleculePath(DummyMoleculeContainerDTO dtoObjectBase, bool shouldCreateAbsolutePaths, IEntity refObject)

--- a/src/MoBi.Presentation/Presenter/ObjectPathCreatorAtTransport.cs
+++ b/src/MoBi.Presentation/Presenter/ObjectPathCreatorAtTransport.cs
@@ -67,7 +67,7 @@ namespace MoBi.Presentation.Presenter
 
          return new ReferenceDTO
          {
-            Path = CreateFormulaUsablePathFrom(new[] { firstPathElemnt, dtoObjectBase.Name }, AppConstants.AmountAlias, Constants.Dimension.MOLAR_AMOUNT)
+            Path = CreateFormulaUsablePathFrom(new[] { firstPathElemnt, ObjectPathKeywords.MOLECULE }, AppConstants.AmountAlias, Constants.Dimension.MOLAR_AMOUNT)
          };
       }
 

--- a/src/MoBi.Presentation/Presenter/ObjectPathCreatorAtTransport.cs
+++ b/src/MoBi.Presentation/Presenter/ObjectPathCreatorAtTransport.cs
@@ -46,12 +46,10 @@ namespace MoBi.Presentation.Presenter
             return dto;
          }
 
-         var newDto = new ReferenceDTO
+         return new ReferenceDTO
          {
-            Path = CreateFormulaUsablePathFrom(new[] { firstPathElement, dtoDummyParameter.ModelParentName, dtoDummyParameter.Name }, dtoDummyParameter.Parameter)
+            Path = CreateFormulaUsablePathFrom(new[] { firstPathElement, ObjectPathKeywords.MOLECULE, dtoDummyParameter.Name }, dtoDummyParameter.Parameter)
          };
-         newDto.Path.Replace(dtoDummyParameter.ModelParentName, ObjectPathKeywords.MOLECULE);
-         return newDto;
       }
 
       public override ReferenceDTO CreateMoleculePath(DummyMoleculeContainerDTO dtoObjectBase, bool shouldCreateAbsolutePaths, IEntity refObject)


### PR DESCRIPTION
Fixes #1619 

# Description

 Creation of reference path for passive is not woring as expected

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/a49a811a-5139-4d19-a1cf-33773175ceb5)

# Questions (if appropriate):