### PR TITLE
Fixes #1045 Silent crash when creating a circular reference

### DIFF
--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -60,8 +60,8 @@
     <PackageReference Include="OSPSuite.Core" Version="12.0.364" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.71" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.17" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/MoBi.Presentation/Presenter/EditFormulaInContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditFormulaInContainerPresenter.cs
@@ -62,8 +62,6 @@ namespace MoBi.Presentation.Presenter
          Initialize(formulaOwner, buildingBlock, formulaDecoder);
       }
 
-
-
       public void Init(IParameter parameter, IBuildingBlock buildingBlock)
       {
          if (IsRHS)

--- a/src/MoBi.Presentation/Presenter/EditFormulaPathListPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditFormulaPathListPresenter.cs
@@ -124,6 +124,9 @@ namespace MoBi.Presentation.Presenter
          var path = new ObjectPath(newPath.ToPathArray());
          var formulaUsablePath = _formula.FormulaUsablePathBy(dto.Alias);
 
+         if (_circularReferenceChecker.HasCircularReference(path, _formulaOwner))
+            throw new OSPSuiteException(AppConstants.Exceptions.CircularReferenceException(path, _formula));
+
          AddCommand(_moBiFormulaTask.ChangePathInFormula(_formula, path, formulaUsablePath, BuildingBlock));
       }
 

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -72,8 +72,8 @@
     <PackageReference Include="OSPSuite.Core" Version="12.0.364" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.71" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.17" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.Presentation" Version="12.0.364" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.5" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -47,8 +47,8 @@
     <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.0.364" />
     <PackageReference Include="OSPSuite.UI" Version="12.0.364" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.68" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.10" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.71" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.17" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.0.5" GeneratePathProperty="true" />
   </ItemGroup>

--- a/tests/MoBi.Tests/Presentation/EditExplicitFormulaPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditExplicitFormulaPresenterSpecs.cs
@@ -22,7 +22,6 @@ namespace MoBi.Presentation
       protected IExplicitFormulaToExplicitFormulaDTOMapper _explicitFormulaMapper;
       protected IActiveSubjectRetriever _activeSubjectRetriever;
       protected IMoBiContext _context;
-      protected ICircularReferenceChecker _formulaChecker;
       protected IDialogCreator _dialogCreator;
       protected IInteractionTasksForChildren<IFormula, FormulaUsablePath> _interactionTask;
       protected IReactionDimensionRetriever _reactionDimensionRetriever;
@@ -38,7 +37,6 @@ namespace MoBi.Presentation
          _explicitFormulaMapper = A.Fake<IExplicitFormulaToExplicitFormulaDTOMapper>();
          _activeSubjectRetriever = A.Fake<IActiveSubjectRetriever>();
          _context = A.Fake<IMoBiContext>();
-         _formulaChecker = A.Fake<ICircularReferenceChecker>();
          _dialogCreator = A.Fake<IDialogCreator>();
          _interactionTask = A.Fake<IInteractionTasksForChildren<IFormula, FormulaUsablePath>>();
          _reactionDimensionRetriever = A.Fake<IReactionDimensionRetriever>();
@@ -147,7 +145,7 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void should_show_the_forula_caption_depepding_on_the_project_reaction_dimension_mode()
+      public void should_show_the_formula_caption_depending_on_the_project_reaction_dimension_mode()
       {
          A.CallTo(() => _view.SetFormulaCaption("THE_RHS_CAPTION")).MustHaveHappened();
       }
@@ -173,7 +171,7 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void should_show_the_forula_caption_depepding_on_the_project_reaction_dimension_mode()
+      public void should_show_the_formula_caption_depending_on_the_project_reaction_dimension_mode()
       {
          A.CallTo(() => _view.SetFormulaCaption("THE_RHS_CAPTION")).MustHaveHappened();
       }

