### PR TITLE
Fixes #1606 Create process option when configuring a simulation

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1650,6 +1650,7 @@ namespace MoBi.Assets
          public static readonly string SimulationChangesSinceConfiguration = "Simulation changes since configuration";
          public static readonly string OriginalValue = "Original Value";
          public static readonly string CurrentValue = "Current Value";
+         public static readonly string CreateProcessRateParameters = "Create all process rates in simulation";
          public static string SelectTheBuildingBlockWhereEntitiesWillBeAddedOrUpdated(string typeBeingAdded) => $"Select the building block where {typeBeingAdded} will be added or updated";
          public static readonly string SelectBuildingBlock = "Select Building Block";
          public static readonly string MakeDefault = "Make defaults";

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1650,7 +1650,7 @@ namespace MoBi.Assets
          public static readonly string SimulationChangesSinceConfiguration = "Simulation changes since configuration";
          public static readonly string OriginalValue = "Original Value";
          public static readonly string CurrentValue = "Current Value";
-         public static readonly string CreateProcessRateParameters = "Create all process rates in simulation";
+         public static readonly string CreateProcessRateParameters = "Create a process rate parameter for each process in the simulation";
          public static string SelectTheBuildingBlockWhereEntitiesWillBeAddedOrUpdated(string typeBeingAdded) => $"Select the building block where {typeBeingAdded} will be added or updated";
          public static readonly string SelectBuildingBlock = "Select Building Block";
          public static readonly string MakeDefault = "Make defaults";

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.343" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.344" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.343" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.344" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.61" GeneratePathProperty="true" />

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.343" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.344" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.343" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.344" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/DTO/SimulationDTO.cs
+++ b/src/MoBi.Presentation/DTO/SimulationDTO.cs
@@ -1,0 +1,20 @@
+﻿using MoBi.Core.Domain.Model;
+
+namespace MoBi.Presentation.DTO
+{
+   public class SimulationDTO : ObjectBaseDTO
+   {
+      private readonly IMoBiSimulation _simulation;
+
+      public SimulationDTO(IMoBiSimulation simulation) : base(simulation)
+      {
+         _simulation = simulation;
+      }
+
+      public bool CreateAllProcessRateParameters
+      {
+         get => _simulation.Configuration.CreateAllProcessRateParameters;
+         set => _simulation.Configuration.CreateAllProcessRateParameters = value;
+      }
+   }
+}

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.5" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.343" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.344" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/CreateSimulationConfigurationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/CreateSimulationConfigurationPresenter.cs
@@ -25,7 +25,7 @@ namespace MoBi.Presentation.Presenter
 
    public class CreateSimulationConfigurationPresenter : WizardPresenter<ICreateSimulationConfigurationView, ICreateSimulationConfigurationPresenter, ISimulationConfigurationItemPresenter>, ICreateSimulationConfigurationPresenter
    {
-      private ObjectBaseDTO _simulationDTO;
+      private SimulationDTO _simulationDTO;
       private readonly IForbiddenNamesRetriever _forbiddenNamesRetriever;
       protected readonly IUserSettings _userSettings;
       private readonly IModuleConfigurationDTOToModuleConfigurationMapper _moduleConfigurationMapper;
@@ -75,7 +75,9 @@ namespace MoBi.Presentation.Presenter
 
       private void edit(IMoBiSimulation simulation, bool allowNaming)
       {
-         _simulationDTO = new ObjectBaseDTO(simulation).WithName(simulation.Name);
+         _simulationDTO = new SimulationDTO(simulation).WithName(simulation.Name);
+         _simulationDTO.CreateAllProcessRateParameters = simulation.Configuration.CreateAllProcessRateParameters;
+         
          if (allowNaming)
             _simulationDTO.AddUsedNames(nameOfSimulationAlreadyUsed(simulation));
          else
@@ -112,6 +114,8 @@ namespace MoBi.Presentation.Presenter
 
          simulationConfiguration.ShouldValidate = true;
          simulationConfiguration.PerformCircularReferenceCheck = _userSettings.CheckCircularReference;
+
+         simulationConfiguration.CreateAllProcessRateParameters = _simulationDTO.CreateAllProcessRateParameters;
       }
    }
 }

