### PR TITLE
1678 v12 logical containers should not have moleculeproperties

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -303,7 +303,6 @@ namespace MoBi.Assets
             return message;
          }
 
-
          public static string DisplayValue(string displayValue, string displayUnit)
          {
             if (string.IsNullOrEmpty(displayUnit))

--- a/src/MoBi.Core/Commands/SetContainerModeCommand.cs
+++ b/src/MoBi.Core/Commands/SetContainerModeCommand.cs
@@ -1,4 +1,8 @@
-﻿using MoBi.Assets;
+﻿using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.Remoting.Contexts;
+using MoBi.Assets;
+using MoBi.Core.Domain.Extensions;
 using OSPSuite.Core.Commands.Core;
 using MoBi.Core.Domain.Model;
 using OSPSuite.Core.Domain;
@@ -30,6 +34,25 @@ namespace MoBi.Core.Commands
       {
          base.ExecuteWith(context);
          _container.Mode = _newContainerMode;
+         if (_container.Mode == ContainerMode.Logical)
+         {
+            var moleculeProperties = _container.Children
+               .OfType<IContainer>()
+               .Where(child => child.IsMoleculeProperties())
+               .ToList();
+
+            foreach (var item in moleculeProperties)
+            {
+               _container.RemoveChild(item);
+            }
+         }
+         else
+         {
+            var moleculeProperties = context.Create<IContainer>()
+               .WithName(Constants.MOLECULE_PROPERTIES)
+               .WithMode(ContainerMode.Logical);
+            _container.Add(moleculeProperties);
+         }
          Description = AppConstants.Commands.EditDescription(ObjectTypes.Container, AppConstants.Captions.ContainerMode, _oldContainerMode.ToString(), _newContainerMode.ToString(), _container.Name);
       }
 

--- a/src/MoBi.Core/Commands/SetContainerModeCommand.cs
+++ b/src/MoBi.Core/Commands/SetContainerModeCommand.cs
@@ -1,13 +1,9 @@
-﻿using System.Linq;
-using System.Runtime.InteropServices;
-using System.Runtime.Remoting.Contexts;
-using MoBi.Assets;
-using MoBi.Core.Domain.Extensions;
-using OSPSuite.Core.Commands.Core;
+﻿using MoBi.Assets;
 using MoBi.Core.Domain.Model;
+using OSPSuite.Assets;
+using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
-using OSPSuite.Assets;
 
 namespace MoBi.Core.Commands
 {
@@ -34,25 +30,6 @@ namespace MoBi.Core.Commands
       {
          base.ExecuteWith(context);
          _container.Mode = _newContainerMode;
-         if (_container.Mode == ContainerMode.Logical)
-         {
-            var moleculeProperties = _container.Children
-               .OfType<IContainer>()
-               .Where(child => child.IsMoleculeProperties())
-               .ToList();
-
-            foreach (var item in moleculeProperties)
-            {
-               _container.RemoveChild(item);
-            }
-         }
-         else
-         {
-            var moleculeProperties = context.Create<IContainer>()
-               .WithName(Constants.MOLECULE_PROPERTIES)
-               .WithMode(ContainerMode.Logical);
-            _container.Add(moleculeProperties);
-         }
          Description = AppConstants.Commands.EditDescription(ObjectTypes.Container, AppConstants.Captions.ContainerMode, _oldContainerMode.ToString(), _newContainerMode.ToString(), _container.Name);
       }
 

--- a/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
@@ -136,8 +136,8 @@ namespace MoBi.Presentation.Presenter
          {
             var moleculeProperties = _editTasks.GetMoleculeProperties(_container);
 
-            if (moleculeProperties.Any())
-               macroCommand.Add(new RemoveContainerFromSpatialStructureCommand(_container, moleculeProperties.FirstOrDefault(), (MoBiSpatialStructure)BuildingBlock).RunCommand(_context));
+            if (moleculeProperties!= null)
+               macroCommand.Add(new RemoveContainerFromSpatialStructureCommand(_container, moleculeProperties, (MoBiSpatialStructure)BuildingBlock).RunCommand(_context));
          }
          else
          {

--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskFor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain;
+using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
 using MoBi.Core.Extensions;
@@ -40,6 +41,8 @@ namespace MoBi.Presentation.Tasks.Edit
       bool EditEntityModal(T newEntity, IEnumerable<IObjectBase> existingObjectsInParent, ICommandCollector commandCollector, IBuildingBlock buildingBlock);
       string IconFor(IObjectBase objectBase);
       void SaveMultiple(IReadOnlyList<T> entitiesToSerialize);
+
+      List<IContainer> GetMoleculeProperties(IContainer container);
    }
 
    public abstract class EditTaskFor<T> : IEditTaskFor<T> where T : class, IObjectBase
@@ -216,5 +219,11 @@ namespace MoBi.Presentation.Tasks.Edit
             presenterWithFormulaCache.BuildingBlock = buildingBlock;
          }
       }
