### PR TITLE
Fixes #1761 Cannot select changed entities in event assignments

### DIFF
--- a/src/MoBi.Presentation/Mappers/SpatialStructureToSpatialStructureDTOMapper.cs
+++ b/src/MoBi.Presentation/Mappers/SpatialStructureToSpatialStructureDTOMapper.cs
@@ -1,4 +1,5 @@
-﻿using MoBi.Presentation.DTO;
+﻿using System.Linq;
+using MoBi.Presentation.DTO;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Utility;
 using OSPSuite.Utility.Extensions;
@@ -22,8 +23,13 @@ namespace MoBi.Presentation.Mappers
       {
          var dto = Map(new SpatialStructureDTO(spatialStructure));
          dto.TopContainers = spatialStructure.TopContainers.MapAllUsing(_containerToDTOContainerMapper);
-         dto.Neighborhoods = _containerToDTOContainerMapper.MapFrom(spatialStructure.NeighborhoodsContainer);
-         dto.MoleculeProperties = _containerToDTOContainerMapper.MapFrom(spatialStructure.GlobalMoleculeDependentProperties);
+         
+         if(spatialStructure.NeighborhoodsContainer != null && spatialStructure.NeighborhoodsContainer.Any())
+            dto.Neighborhoods = _containerToDTOContainerMapper.MapFrom(spatialStructure.NeighborhoodsContainer);
+
+         if(spatialStructure.GlobalMoleculeDependentProperties != null && spatialStructure.GlobalMoleculeDependentProperties.Any())
+            dto.MoleculeProperties = _containerToDTOContainerMapper.MapFrom(spatialStructure.GlobalMoleculeDependentProperties);
+         
          dto.Name = spatialStructure.DisplayName;
 
          return dto;

--- a/src/MoBi.Presentation/Presenter/SelectEventAssignmentTargetPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectEventAssignmentTargetPresenter.cs
@@ -8,6 +8,7 @@ using MoBi.Core.Domain.Repository;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Views;
+using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
@@ -92,6 +93,10 @@ namespace MoBi.Presentation.Presenter
          if (parent.IsAnImplementationOf<IDistributedParameter>())
             return Array.Empty<ObjectBaseDTO>();
 
+         var spatialStructureDTO = parentDTO as SpatialStructureDTO;
+         if (spatialStructureDTO != null)
+            return mapSpatialStructureChildren(spatialStructureDTO);
+
          var container = parent as IContainer;
          if (container == null)
             return Array.Empty<ObjectBaseDTO>();
@@ -122,6 +127,21 @@ namespace MoBi.Presentation.Presenter
          list.Where(objectSelectionIsForbidden).Each(x => cannotSelectDescription(x, _forbiddenAssignees[x.ObjectBase]));
 
          return list;
+      }
+
+      private IReadOnlyList<ObjectBaseDTO> mapSpatialStructureChildren(SpatialStructureDTO spatialStructureDTO)
+      {
+         var objectBaseDTOs = new List<ObjectBaseDTO>();
+         if (spatialStructureDTO.MoleculeProperties != null)
+            objectBaseDTOs.Add(spatialStructureDTO.MoleculeProperties);
+
+         if(spatialStructureDTO.TopContainers != null && spatialStructureDTO.TopContainers.Any())
+            objectBaseDTOs.AddRange(spatialStructureDTO.TopContainers);
+
+         if(spatialStructureDTO.Neighborhoods != null)
+            objectBaseDTOs.Add(spatialStructureDTO.Neighborhoods);
+
+         return objectBaseDTOs;
       }
 
       private bool objectSelectionIsForbidden(ObjectBaseDTO x)


### PR DESCRIPTION
Fixes #1761

# Description
Spatial structures were not added to this view as they were in V11.

Should Events and MoleculeProperties be shown in this view?

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/cc2e7474-550b-4c7d-8ecf-755281e0e2eb)


# Questions (if appropriate):