### PR TITLE
#1716 Clarify thet the PV are always added in the last module

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -286,7 +286,8 @@ namespace MoBi.Assets
 
          public static string CommitingChangesToModulesMessage(ModuleConfiguration moduleConfiguration, bool hasMoleculeChanges, bool hasParameterChanges)
          {
-            string message = $"Changed parameter values will be committed to the parameter values building block of the module <i>{moduleConfiguration.Module.Name}</i>:{Environment.NewLine}";
+            string message = $"Parameter Values are always added in the last module of the simulation configuration. {Environment.NewLine}"+
+                             $"{Environment.NewLine}Changed parameter values will be committed to the parameter values building block of the module <i>{moduleConfiguration.Module.Name}</i>:{Environment.NewLine}";
 
             if (hasMoleculeChanges)
             {

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -286,8 +286,7 @@ namespace MoBi.Assets
 
          public static string CommitingChangesToModulesMessage(ModuleConfiguration moduleConfiguration, bool hasMoleculeChanges, bool hasParameterChanges)
          {
-            string message = $"Parameter Values are always added in the last module of the simulation configuration. {Environment.NewLine}"+
-                             $"{Environment.NewLine}Changed parameter values will be committed to the parameter values building block of the module <i>{moduleConfiguration.Module.Name}</i>:{Environment.NewLine}";
+            string message = $"Parameter Values are always added in the last module of the simulation configuration. {Environment.NewLine}";
 
             if (hasMoleculeChanges)
             {

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -290,13 +290,13 @@ namespace MoBi.Assets
 
             if (hasMoleculeChanges)
             {
-               var icName = moduleConfiguration.SelectedInitialConditions == null ? "A new initial conditions building block will be created" : $"Initial conditions will be written to the initial conditions building block <i>{moduleConfiguration.SelectedInitialConditions.DisplayName}</i>";
+               var icName = moduleConfiguration.SelectedInitialConditions == null ? $"A new initial conditions building block will be created in the module <i>{moduleConfiguration.Module.Name}</i>" : $"Initial conditions will be written to the initial conditions building block <i>{moduleConfiguration.SelectedInitialConditions.Name}</i> in module <i>{moduleConfiguration.Module.Name}</i>";
                message += $"{Environment.NewLine}- {icName}";
             }
 
             if (hasParameterChanges)
             {
-               var pvName = moduleConfiguration.SelectedParameterValues == null ? "A new parameter values building block will be created" : $"Parameter values will be written to the parameter values building block <i>{moduleConfiguration.SelectedParameterValues.DisplayName}</i>";
+               var pvName = moduleConfiguration.SelectedParameterValues == null ? $"A new parameter values building block will be created in the module <i>{moduleConfiguration.Module.Name}</i>" : $"Parameter values will be written to the parameter values building block <i>{moduleConfiguration.SelectedParameterValues.Name}</i> in module <i>{moduleConfiguration.Module.Name}</i>";
                message += $"{Environment.NewLine}- {pvName}";
             }
 

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -286,17 +286,17 @@ namespace MoBi.Assets
 
          public static string CommitingChangesToModulesMessage(ModuleConfiguration moduleConfiguration, bool hasMoleculeChanges, bool hasParameterChanges)
          {
-            string message = $"Parameter Values are always added in the last module of the simulation configuration. {Environment.NewLine}";
+            var message = $"Values changed in a simulation are always committed to the last module of the simulation configuration. {Environment.NewLine}";
 
             if (hasMoleculeChanges)
             {
-               var icName = moduleConfiguration.SelectedInitialConditions == null ? $"A new initial conditions building block will be created in the module <i>{moduleConfiguration.Module.Name}</i>" : $"Initial conditions will be written to the initial conditions building block <i>{moduleConfiguration.SelectedInitialConditions.Name}</i> in module <i>{moduleConfiguration.Module.Name}</i>";
+               var icName = moduleConfiguration.SelectedInitialConditions == null ? $"A new initial conditions building block will be created in module <i>{moduleConfiguration.Module.Name}</i>" : $"Initial conditions will be written to the initial conditions building block <i>{moduleConfiguration.SelectedInitialConditions.Name}</i> in module <i>{moduleConfiguration.Module.Name}</i>";
                message += $"{Environment.NewLine}- {icName}";
             }
 
             if (hasParameterChanges)
             {
-               var pvName = moduleConfiguration.SelectedParameterValues == null ? $"A new parameter values building block will be created in the module <i>{moduleConfiguration.Module.Name}</i>" : $"Parameter values will be written to the parameter values building block <i>{moduleConfiguration.SelectedParameterValues.Name}</i> in module <i>{moduleConfiguration.Module.Name}</i>";
+               var pvName = moduleConfiguration.SelectedParameterValues == null ? $"A new parameter values building block will be created in module <i>{moduleConfiguration.Module.Name}</i>" : $"Parameter values will be written to the parameter values building block <i>{moduleConfiguration.SelectedParameterValues.Name}</i> in module <i>{moduleConfiguration.Module.Name}</i>";
                message += $"{Environment.NewLine}- {pvName}";
             }
 


### PR DESCRIPTION
Fixes #1716 

# Description

Clarify thet the PV are always added in the last module

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [x] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/ae15d86a-a9ba-4622-972d-9e8b2427c48c)

# Questions (if appropriate):