+
+      public List<IContainer> GetMoleculeProperties(IContainer container) =>
+         container?.Children
+            .OfType<IContainer>()
+            .Where(child => child.IsMoleculeProperties())
+            .ToList() ?? new List<IContainer>();
    }
 }

--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskFor.cs
@@ -42,7 +42,7 @@ namespace MoBi.Presentation.Tasks.Edit
       string IconFor(IObjectBase objectBase);
       void SaveMultiple(IReadOnlyList<T> entitiesToSerialize);
 
-      List<IContainer> GetMoleculeProperties(IContainer container);
+      IContainer GetMoleculeProperties(IContainer container);
    }
 
    public abstract class EditTaskFor<T> : IEditTaskFor<T> where T : class, IObjectBase
@@ -220,10 +220,7 @@ namespace MoBi.Presentation.Tasks.Edit
          }
       }
 
-      public List<IContainer> GetMoleculeProperties(IContainer container) =>
-         container?.Children
-            .OfType<IContainer>()
-            .Where(child => child.IsMoleculeProperties())
-            .ToList() ?? new List<IContainer>();
+      public IContainer GetMoleculeProperties(IContainer container) =>
+         container?.Container(Constants.MOLECULE_PROPERTIES);
    }
 }

--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
@@ -9,6 +9,7 @@ using MoBi.Core.Serialization.Exchange;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Interaction;
+using NPOI.POIFS.Properties;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;

--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
@@ -9,7 +9,6 @@ using MoBi.Core.Serialization.Exchange;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Interaction;
-using NPOI.POIFS.Properties;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
@@ -186,7 +185,7 @@ namespace MoBi.Presentation.Tasks.Edit
                tmpSpatialStructure.DiagramModel = existingSpatialStructure.DiagramModel.CreateCopy(container.Id);
          }
 
-         if(!expressionParametersToExport.Any() && !initialConditionsToExport.Any())
+         if (!expressionParametersToExport.Any() && !initialConditionsToExport.Any())
             _interactionTask.Save(tmpSpatialStructure, fileName);
          else
             exportSpatialStructureTransfer(tmpSpatialStructure, fileName, expressionParametersToExport, initialConditionsToExport, container.Name);

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Commands;
+using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Repository;
 using MoBi.Core.Events;
@@ -102,7 +103,22 @@ namespace MoBi.Presentation.Tasks.Interaction
 
       protected virtual void PerformPostAddActions(TChild newEntity, TParent parent, IBuildingBlock buildingBlockToAddTo)
       {
-         //by default nothing to do
+         var container = (newEntity as Container);
+         if (container == null)
+            return;
+
+         if (container.Mode == ContainerMode.Logical)
+         {
+            var moleculeProperties = container.Children
+               .OfType<IContainer>() 
+               .Where(child => child.IsMoleculeProperties())
+               .ToList();
+
+            foreach (var item in moleculeProperties)
+            {
+               container.RemoveChild(item);
+            }
+         }
       }
 
       /// <summary>

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Commands;
-using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Repository;
 using MoBi.Core.Events;