--- a/src/MoBi.Presentation/Views/ICreateSimulationConfigurationView.cs
+++ b/src/MoBi.Presentation/Views/ICreateSimulationConfigurationView.cs
@@ -6,7 +6,7 @@ namespace MoBi.Presentation.Views
 {
    public interface ICreateSimulationConfigurationView : IWizardView, IModalView<ICreateSimulationConfigurationPresenter>
    {
-      void BindTo(ObjectBaseDTO simulationDTO);
+      void BindTo(SimulationDTO simulationDTO);
       void DisableNaming();
    }
 }

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.343" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.344" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/Views/CreateSimulationConfigurationView.Designer.cs
+++ b/src/MoBi.UI/Views/CreateSimulationConfigurationView.Designer.cs
@@ -30,37 +30,87 @@
       private void InitializeComponent()
       {
          this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.cbCreateProcessRate = new OSPSuite.UI.Controls.UxCheckEdit();
          this.tabWizard = new DevExpress.XtraTab.XtraTabControl();
          this.tbName = new DevExpress.XtraEditors.TextEdit();
          this.layoutControlGroup1 = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutControlItem1 = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutItemName = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutControlItem2 = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlBase)).BeginInit();
          this.layoutControlBase.SuspendLayout();
          ((System.ComponentModel.ISupportInitialize)(this.emptySpaceItemBase)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
          this.layoutControl.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.cbCreateProcessRate.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.tabWizard)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.tbName.Properties)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup1)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemName)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem2)).BeginInit();
          this.SuspendLayout();
-        
+         // 
+         // btnPrevious
+         // 
+         this.btnPrevious.Location = new System.Drawing.Point(566, 12);
+         this.btnPrevious.Size = new System.Drawing.Size(164, 22);
+         // 
+         // btnNext
+         // 
+         this.btnNext.Location = new System.Drawing.Point(734, 12);
+         this.btnNext.Size = new System.Drawing.Size(122, 22);
+         // 
+         // btnOk
+         // 
+         this.btnOk.Location = new System.Drawing.Point(860, 12);
+         this.btnOk.Size = new System.Drawing.Size(98, 22);
+         // 
+         // btnCancel
+         // 
+         this.btnCancel.Location = new System.Drawing.Point(962, 12);
+         this.btnCancel.Size = new System.Drawing.Size(224, 22);
+         // 
+         // layoutControlBase
+         // 
+         this.layoutControlBase.Location = new System.Drawing.Point(0, 722);
+         this.layoutControlBase.OptionsCustomizationForm.DesignTimeCustomizationFormPositionAndSize = new System.Drawing.Rectangle(574, 236, 650, 400);
+         this.layoutControlBase.Size = new System.Drawing.Size(1198, 46);
+         this.layoutControlBase.Controls.SetChildIndex(this.btnPrevious, 0);
+         this.layoutControlBase.Controls.SetChildIndex(this.btnNext, 0);
+         this.layoutControlBase.Controls.SetChildIndex(this.btnOk, 0);
+         this.layoutControlBase.Controls.SetChildIndex(this.btnCancel, 0);
+         // 
+         // emptySpaceItemBase
+         // 
+         this.emptySpaceItemBase.Size = new System.Drawing.Size(554, 26);
          // 
          // layoutControl
          // 
          this.layoutControl.AllowCustomization = false;
          this.layoutControl.Controls.Add(this.tabWizard);
          this.layoutControl.Controls.Add(this.tbName);
+         this.layoutControl.Controls.Add(this.cbCreateProcessRate);
          this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
          this.layoutControl.Location = new System.Drawing.Point(0, 0);
          this.layoutControl.Name = "layoutControl";
+         this.layoutControl.OptionsCustomizationForm.DesignTimeCustomizationFormPositionAndSize = new System.Drawing.Rectangle(474, 400, 650, 400);
          this.layoutControl.Root = this.layoutControlGroup1;
          this.layoutControl.Size = new System.Drawing.Size(1198, 722);
          this.layoutControl.TabIndex = 5;
          this.layoutControl.Text = "layoutControl1";
+         // 
+         // cbCreateProcessRate
+         // 
+         this.cbCreateProcessRate.AllowClicksOutsideControlArea = false;
+         this.cbCreateProcessRate.Location = new System.Drawing.Point(408, 12);
+         this.cbCreateProcessRate.Name = "cbCreateProcessRate";
+         this.cbCreateProcessRate.Properties.AllowFocused = false;
+         this.cbCreateProcessRate.Properties.Caption = "cbCreateProcessRate";
+         this.cbCreateProcessRate.Size = new System.Drawing.Size(778, 20);
+         this.cbCreateProcessRate.StyleController = this.layoutControl;
+         this.cbCreateProcessRate.TabIndex = 6;
          // 
          // tabWizard
          // 
@@ -73,7 +123,7 @@
          // 
          this.tbName.Location = new System.Drawing.Point(103, 12);
          this.tbName.Name = "tbName";
-         this.tbName.Size = new System.Drawing.Size(1083, 20);
+         this.tbName.Size = new System.Drawing.Size(301, 20);
          this.tbName.StyleController = this.layoutControl;
          this.tbName.TabIndex = 4;
          // 
