### PR TITLE
1721 drag drop of building blocks between modules

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.346" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -26,9 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.347" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.347" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.61" GeneratePathProperty="true" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.346" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.61" GeneratePathProperty="true" />

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.347" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -34,13 +34,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.346" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.0.0-niqOL" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.346" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-niqOL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.0.347" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.5" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.347" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.5" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.346" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/EditIndividualAndExpressionConfigurationsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditIndividualAndExpressionConfigurationsPresenter.cs
@@ -149,12 +149,14 @@ namespace MoBi.Presentation.Presenter
       public IndividualBuildingBlock SelectedIndividual => _individualSelectionDTO.IsNull() ? null : _individualSelectionDTO.SelectedIndividualBuildingBlock;
       public IReadOnlyList<ExpressionProfileBuildingBlock> ExpressionProfiles => _selectedExpressions;
 
+      public bool CopyAllowed() => false;
+
       public bool CanDrag(ITreeNode node)
       {
          return node.TagAsObject is ExpressionProfileBuildingBlock;
       }
 
-      public bool CanDrop(ITreeNode dragNode, ITreeNode targetNode)
+      public bool CanDrop(ITreeNode dragNode, ITreeNode targetNode, DragDropKeyFlags keyFlags)
       {
          var expression = expressionProfileFromNode(targetNode);
          return expression != null;

--- a/src/MoBi.Presentation/Presenter/EditModuleConfigurationsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditModuleConfigurationsPresenter.cs
@@ -210,7 +210,8 @@ namespace MoBi.Presentation.Presenter
 
       private bool nodeIsModuleConfiguration(ITreeNode node) => node?.TagAsObject is ModuleConfigurationDTO;
 
-      public bool CanDrop(ITreeNode dragNode, ITreeNode targetNode) => nodeIsModuleConfiguration(targetNode) && !Equals(dragNode, targetNode);
+      public bool CanDrop(ITreeNode dragNode, ITreeNode targetNode, DragDropKeyFlags keyFlags) => nodeIsModuleConfiguration(targetNode) && !Equals(dragNode, targetNode);
+
       public void DropNode(ITreeNode dragNode, ITreeNode targetNode, DragDropKeyFlags keyState = DragDropKeyFlags.None)
       {
          var movingConfiguration = moduleConfigurationDTOFor(dragNode);
@@ -221,6 +222,8 @@ namespace MoBi.Presentation.Presenter
          moveConfiguration(movingConfiguration, targetConfiguration);
          refreshSelectedModulesView(dragNode);
       }
+
+      public bool CopyAllowed() => false;
 
       public void MoveUp(ITreeNode selectedNode)
       {

--- a/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/ModuleExplorerPresenter.cs
@@ -77,9 +77,9 @@ namespace MoBi.Presentation.Presenter.Main
          return base.ContextMenuFor(treeNode);
       }
 
-      public override bool CanDrop(ITreeNode nodeToDrop, ITreeNode targetNode)
+      public override bool CanDrop(ITreeNode nodeToDrop, ITreeNode targetNode, DragDropKeyFlags keyFlags)
       {
-         if (base.CanDrop(nodeToDrop, targetNode))
+         if (base.CanDrop(nodeToDrop, targetNode, keyFlags))
             return true;
 
          var (targetModuleNode, buildingBlockSourceNode) = convertToExpectedTypes(nodeToDrop, targetNode);
@@ -90,10 +90,22 @@ namespace MoBi.Presentation.Presenter.Main
          if (moduleAlreadyContainsNode(buildingBlockSourceNode, targetModuleNode))
             return false;
 
-         if (!isPossibleToAddBuildingBlockToModule(targetModuleNode, buildingBlockSourceNode))
+         if (!isPossibleToAddBuildingBlockToModule(targetModuleNode, buildingBlockSourceNode) || (isMove(keyFlags) && !canMove(buildingBlockSourceNode.Tag)))
             return false;
 
          return true;
+      }
+
+      public override bool CopyAllowed() => true;
+
+      private bool canMove(IBuildingBlock buildingBlockToMove)
+      {
+         return !_context.CurrentProject.Simulations.Any(x => x.Uses(buildingBlockToMove));
+      }
+
+      private static bool isMove(DragDropKeyFlags keyFlags)
+      {
+         return !keyFlags.HasFlag(DragDropKeyFlags.CtrlKey);
       }
 
       private static bool isPossibleToAddBuildingBlockToModule(ModuleNode targetModuleNode, ITreeNode<IBuildingBlock> buildingBlockSourceNode) =>

--- a/src/MoBi.Presentation/Presenter/Main/SimulationExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/SimulationExplorerPresenter.cs
@@ -97,6 +97,8 @@ namespace MoBi.Presentation.Presenter.Main
                 _parameterAnalysablesInExplorerPresenter.CanDrag(node);
       }
 
+      public override bool CopyAllowed() => false;
+
       private ITreeNode addClassifiableSimulationToSimulationRootFolder(ClassifiableSimulation classifiableSimulation)
       {
          return AddClassifiableToTree(classifiableSimulation, RootNodeTypes.SimulationFolder, addClassifiableSimulationToTree);
@@ -114,9 +116,9 @@ namespace MoBi.Presentation.Presenter.Main
 
       public void Handle(SimulationAddedEvent eventToHandle) => addSimulationToTree(eventToHandle.Simulation);
 
-      private ITreeNode addSimulationToTree(IMoBiSimulation simulation)
+      private void addSimulationToTree(IMoBiSimulation simulation)
       {
-         return AddSubjectToClassifyToTree<IMoBiSimulation, ClassifiableSimulation>(simulation, addClassifiableSimulationToSimulationRootFolder);
+         AddSubjectToClassifyToTree<IMoBiSimulation, ClassifiableSimulation>(simulation, addClassifiableSimulationToSimulationRootFolder);
       }
 
       public void Handle(SimulationRemovedEvent eventToHandle) => RemoveNodeFor(eventToHandle.Simulation);

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.346" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -27,11 +27,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.0.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.0.6" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.347" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -69,13 +69,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.347" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.61" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-niqOL" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.347" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.5" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -69,13 +69,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.0.346" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.61" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.0.346" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.0.0-niqOL" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.5" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -42,10 +42,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.346" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-niqOL" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.61" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -42,10 +42,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.347" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.61" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.347" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.347" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.0.346" />
-    <PackageReference Include="OSPSuite.UI" Version="12.0.346" />
+    <PackageReference Include="OSPSuite.Core" Version="12.0.0-niqOL" />
+    <PackageReference Include="OSPSuite.UI" Version="12.0.0-niqOL" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1721 

# Description
We did not prevent users from moving building blocks by drag and drop when the module was used by a simulation.

By preventing this, it made sense to make a distinction between move and copy in the drag effects.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):