@@ -103,23 +102,7 @@ namespace MoBi.Presentation.Tasks.Interaction
 
       protected virtual void PerformPostAddActions(TChild newEntity, TParent parent, IBuildingBlock buildingBlockToAddTo)
       {
-         var container = (newEntity as Container);
-         if (container == null)
-            return;
-
-         if (container.Mode == ContainerMode.Logical)
-         {
-            var moleculeProperties = GetMoleculePropertiesForContainer(container);
-
-            foreach (var item in moleculeProperties)
-            {
-               container.RemoveChild(item);
-            }
-         }
       }
-
-      
-
 
       /// <summary>
       ///    Sets the command description after the new object is named.

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -109,10 +109,7 @@ namespace MoBi.Presentation.Tasks.Interaction
 
          if (container.Mode == ContainerMode.Logical)
          {
-            var moleculeProperties = container.Children
-               .OfType<IContainer>() 
-               .Where(child => child.IsMoleculeProperties())
-               .ToList();
+            var moleculeProperties = GetMoleculePropertiesForContainer(container);
 
             foreach (var item in moleculeProperties)
             {
@@ -120,6 +117,9 @@ namespace MoBi.Presentation.Tasks.Interaction
             }
          }
       }
+
+      
+
 
       /// <summary>
       ///    Sets the command description after the new object is named.

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainer.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using MoBi.Core.Commands;
+using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Presentation.Tasks.Edit;
 using OSPSuite.Core.Domain;
@@ -39,6 +41,6 @@ namespace MoBi.Presentation.Tasks.Interaction
       protected override IMoBiCommand AddNeighborhoodsToSpatialStructure(IReadOnlyList<NeighborhoodBuilder> neighborhoods, MoBiSpatialStructure spatialStructure)
       {
          return AddTo(neighborhoods, spatialStructure.NeighborhoodsContainer, spatialStructure);
-      }
+      }  
    }
 }

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainer.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using MoBi.Core.Commands;
-using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Presentation.Tasks.Edit;
 using OSPSuite.Core.Domain;
@@ -13,11 +11,15 @@ namespace MoBi.Presentation.Tasks.Interaction
    public class InteractionTasksForContainer : InteractionTasksForContainerBase<IContainer>
    {
       public InteractionTasksForContainer(
-         IInteractionTaskContext interactionTaskContext, 
-         IEditTaskFor<IContainer> editTask, 
-         IObjectPathFactory objectPathFactory, 
-         IParameterValuesTask parameterValuesTask, 
+         IInteractionTaskContext interactionTaskContext,
+         IEditTaskFor<IContainer> editTask,
+         IObjectPathFactory objectPathFactory,
+         IParameterValuesTask parameterValuesTask,
          IInitialConditionsTask<InitialConditionsBuildingBlock> initialConditionsTask) : base(interactionTaskContext, editTask, objectPathFactory, parameterValuesTask, initialConditionsTask)
+      {
+      }
+
+      protected override void PerformPostAddActions(IContainer entity, IContainer parent, IBuildingBlock buildingBlock)
       {
       }
 
@@ -41,6 +43,6 @@ namespace MoBi.Presentation.Tasks.Interaction
       protected override IMoBiCommand AddNeighborhoodsToSpatialStructure(IReadOnlyList<NeighborhoodBuilder> neighborhoods, MoBiSpatialStructure spatialStructure)
       {
          return AddTo(neighborhoods, spatialStructure.NeighborhoodsContainer, spatialStructure);
-      }  
+      }
    }
 }

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainerBase.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainerBase.cs
@@ -119,7 +119,7 @@ namespace MoBi.Presentation.Tasks.Interaction
          parameterValuesBuildingBlock.Each(x => { x.ContainerPath.Replace(oldName, newName); });
       }
 
-      
+
 
       private (MoBiSpatialStructure, ParameterValuesBuildingBlock, InitialConditionsBuildingBlock) loadFromPKML(string filename)
       {

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainerBase.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainerBase.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Commands;
-using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Model.Diagram;
 using MoBi.Core.Serialization.Exchange;
@@ -45,16 +44,6 @@ namespace MoBi.Presentation.Tasks.Interaction
          return newEntity;
       }
 
