### PR TITLE
Fixes #1692 Cloning a simulation - if an error has been found, the cl…

### DIFF
--- a/src/MoBi.Presentation/Presenter/Main/SimulationExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/SimulationExplorerPresenter.cs
@@ -155,6 +155,12 @@ namespace MoBi.Presentation.Presenter.Main
       private void reCreateSimulationNode(IMoBiSimulation simulation)
       {
          var simulationNode = _view.NodeById(simulation.Id);
+
+         // In case of a cloned simulation, the reload event will be published by the command
+         // before the simulation is added to the project
+         if (simulationNode == null)
+            return;
+
          bool simulationNodeExpanded = _view.IsNodeExpanded(simulationNode);
          var parentNode = simulationNode.ParentNode.DowncastTo<ITreeNode<IClassification>>();
          RemoveNodeFor(simulation);

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
@@ -193,8 +193,7 @@ namespace MoBi.Presentation.Tasks.Interaction
 
          // during cloning, we don't need to track the rename in history since the simulation is not yet added to the project
          new RenameModelCommand(newSimulation.Model, newName).RunCommand(_interactionTaskContext.Context);
-         _interactionTaskContext.Context.AddToHistory(new AddSimulationCommand(newSimulation).RunCommand(_interactionTaskContext.Context));
-
+         
          return newSimulation;
       }
 

--- a/src/MoBi.Presentation/UICommand/CloneSimulationUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/CloneSimulationUICommand.cs
@@ -25,7 +25,7 @@ namespace MoBi.Presentation.UICommand
          if (clonedSimulation == null) 
             return;
 
-         _context.AddToHistory(_simulationUpdateTask.ConfigureSimulation(clonedSimulation));
+         _context.AddToHistory(_simulationUpdateTask.ConfigureSimulationAndAddToProject(clonedSimulation));
       }
    }
 }

--- a/tests/MoBi.Tests/Presentation/InteractionTasksForSimulationSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/InteractionTasksForSimulationSpecs.cs
@@ -131,9 +131,9 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void the_new_simulation_is_added_to_the_project_by_command()
+      public void the_new_simulation_is_not_added_to_the_project_by_command()
       {
-         _moBiProject.Simulations.ShouldContain(_clonedSimulation);
+         _moBiProject.Simulations.ShouldNotContain(_clonedSimulation);
       }
 
       [Observation]


### PR DESCRIPTION
…oned simulation still remains

Fixes #1692

# Description
Previously we added the cloned simulation to the project, then configured it. If the configuration failed, the original clone was still left in the project.

This changes the flow by adding the simulation after it's been configured. If configuration fails, nothing is ever added to the project

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):