--- a/tests/MoBi.Tests/Presentation/EditFormulaPathListPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditFormulaPathListPresenterSpecs.cs
@@ -17,10 +17,11 @@ using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Utility.Exceptions;
 
 namespace MoBi.Presentation
 {
-   public abstract class concern_for_EditFormulaPathListPresenter : ContextSpecification<IEditFormulaPathListPresenter>
+   public abstract class concern_for_EditFormulaPathListPresenter : ContextSpecification<EditFormulaPathListPresenter>
    {
       protected IEditFormulaPathListView _view;
       protected IMoBiFormulaTask _moBiFormulaTask;
@@ -41,9 +42,68 @@ namespace MoBi.Presentation
          _contextMenuFactory = A.Fake<IViewItemContextMenuFactory>();
          _circularReferenceChecker = A.Fake<ICircularReferenceChecker>();
          _formulaUsablePathDTOMapper = A.Fake<IFormulaUsablePathToFormulaUsablePathDTOMapper>();
-
          sut = new EditFormulaPathListPresenter(_view, _moBiFormulaTask, _context, _dimensionFactory, _userSettings, _contextMenuFactory, _circularReferenceChecker, _formulaUsablePathDTOMapper);
+         sut.InitializeWith(A.Fake<ICommandCollector>());
       }
+   }
+
+   internal abstract class When_setting_a_path : concern_for_EditFormulaPathListPresenter
+   {
+      protected FormulaUsablePathDTO _formulaUsablePathDTO;
+      protected string _aNewPath;
+      protected IFormula _formula;
+      protected IParameter _parameter;
+
+      protected override void Context()
+      {
+         base.Context();
+         _formula = new ExplicitFormula("5");
+         _aNewPath = "a|new|path";
+         _parameter = new Parameter();
+         _parameter.Formula = _formula;
+         _formulaUsablePathDTO = new FormulaUsablePathDTO(new FormulaUsablePath(), _formula);
+
+         A.CallTo(() => _formulaUsablePathDTOMapper.MapFrom(_formula, A<IUsingFormula>._)).Returns(new[] { _formulaUsablePathDTO });
+         A.CallTo(() => _circularReferenceChecker.HasCircularReference(A<ObjectPath>._, A<IUsingFormula>._)).Returns(CreatesCircularRef);
+         sut.Edit(_formula, _parameter);
+      }
+
+      protected abstract bool CreatesCircularRef { get; }
+   }
+
+   internal class When_setting_a_path_that_without_circular_reference : When_setting_a_path
+   {
+      protected override void Because()
+      {
+         sut.SetFormulaUsablePath(_aNewPath, _formulaUsablePathDTO);
+      }
+
+      [Observation]
+      public void the_circular_reference_checker_is_used_to_check_for_circular_references()
+      {
+         A.CallTo(() => _circularReferenceChecker.HasCircularReference(A<ObjectPath>._, _parameter)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_path_is_changed_by_command()
+      {
+         A.CallTo(() => _moBiFormulaTask.ChangePathInFormula(A<IFormula>._, A<ObjectPath>._, A<FormulaUsablePath>._, A<IBuildingBlock>._)).MustHaveHappened();
+      }
+
+      protected override bool CreatesCircularRef => false;
+   }
+
+   internal class When_setting_a_path_that_creates_a_circular_reference : When_setting_a_path
+   {
+      [Observation]
+      public void the_circular_reference_checker_is_used_to_check_for_circular_references()
+      {
+         The.Action(() => sut.SetFormulaUsablePath(_aNewPath, _formulaUsablePathDTO)).ShouldThrowAn<OSPSuiteException>();
+         A.CallTo(() => _circularReferenceChecker.HasCircularReference(A<ObjectPath>._, _parameter)).MustHaveHappened();
+         A.CallTo(() => _moBiFormulaTask.ChangePathInFormula(A<IFormula>._, A<ObjectPath>._, A<FormulaUsablePath>._, A<IBuildingBlock>._)).MustNotHaveHappened();
+      }
+
+      protected override bool CreatesCircularRef => true;
    }
 
    internal class When_adding_a_ReferencePath : concern_for_EditFormulaPathListPresenter
@@ -56,7 +116,6 @@ namespace MoBi.Presentation
          base.Context();
          _formula = new ExplicitFormula();
          sut.Edit(_formula, null);
-         sut.InitializeWith(A.Fake<ICommandCollector>());
          _formula.AddObjectPath(new FormulaUsablePath());
          A.CallTo(() => _dimensionFactory.Dimension(_userSettings.ParameterDefaultDimension)).Returns(DomainHelperForSpecs.AmountDimension);
          A.CallTo(() => _moBiFormulaTask.AddFormulaUsablePath(_formula, A<FormulaUsablePath>._, A<IBuildingBlock>._))


### PR DESCRIPTION
Fixes #1045
Fixes #509

# Description
When adding a new alias in an explicit formula it was possible to crash MoBi on a stack overflow exception.

This is just an explicit check to make sure that the new path does not create a circular reference. The exception throw is the same as the strategy when creating a new parameter.

This fixes both issues because we are catching the circular reference at the stage where the path is entered, which is common to creating or editing a parameter formula. You will not be able to enter the value like this as described in the issue.

![image](https://github.com/user-attachments/assets/c8bee999-a06b-49dd-9654-8d2f885a10e2)

The exception is thrown for a different parameter name, but the dialog is shown and then the value is cleared

![image](https://github.com/user-attachments/assets/9b602d72-65d1-4a10-a41d-d4e136ada02f)



## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):