-      protected virtual List<IContainer> GetMoleculePropertiesForContainer(Container container)
-      {
-         var moleculeProperties = container?.Children
-            .OfType<IContainer>()
-            .Where(child => child.IsMoleculeProperties())
-            .ToList() ?? new List<IContainer>();
-
-         return moleculeProperties;
-      }
-      
       private MoBiSpatialStructure getSpatialStructure(IBuildingBlock buildingBlockWithFormulaCache)
       {
          return buildingBlockWithFormulaCache as MoBiSpatialStructure ?? _interactionTaskContext.Active<MoBiSpatialStructure>();

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainerBase.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainerBase.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Commands;
+using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Model.Diagram;
 using MoBi.Core.Serialization.Exchange;
@@ -44,6 +45,16 @@ namespace MoBi.Presentation.Tasks.Interaction
          return newEntity;
       }
 
+      protected virtual List<IContainer> GetMoleculePropertiesForContainer(Container container)
+      {
+         var moleculeProperties = container?.Children
+            .OfType<IContainer>()
+            .Where(child => child.IsMoleculeProperties())
+            .ToList() ?? new List<IContainer>();
+
+         return moleculeProperties;
+      }
+      
       private MoBiSpatialStructure getSpatialStructure(IBuildingBlock buildingBlockWithFormulaCache)
       {
          return buildingBlockWithFormulaCache as MoBiSpatialStructure ?? _interactionTaskContext.Active<MoBiSpatialStructure>();
@@ -118,8 +129,6 @@ namespace MoBi.Presentation.Tasks.Interaction
          parameterValuesBuildingBlock.Name = parameterValuesBuildingBlock.Name.Replace(oldName, newName);
          parameterValuesBuildingBlock.Each(x => { x.ContainerPath.Replace(oldName, newName); });
       }
-
-
 
       private (MoBiSpatialStructure, ParameterValuesBuildingBlock, InitialConditionsBuildingBlock) loadFromPKML(string filename)
       {

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForTopContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForTopContainer.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using MoBi.Core.Commands;
+using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Presentation.Tasks.Edit;
 using OSPSuite.Core.Domain;

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForTopContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForTopContainer.cs
@@ -34,10 +34,9 @@ namespace MoBi.Presentation.Tasks.Interaction
          {
             var moleculeProperties = _editTask.GetMoleculeProperties(newEntity);
 
-            foreach (var item in moleculeProperties)
-            {
-               newEntity.RemoveChild(item);
-            }
+            if(moleculeProperties != null)
+               newEntity.RemoveChild(moleculeProperties);
+            
          }
       }
 

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForTopContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForTopContainer.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using MoBi.Core.Commands;
-using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Presentation.Tasks.Edit;
 using OSPSuite.Core.Domain;
@@ -21,10 +19,26 @@ namespace MoBi.Presentation.Tasks.Interaction
          IEditTaskFor<IContainer> editTask,
          IObjectPathFactory objectPathFactory,
          IInteractionTasksForChildren<IContainer, IContainer> interactionTaskForNeighborhood,
-         IParameterValuesTask parameterValuesTask, 
+         IParameterValuesTask parameterValuesTask,
          IInitialConditionsTask<InitialConditionsBuildingBlock> initialConditionsTask) : base(interactionTaskContext, editTask, objectPathFactory, parameterValuesTask, initialConditionsTask)
       {
          _interactionTaskForNeighborhood = interactionTaskForNeighborhood;
+      }
+
+      protected override void PerformPostAddActions(IContainer newEntity, MoBiSpatialStructure parent, IBuildingBlock buildingBlockToAddTo)
+      {
+         if (newEntity == null)
+            return;
+
+         if (newEntity.Mode == ContainerMode.Logical)
+         {
+            var moleculeProperties = _editTask.GetMoleculeProperties(newEntity);
+
+            foreach (var item in moleculeProperties)
+            {
+               newEntity.RemoveChild(item);
+            }
+         }
       }
 
       public override IMoBiCommand GetRemoveCommand(IContainer entityToRemove, MoBiSpatialStructure parent, IBuildingBlock buildingBlock)

