### PR TITLE
Fixes #1774 Exception after entering the name of new reaction or passive transport

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditFormulaPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditFormulaPresenter.cs
@@ -345,6 +345,9 @@ namespace MoBi.Presentation.Presenter
 
          _formula = _formulaDecoder.GetFormula(_formulaOwner);
 
+         if (_formula == null)
+            return;
+
          rebind();
       }
 

--- a/tests/MoBi.Tests/Presentation/EditFormulaInPathAndValuesPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditFormulaInPathAndValuesPresenterSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using FakeItEasy;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
+using MoBi.Core.Events;
 using MoBi.Core.Helper;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Presenter;
@@ -111,6 +112,27 @@ namespace MoBi.Presentation
       public void the_update_formula_should_be_called_with_expected_formula()
       {
          A.CallTo(() => _moBiFormulaTask.UpdateFormula(_formulaOwner, _expectedOldFormula, A<IFormula>.Ignored, _formulaDecoder, A<IBuildingBlock>.Ignored)).MustHaveHappened();
+      }
+   }
+
+   public class When_handling_rename_events_and_formula_is_null : concern_for_EditFormulaInPathAndValuesPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _pathAndValueEntity.Formula = null;
+         sut.Init(_entity, _buildingBlock, new UsingFormulaDecoder());
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new ObjectPropertyChangedEvent(_pathAndValueEntity));
+      }
+
+      [Observation]
+      public void the_formula_mapper_is_not_used()
+      {
+         A.CallTo(() => _formulaToFormulaInfoDTOMapper.MapFrom(A<IFormula>._)).MustHaveHappenedOnceExactly();
       }
    }
 }


### PR DESCRIPTION
Fixes #1774

# Description


## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):