### PR TITLE
Fixes #1711 "Events" container is exported every time any container is exported to PKML?

### DIFF
--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskForContainer.cs
@@ -158,6 +158,7 @@ namespace MoBi.Presentation.Tasks.Edit
       private void exportContainer(IContainer container, string fileName, IndividualBuildingBlock individual = null, IReadOnlyList<ExpressionProfileBuildingBlock> expressionProfileBuildingBlocks = null)
       {
          var tmpSpatialStructure = (MoBiSpatialStructure)_spatialStructureFactory.Create();
+         removeEventsContainer(tmpSpatialStructure);
 
          var clonedEntity = _cloneManager.Clone(container, tmpSpatialStructure.FormulaCache);
 
@@ -189,6 +190,13 @@ namespace MoBi.Presentation.Tasks.Edit
             _interactionTask.Save(tmpSpatialStructure, fileName);
          else
             exportSpatialStructureTransfer(tmpSpatialStructure, fileName, expressionParametersToExport, initialConditionsToExport, container.Name);
+      }
+
+      private void removeEventsContainer(MoBiSpatialStructure spatialStructure)
+      {
+         var eventsContainer = spatialStructure.TopContainers.FirstOrDefault(x => x.IsNamed(Constants.EVENTS));
+         if (eventsContainer != null)
+            spatialStructure.Remove(eventsContainer);
       }
 
       private void exportSpatialStructureTransfer(MoBiSpatialStructure tmpSpatialStructure, string fileName, IReadOnlyList<ExpressionParameter> expressionParametersToExport, IReadOnlyList<InitialCondition> initialConditionsToExport, string containerName)

--- a/tests/MoBi.Tests/Presentation/Tasks/EditTaskForContainerSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/EditTaskForContainerSpecs.cs
@@ -149,6 +149,7 @@ namespace MoBi.Presentation.Tasks
          {
             NeighborhoodsContainer = new Container().WithName(Constants.NEIGHBORHOODS)
          };
+         _tmpSpatialStructure.AddTopContainer(new Container().WithName(Constants.EVENTS));
 
          A.CallTo(() => _selectIndividualAndExpressionFromProjectPresenter.GetPathIndividualAndExpressionsForExport(_containerToSave)).Returns(("FilePath", _individual, _expressionProfiles));
          A.CallTo(() => _spatialStructureFactory.Create()).Returns(_tmpSpatialStructure);
@@ -179,6 +180,7 @@ namespace MoBi.Presentation.Tasks
          _transfer.ParameterValues.FindByPath("Parent|Container1|expression1").ShouldNotBeNull();
          _transfer.InitialConditions.FindByPath("Parent|Container1|initialCondition1").ShouldNotBeNull();
          _transfer.SpatialStructure.ShouldBeEqualTo(_tmpSpatialStructure);
+         _transfer.SpatialStructure.TopContainers.SingleOrDefault(x => x.IsNamed(Constants.EVENTS)).ShouldBeNull();
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #1711

# Description
We made it the default from `SpatialStructureFactory` that an `Events` container is always added. In this special case, we don't want this container during export.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):