--- a/src/MoBi.UI/Views/EditContainerView.cs
+++ b/src/MoBi.UI/Views/EditContainerView.cs
@@ -1,4 +1,5 @@
-﻿using DevExpress.LookAndFeel;
+﻿using System.Linq;
+using DevExpress.LookAndFeel;
 using DevExpress.XtraEditors.Controls;
 using MoBi.Assets;
 using MoBi.Presentation.DTO;
@@ -7,7 +8,6 @@ using MoBi.Presentation.Views;
 using MoBi.UI.Extensions;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
-using OSPSuite.Core.Services;
 using OSPSuite.DataBinding;
 using OSPSuite.DataBinding.DevExpress;
 using OSPSuite.Presentation.Extensions;
@@ -40,7 +40,7 @@ namespace MoBi.UI.Views
             .To(cbContainerMode)
             .WithValues(dto => _presenter.AllContainerModes)
             .AndDisplays(mode => _presenter.ContainerModeDisplayFor(mode))
-            .OnValueUpdating += (o, e) => executeContainerModeChange(e.NewValue);
+            .OnValueUpdating += (o, e) => executeContainerModeChange(o, e.NewValue);
 
          _screenBinder.Bind(dto => dto.ContainerType)
             .To(cbContainerType)
@@ -66,13 +66,15 @@ namespace MoBi.UI.Views
          btParentPath.ButtonClick += (o, e) => OnEvent(_presenter.UpdateParentPath);
       }
 
-      private void executeContainerModeChange(ContainerMode newMode)
+      private void executeContainerModeChange(ContainerDTO container, ContainerMode newMode)
       {
          OnEvent(() =>
          {
             var result = _presenter.ConfirmAndSetContainerMode(newMode);
-            if (!result)
-               cbContainerMode.SelectedIndex = 0;
+            cbContainerMode.SelectedIndex = _presenter.AllContainerModes.Select((mode, index) => new { mode, index })
+               .Where(x => x.mode == result)
+               .Select(x => x.index)
+               .FirstOrDefault();
          });
       }
 

--- a/src/MoBi.UI/Views/EditContainerView.cs
+++ b/src/MoBi.UI/Views/EditContainerView.cs
@@ -15,7 +15,6 @@ using OSPSuite.Presentation.Views;
 using OSPSuite.UI.Controls;
 using OSPSuite.UI.Extensions;
 using OSPSuite.Utility.Extensions;
-using System;
 using ToolTips = MoBi.Assets.ToolTips;
 
 namespace MoBi.UI.Views
@@ -26,12 +25,10 @@ namespace MoBi.UI.Views
       protected ScreenBinder<ContainerDTO> _screenBinder;
       protected bool _readOnly;
       private readonly UserLookAndFeel _lookAndFeel;
-      private readonly IDialogCreator _dialogCreator;
 
       public EditContainerView(UserLookAndFeel lookAndFeel, IDialogCreator dialogCreator)
       {
          _lookAndFeel = lookAndFeel;
-         _dialogCreator = dialogCreator;
          InitializeComponent();
       }
 
@@ -71,19 +68,14 @@ namespace MoBi.UI.Views
 
       private void ConfirmAndExecuteContainerModeChange(ContainerMode newMode)
       {
-         if (newMode == ContainerMode.Logical)
+         OnEvent(() =>
          {
-            var ans = _dialogCreator.MessageBoxYesNo("This action will remove all MoleculeProperties of this container, are you sure?");
-            if (ans == ViewResult.No)
-            {
+            var result = _presenter.SetContainerMode(newMode);
+            if (!result)
                cbContainerMode.SelectedIndex = 0;
-               return;
-            }
-               
-         }
-         
-         OnEvent(() => _presenter.SetContainerMode(newMode));
+         });
       }