@@ -84,8 +134,9 @@
          this.layoutControlGroup1.GroupBordersVisible = false;
          this.layoutControlGroup1.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
             this.layoutControlItem1,
-            this.layoutItemName});
-         this.layoutControlGroup1.Name = "layoutControlGroup1";
+            this.layoutItemName,
+            this.layoutControlItem2});
+         this.layoutControlGroup1.Name = "Root";
          this.layoutControlGroup1.Size = new System.Drawing.Size(1198, 722);
          this.layoutControlGroup1.TextVisible = false;
          // 
@@ -105,8 +156,17 @@
          this.layoutItemName.CustomizationFormText = "layoutItemName";
          this.layoutItemName.Location = new System.Drawing.Point(0, 0);
          this.layoutItemName.Name = "layoutItemName";
-         this.layoutItemName.Size = new System.Drawing.Size(1178, 24);
+         this.layoutItemName.Size = new System.Drawing.Size(396, 24);
          this.layoutItemName.TextSize = new System.Drawing.Size(79, 13);
+         // 
+         // layoutControlItem2
+         // 
+         this.layoutControlItem2.Control = this.cbCreateProcessRate;
+         this.layoutControlItem2.Location = new System.Drawing.Point(396, 0);
+         this.layoutControlItem2.Name = "layoutControlItem2";
+         this.layoutControlItem2.Size = new System.Drawing.Size(782, 24);
+         this.layoutControlItem2.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutControlItem2.TextVisible = false;
          // 
          // CreateSimulationConfigurationView
          // 
@@ -125,11 +185,13 @@
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
          this.layoutControl.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.cbCreateProcessRate.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.tabWizard)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.tbName.Properties)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup1)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemName)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem2)).EndInit();
          this.ResumeLayout(false);
          this.PerformLayout();
 
@@ -143,5 +205,7 @@
       private DevExpress.XtraTab.XtraTabControl tabWizard;
       private DevExpress.XtraLayout.LayoutControlItem layoutControlItem1;
       private OSPSuite.UI.Controls.UxLayoutControl layoutControl;
+      private OSPSuite.UI.Controls.UxCheckEdit cbCreateProcessRate;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlItem2;
    }
 }

--- a/src/MoBi.UI/Views/CreateSimulationConfigurationView.cs
+++ b/src/MoBi.UI/Views/CreateSimulationConfigurationView.cs
@@ -15,12 +15,12 @@ namespace MoBi.UI.Views
 {
    public partial class CreateSimulationConfigurationView : WizardView, ICreateSimulationConfigurationView
    {
-      private readonly ScreenBinder<ObjectBaseDTO> _screenBinder;
+      private readonly ScreenBinder<SimulationDTO> _screenBinder;
 
       public CreateSimulationConfigurationView()
       {
          InitializeComponent();
-         _screenBinder = new ScreenBinder<ObjectBaseDTO>();
+         _screenBinder = new ScreenBinder<SimulationDTO>();
          ClientSize = new Size(UIConstants.UI.SIMULATION_VIEW_WIDTH, UIConstants.UI.SIMULATION_VIEW_HEIGHT);
       }
 
@@ -33,6 +33,7 @@ namespace MoBi.UI.Views
       {
          base.InitializeBinding();
          _screenBinder.Bind(x => x.Name).To(tbName);
+         _screenBinder.Bind(x => x.CreateAllProcessRateParameters).To(cbCreateProcessRate);
          RegisterValidationFor(_screenBinder, NotifyViewChanged);
       }
 
@@ -41,7 +42,7 @@ namespace MoBi.UI.Views
          WizardPresenter = presenter;
       }
 
-      public void BindTo(ObjectBaseDTO simulationDTO)
+      public void BindTo(SimulationDTO simulationDTO)
       {
          _screenBinder.BindToSource(simulationDTO);
          NotifyViewChanged();
@@ -58,6 +59,7 @@ namespace MoBi.UI.Views
          layoutItemName.Text = AppConstants.Captions.Name.FormatForLabel();
          ApplicationIcon = ApplicationIcons.Simulation;
          Caption = AppConstants.Captions.SimulationConfigurationWizard;
+         cbCreateProcessRate.Text = AppConstants.Captions.CreateProcessRateParameters;
          this.ResizeForCurrentScreen(fractionHeight: UIConstants.UI.SCREEN_RESIZE_FRACTION, fractionWidth: UIConstants.UI.SCREEN_RESIZE_FRACTION);
       }
 

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -69,13 +69,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.343" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.344" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.61" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.343" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.344" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.5" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -42,10 +42,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.343" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.344" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.61" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.343" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.343" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.344" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.344" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1606

# Description
This is just an update that exposes an option to create all process rate parameters for a simulation during simulation creation

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/fb501ac1-f5f7-4f3f-83b3-917634487def)

# Questions (if appropriate):