### PR TITLE
Fixes #1703 Corrupted settings.xml causes empty MoBi screen

### DIFF
--- a/src/MoBi.UI/Settings/UserSettings.cs
+++ b/src/MoBi.UI/Settings/UserSettings.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
+using System.Linq;
+using DevExpress.Utils;
 using DevExpress.XtraBars.Docking;
 using DevExpress.XtraBars.Ribbon;
 using MoBi.Assets;
 using MoBi.Core;
 using MoBi.Core.Domain;
+using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model.Diagram;
 using MoBi.Presentation.Settings;
 using OSPSuite.Assets;
@@ -117,13 +121,13 @@ namespace MoBi.UI.Settings
          ShowAdvancedParameters = true;
          GroupParameters = false;
          VisibleNotification = NotificationType.Warning | NotificationType.Error;
-         ValidationSettings = new ValidationSettings {CheckDimensions = true, CheckCircularReference = true};
+         ValidationSettings = new ValidationSettings { CheckDimensions = true, CheckCircularReference = true };
          DisplayUnits = new DisplayUnitsManager();
          DefaultChartYScaling = Scalings.Log;
          IconSizeTreeView = IconSizes.Size24x24;
          IconSizeTab = IconSizes.Size16x16;
          IconSizeContextMenu = IconSizes.Size16x16;
-         ComparerSettings = new ComparerSettings {CompareHiddenEntities = true};
+         ComparerSettings = new ComparerSettings { CompareHiddenEntities = true };
          JournalPageEditorSettings = new JournalPageEditorSettings();
          ParameterIdentificationFeedbackEditorSettings = new ParameterIdentificationFeedbackEditorSettings();
          SensitivityAnalysisFeedbackEditorSettings = new SensitivityAnalysisFeedbackEditorSettings();
@@ -157,7 +161,7 @@ namespace MoBi.UI.Settings
          set => ValidationSettings.ShowUnresolvedEndosomesWarningsForInitialConditions = value;
          get => ValidationSettings.ShowUnresolvedEndosomesWarningsForInitialConditions;
       }
-      
+
       public bool ShowPKSimObserverMessages
       {
          set => ValidationSettings.ShowPKSimObserverMessages = value;
@@ -184,7 +188,7 @@ namespace MoBi.UI.Settings
          set => _numericFormatterOptions.DecimalPlace = value;
       }
 
-   
+
       public DirectoryMapSettings DirectoryMapSettings { get; }
 
       public IEnumerable<DirectoryMap> UsedDirectories => DirectoryMapSettings.UsedDirectories;
@@ -192,21 +196,30 @@ namespace MoBi.UI.Settings
       public void SaveLayout()
       {
          LayoutVersion = AppConstants.LayoutVersion;
-         var streamMainView = new MemoryStream();
-         _dockManager.SaveLayoutToStream(streamMainView);
-         MainViewLayout = streamToString(streamMainView);
+         MainViewLayout = mainViewLayoutToString();
          var streamRibbon = new MemoryStream();
          _ribbonManager.Ribbon.Toolbar.SaveLayoutToStream(streamRibbon);
          RibbonLayout = streamToString(streamRibbon);
+      }
+
+      private string mainViewLayoutToString()
+      {
+         var streamMainView = new MemoryStream();
+         _dockManager.SaveLayoutToStream(streamMainView);
+         return streamToString(streamMainView);
       }
 
       public void RestoreLayout()
       {
          if (LayoutVersion != AppConstants.LayoutVersion)
             resetLayout();
+         var defaultLayout = mainViewLayoutToString();
 
          if (!MainViewLayout.IsNullOrEmpty())
             _dockManager.RestoreFromStream(streamFromString(MainViewLayout));
+
+         if (_dockManager.Panels.Count == 0)
+            _dockManager.RestoreFromStream(streamFromString(defaultLayout));
 
          if (!RibbonLayout.IsNullOrEmpty())
             _ribbonManager.RestoreFromStream(streamFromString(RibbonLayout));

--- a/src/MoBi.UI/Settings/UserSettings.cs
+++ b/src/MoBi.UI/Settings/UserSettings.cs
@@ -1,16 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Globalization;
 using System.IO;
-using System.Linq;
-using DevExpress.Utils;
 using DevExpress.XtraBars.Docking;
 using DevExpress.XtraBars.Ribbon;
 using MoBi.Assets;
 using MoBi.Core;
 using MoBi.Core.Domain;
-using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model.Diagram;
 using MoBi.Presentation.Settings;
 using OSPSuite.Assets;
@@ -78,6 +74,7 @@ namespace MoBi.UI.Settings
          get => ChartOptions.ColorGroupObservedDataFromSameFolder;
          set => ChartOptions.ColorGroupObservedDataFromSameFolder = value;
       }
+
       public bool RenameDependentObjectsDefault { get; set; }
       public IDiagramOptions DiagramOptions { get; set; }
       public IForceLayoutConfiguration ForceLayoutConfigutation { get; set; }
@@ -187,7 +184,6 @@ namespace MoBi.UI.Settings
          get => _numericFormatterOptions.DecimalPlace;
          set => _numericFormatterOptions.DecimalPlace = value;
       }
-
 
       public DirectoryMapSettings DirectoryMapSettings { get; }
 


### PR DESCRIPTION
Fixes #1703 

# Description
Occasionally an error occurs when serializing layout data to the user settings in MoBi. This is a patch that checks if the dock windows were all removed when the settings were restored. If so, we re-apply the defaults.

It's a bit of a patch, because we don't know why the XML is corrupted in the first place, so I don't know if it's really a 'Bug **Fix**'.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):