+
       public void Activate()
       {
          ActiveControl = btName;

--- a/src/MoBi.UI/Views/EditContainerView.cs
+++ b/src/MoBi.UI/Views/EditContainerView.cs
@@ -26,7 +26,7 @@ namespace MoBi.UI.Views
       protected bool _readOnly;
       private readonly UserLookAndFeel _lookAndFeel;
 
-      public EditContainerView(UserLookAndFeel lookAndFeel, IDialogCreator dialogCreator)
+      public EditContainerView(UserLookAndFeel lookAndFeel)
       {
          _lookAndFeel = lookAndFeel;
          InitializeComponent();
@@ -40,7 +40,7 @@ namespace MoBi.UI.Views
             .To(cbContainerMode)
             .WithValues(dto => _presenter.AllContainerModes)
             .AndDisplays(mode => _presenter.ContainerModeDisplayFor(mode))
-            .OnValueUpdating += (o, e) => ConfirmAndExecuteContainerModeChange(e.NewValue);
+            .OnValueUpdating += (o, e) => executeContainerModeChange(e.NewValue);
 
          _screenBinder.Bind(dto => dto.ContainerType)
             .To(cbContainerType)
@@ -66,11 +66,11 @@ namespace MoBi.UI.Views
          btParentPath.ButtonClick += (o, e) => OnEvent(_presenter.UpdateParentPath);
       }
 
-      private void ConfirmAndExecuteContainerModeChange(ContainerMode newMode)
+      private void executeContainerModeChange(ContainerMode newMode)
       {
          OnEvent(() =>
          {
-            var result = _presenter.SetContainerMode(newMode);
+            var result = _presenter.ConfirmAndSetContainerMode(newMode);
             if (!result)
                cbContainerMode.SelectedIndex = 0;
          });

--- a/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
@@ -265,7 +265,7 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.SetContainerMode(ContainerMode.Logical);
+         sut.ConfirmAndSetContainerMode(ContainerMode.Logical);
       }
 
       [Observation]
@@ -289,7 +289,7 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.SetContainerMode(ContainerMode.Logical);
+         sut.ConfirmAndSetContainerMode(ContainerMode.Logical);
       }
 
       [Observation]

--- a/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
@@ -300,7 +300,7 @@ namespace MoBi.Presentation
          _muscle.Name = "Muscle";
          sut.Edit(_muscle);
          A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>.Ignored, A<ViewResult>.Ignored)).Returns(ViewResult.Yes);
-         A.CallTo(() => _editTasks.GetMoleculeProperties(_muscle)).Returns(new List<IContainer>() { moleculeProperties });
+         A.CallTo(() => _editTasks.GetMoleculeProperties(_muscle)).Returns(moleculeProperties);
          A.CallTo(() => _editTasks.SetContainerMode(A<IBuildingBlock>.Ignored, _muscle,ContainerMode.Logical)).Returns(new SetContainerModeCommand(new MoBiSpatialStructure(),_muscle, ContainerMode.Logical));
          
       }

--- a/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
@@ -5,14 +5,15 @@ using MoBi.Core.Domain.Model;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Edit;
-using MoBi.Presentation.Tasks.Interaction;
 using MoBi.Presentation.Views;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Diagram;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Utility.Extensions;
 
@@ -24,14 +25,16 @@ namespace MoBi.Presentation
       private IContainerToContainerDTOMapper _containerMapper;
       private IEditTaskForContainer _editTasks;
       protected IEditParametersInContainerPresenter _parametersInContainerPresenter;
-      private IMoBiContext _context;
+      protected IMoBiContext _context;
       private ITagsPresenter _tagsPresenter;
       protected IApplicationController _applicationController;
       protected ICommandCollector _commandCollector;
       private IObjectPathFactory _objectPathFactory;
+      protected IDialogCreator _dialogCreator;
 
       protected override void Context()
       {
+         _dialogCreator = A.Fake<IDialogCreator>();
          _view = A.Fake<IEditContainerView>();
          _containerMapper = A.Fake<IContainerToContainerDTOMapper>();
          _editTasks = A.Fake<IEditTaskForContainer>();
@@ -40,7 +43,7 @@ namespace MoBi.Presentation
          _tagsPresenter = A.Fake<ITagsPresenter>();
          _applicationController = A.Fake<IApplicationController>();
          _objectPathFactory = A.Fake<IObjectPathFactory>();
-         sut = new EditContainerPresenter(_view, _containerMapper, _editTasks, _parametersInContainerPresenter, _context, _tagsPresenter, _applicationController, _objectPathFactory);
+         sut = new EditContainerPresenter(_view, _containerMapper, _editTasks, _parametersInContainerPresenter, _context, _tagsPresenter, _applicationController, _objectPathFactory, _dialogCreator);
          _commandCollector = new MoBiMacroCommand();
          sut.InitializeWith(_commandCollector);
       }
@@ -233,6 +236,81 @@ namespace MoBi.Presentation
       public void should_not_update_the_parent_path()
       {
          _container.ParentPath.PathAsString.ShouldBeEqualTo("A|B");
+      }
+   }
+
+   internal class When_setting_container_mode_to_new_container : concern_for_EditContainerPresenter
+   {
+      protected IContainer _muscle;
+      protected MoBiSpatialStructure _spatialStructure;
+
+      protected override void Context()
+      {
+         base.Context();
+         _muscle = new Container { ParentPath = new ObjectPath("A", "B") };
+         _spatialStructure = new MoBiSpatialStructure
+         {
+            NeighborhoodsContainer = new Container(),
+            DiagramManager = A.Fake<IDiagramManager<MoBiSpatialStructure>>()
+         };
+         _spatialStructure.AddTopContainer(_muscle);
+         _muscle.Mode = ContainerMode.Physical;
+         var moleculeProperties = _context.Create<IContainer>()
+            .WithName(Constants.MOLECULE_PROPERTIES)
+            .WithMode(ContainerMode.Logical);
+         _muscle.Add(moleculeProperties);
+         sut.Edit(_muscle);
+         sut.BuildingBlock = _spatialStructure;
+      }
+
+      protected override void Because()
+      {
+         sut.SetContainerMode(ContainerMode.Logical);
+      }
+
+      [Observation]
+      public void should_not_show_confirm_dialog()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>.Ignored, A<ViewResult>.Ignored)).MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void should_change_mode()
+      {
+         _muscle.Mode.ShouldBeEqualTo(ContainerMode.Logical);
+      }
+   }
+
+   internal class When_setting_container_mode_to_existing_container : When_setting_container_mode_to_new_container
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _muscle.Mode = ContainerMode.Physical;
+         _muscle.Name = "Muscle";
+         sut.BuildingBlock = _spatialStructure;
+         sut.Edit(_muscle);
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>.Ignored, A<ViewResult>.Ignored)).Returns(ViewResult.Yes);
+      }
+
+      protected override void Because()
+      {
+         sut.SetContainerMode(ContainerMode.Logical);
+      }
+
+      [Observation]
+      public void should_show_confirm_dialog()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>.Ignored, A<ViewResult>.Ignored)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_create_the_macro_command_for_changing_mode()
+      {
+         _commandCollector.All().Any(x => x.IsAnImplementationOf<MoBiMacroCommand>()).ShouldBeTrue();
+         var macroCommand = (_commandCollector.All().FirstOrDefault() as MoBiMacroCommand);
+         macroCommand.All().Any(x => x.IsAnImplementationOf<SetContainerModeCommand>()).ShouldBeTrue();
+         macroCommand.All().Any(x => x.IsAnImplementationOf<RemoveContainerFromSpatialStructureCommand>()).ShouldBeTrue();
       }
    }
 }

--- a/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
@@ -269,12 +269,6 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void should_not_show_confirm_dialog()
-      {
-         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>.Ignored, A<ViewResult>.Ignored)).MustNotHaveHappened();
-      }
-
-      [Observation]
       public void should_change_mode()
       {
          _muscle.Mode.ShouldBeEqualTo(ContainerMode.Logical);


### PR DESCRIPTION
Fixes #1678

# Description

Logical containers containers should not have molecule properties.
When switching modes it should either create or alert and remove the molecule properties

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):