### PR TITLE
Fixes #294 Parameter CanBeVaried flag should be editable in MoBi

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1558,6 +1558,7 @@ namespace MoBi.Assets
          public static readonly string Tree = "Tree";
          public static readonly string MessageOrigin = "Origin";
          public static readonly string CanBeVariedInPopulation = "Can be varied in population";
+         public static readonly string CanBeVaried = "Can be varied";
          public static readonly string ImportObservedData = "Import Observed Data";
          public static readonly string AddUnitMap = "Add Unit";
          public static readonly string DisplayUnit = "Display Unit";

--- a/src/MoBi.Core/Commands/EditParameterCanBeVariedCommand.cs
+++ b/src/MoBi.Core/Commands/EditParameterCanBeVariedCommand.cs
@@ -1,0 +1,35 @@
+using MoBi.Assets;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Events;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+
+namespace MoBi.Core.Commands
+{
+   public class EditParameterCanBeVariedCommand : EditQuantityInBuildingBlockCommand<IParameter>
+   {
+      private readonly bool _newValue;
+      private readonly bool _oldValue;
+
+      public EditParameterCanBeVariedCommand(IParameter parameter, bool newValue, IBuildingBlock buildingBlock) :
+         base(parameter, buildingBlock)
+      {
+         _newValue = newValue;
+         _oldValue = parameter.CanBeVaried;
+         Description = AppConstants.Commands.EditDescription(ObjectType, AppConstants.Captions.CanBeVaried, _oldValue.ToString(), newValue.ToString(), parameter.Name);
+      }
+
+      protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
+      {
+         return new EditParameterCanBeVariedCommand(_quantity, _oldValue, _buildingBlock).AsInverseFor(this);
+      }
+
+      protected override void ExecuteWith(IMoBiContext context)
+      {
+         base.ExecuteWith(context);
+         _quantity.CanBeVaried = _newValue;
+         context.PublishEvent(new ParameterChangedEvent(_quantity));
+      }
+   }
+}

--- a/src/MoBi.Presentation/DTO/ParameterDTO.cs
+++ b/src/MoBi.Presentation/DTO/ParameterDTO.cs
@@ -23,6 +23,7 @@ namespace MoBi.Presentation.DTO
       public bool IsAdvancedParameter { get; set; }
       public IGroup Group { get; set; }
       public bool CanBeVariedInPopulation { get; set; }
+      public bool CanBeVaried => Parameter.CanBeVaried;
       public bool IsFavorite { get; set; }
       public string DisplayName { get; set; }
       public FormulaType FormulaType { get; set; }

--- a/src/MoBi.Presentation/Presenter/EditParameterPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditParameterPresenter.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
+using MoBi.Core.Events;
 using MoBi.Core.Extensions;
 using MoBi.Core.Services;
 using MoBi.Presentation.DTO;
@@ -27,7 +28,8 @@ namespace MoBi.Presentation.Presenter
 {
    public interface IEditParameterPresenter : IEditPresenter<IParameter>,
       IPresenterWithFormulaCache,
-      ICreatePresenter<IParameter>
+      ICreatePresenter<IParameter>,
+      IListener<ParameterChangedEvent>
    {
       void SetUseRHSFormula(bool useRHS);
       IReadOnlyList<IDimension> AllDimensions();
@@ -40,6 +42,7 @@ namespace MoBi.Presentation.Presenter
       void SetIsAdvancedParameter(bool isAdvancedParameter);
       void SetPersistable(bool isPersitable);
       void SetIsVariablePopulation(bool isVariableInPopulation);
+      void SetIsVariable(bool isVariable);
       IEnumerable<IGroup> AllGroups();
       void SetGroup(IGroup group);
       string DisplayFor(IGroup group);
@@ -279,6 +282,11 @@ namespace MoBi.Presentation.Presenter
          _parameter.Persistable = isPersitable;
       }
 
+      public void SetIsVariable(bool isVariable)
+      {
+         addCommandToRun(new EditParameterCanBeVariedCommand(_parameter, isVariable, BuildingBlock));
+      }
+
       public void SetIsVariablePopulation(bool isVariableInPopulation)
       {
          addCommandToRun(new EditParameterCanBeVariedInPopulationCommand(_parameter, isVariableInPopulation, BuildingBlock));
@@ -328,6 +336,12 @@ namespace MoBi.Presentation.Presenter
             //Do not include rhs formula presenter into error check if we do not use the rhs
             return !_view.HasError && _editValueFormulaPresenter.CanClose;
          }
+      }
+
+      public void Handle(ParameterChangedEvent eventToHandle)
+      {
+         if(eventToHandle.Parameters.Contains(_parameter))
+            _view.Show(_parameterDTO);
       }
    }
 }

--- a/src/MoBi.UI/Views/EditParameterView.Designer.cs
+++ b/src/MoBi.UI/Views/EditParameterView.Designer.cs
@@ -69,10 +69,12 @@ namespace MoBi.UI.Views
          this.tabTags = new DevExpress.XtraTab.XtraTabPage();
          this.tabCriteria = new DevExpress.XtraTab.XtraTabPage();
          this.layoutControl = new DevExpress.XtraLayout.LayoutControl();
-         this.Root = new DevExpress.XtraLayout.LayoutControlGroup();
          this.panelContainerCriteria = new DevExpress.XtraEditors.PanelControl();
-         this.layoutItemContainerCriteria = new DevExpress.XtraLayout.LayoutControlItem();
+         this.Root = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutGroupContainerCriteria = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.layoutItemContainerCriteria = new DevExpress.XtraLayout.LayoutControlItem();
+         this.chkCanBeVaried = new OSPSuite.UI.Controls.UxCheckEdit();
+         this.canBeVariedLayoutControlItem = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.tabControl)).BeginInit();
          this.tabControl.SuspendLayout();
@@ -113,10 +115,12 @@ namespace MoBi.UI.Views
          this.tabCriteria.SuspendLayout();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
          this.layoutControl.SuspendLayout();
-         ((System.ComponentModel.ISupportInitialize)(this.Root)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelContainerCriteria)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutItemContainerCriteria)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.Root)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutGroupContainerCriteria)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemContainerCriteria)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.chkCanBeVaried.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.canBeVariedLayoutControlItem)).BeginInit();
          this.SuspendLayout();
          // 
          // tabControl
@@ -142,6 +146,7 @@ namespace MoBi.UI.Views
          // layoutControlProperties
          // 
          this.layoutControlProperties.AllowCustomization = false;
+         this.layoutControlProperties.Controls.Add(this.chkCanBeVaried);
          this.layoutControlProperties.Controls.Add(this.panelOrigiView);
          this.layoutControlProperties.Controls.Add(this.chkIsFavorite);
          this.layoutControlProperties.Controls.Add(this.cbGroup);
@@ -176,7 +181,7 @@ namespace MoBi.UI.Views
          this.chkIsFavorite.Location = new System.Drawing.Point(24, 164);
          this.chkIsFavorite.Name = "chkIsFavorite";
          this.chkIsFavorite.Properties.Caption = "chkIsFavorite";
-         this.chkIsFavorite.Size = new System.Drawing.Size(174, 20);
+         this.chkIsFavorite.Size = new System.Drawing.Size(133, 20);
          this.chkIsFavorite.StyleController = this.layoutControlProperties;
          this.chkIsFavorite.TabIndex = 27;
          // 
@@ -193,20 +198,20 @@ namespace MoBi.UI.Views
          // chkCanBeVariedInPopulation
          // 
          this.chkCanBeVariedInPopulation.AllowClicksOutsideControlArea = false;
-         this.chkCanBeVariedInPopulation.Location = new System.Drawing.Point(558, 164);
+         this.chkCanBeVariedInPopulation.Location = new System.Drawing.Point(572, 164);
          this.chkCanBeVariedInPopulation.Name = "chkCanBeVariedInPopulation";
          this.chkCanBeVariedInPopulation.Properties.Caption = "chkCanBeVariedInPopulation";
-         this.chkCanBeVariedInPopulation.Size = new System.Drawing.Size(174, 20);
+         this.chkCanBeVariedInPopulation.Size = new System.Drawing.Size(160, 20);
          this.chkCanBeVariedInPopulation.StyleController = this.layoutControlProperties;
          this.chkCanBeVariedInPopulation.TabIndex = 25;
          // 
          // chkPersistable
          // 
          this.chkPersistable.AllowClicksOutsideControlArea = false;
-         this.chkPersistable.Location = new System.Drawing.Point(202, 164);
+         this.chkPersistable.Location = new System.Drawing.Point(161, 164);
          this.chkPersistable.Name = "chkPersistable";
          this.chkPersistable.Properties.Caption = "chkPersistable";
-         this.chkPersistable.Size = new System.Drawing.Size(174, 20);
+         this.chkPersistable.Size = new System.Drawing.Size(126, 20);
          this.chkPersistable.StyleController = this.layoutControlProperties;
          this.chkPersistable.TabIndex = 24;
          // 
@@ -252,10 +257,10 @@ namespace MoBi.UI.Views
          // chkAdvancedParameter
          // 
          this.chkAdvancedParameter.AllowClicksOutsideControlArea = false;
-         this.chkAdvancedParameter.Location = new System.Drawing.Point(380, 164);
+         this.chkAdvancedParameter.Location = new System.Drawing.Point(291, 164);
          this.chkAdvancedParameter.Name = "chkAdvancedParameter";
          this.chkAdvancedParameter.Properties.Caption = "chkAdvancedParameter";
-         this.chkAdvancedParameter.Size = new System.Drawing.Size(174, 20);
+         this.chkAdvancedParameter.Size = new System.Drawing.Size(140, 20);
          this.chkAdvancedParameter.StyleController = this.layoutControlProperties;
          this.chkAdvancedParameter.TabIndex = 23;
          // 
@@ -399,7 +404,8 @@ namespace MoBi.UI.Views
             this.layoutControlItemPersistable,
             this.layoutControlItemAdvancedParameter,
             this.layoutControlItemCanBeVariedInPopulation,
-            this.layoutItemValueOrigin});
+            this.layoutItemValueOrigin,
+            this.canBeVariedLayoutControlItem});
          this.layoutGroupProperties.Location = new System.Drawing.Point(0, 24);
          this.layoutGroupProperties.Name = "layoutGroupProperties";
          this.layoutGroupProperties.Size = new System.Drawing.Size(736, 164);
@@ -437,7 +443,7 @@ namespace MoBi.UI.Views
          this.layoutItemIsFavorite.CustomizationFormText = "layoutItemIsFavorite";
          this.layoutItemIsFavorite.Location = new System.Drawing.Point(0, 95);
          this.layoutItemIsFavorite.Name = "layoutItemIsFavorite";
-         this.layoutItemIsFavorite.Size = new System.Drawing.Size(178, 24);
+         this.layoutItemIsFavorite.Size = new System.Drawing.Size(137, 24);
          this.layoutItemIsFavorite.TextSize = new System.Drawing.Size(0, 0);
          this.layoutItemIsFavorite.TextVisible = false;
          // 
@@ -445,9 +451,9 @@ namespace MoBi.UI.Views
          // 
          this.layoutControlItemPersistable.Control = this.chkPersistable;
          this.layoutControlItemPersistable.CustomizationFormText = "layoutControlItemPersistable";
-         this.layoutControlItemPersistable.Location = new System.Drawing.Point(178, 95);
+         this.layoutControlItemPersistable.Location = new System.Drawing.Point(137, 95);
          this.layoutControlItemPersistable.Name = "layoutControlItemPersistable";
-         this.layoutControlItemPersistable.Size = new System.Drawing.Size(178, 24);
+         this.layoutControlItemPersistable.Size = new System.Drawing.Size(130, 24);
          this.layoutControlItemPersistable.TextSize = new System.Drawing.Size(0, 0);
          this.layoutControlItemPersistable.TextVisible = false;
          // 
@@ -455,9 +461,9 @@ namespace MoBi.UI.Views
          // 
          this.layoutControlItemAdvancedParameter.Control = this.chkAdvancedParameter;
          this.layoutControlItemAdvancedParameter.CustomizationFormText = "layoutControlItemAdvancedParameter";
-         this.layoutControlItemAdvancedParameter.Location = new System.Drawing.Point(356, 95);
+         this.layoutControlItemAdvancedParameter.Location = new System.Drawing.Point(267, 95);
          this.layoutControlItemAdvancedParameter.Name = "layoutControlItemAdvancedParameter";
-         this.layoutControlItemAdvancedParameter.Size = new System.Drawing.Size(178, 24);
+         this.layoutControlItemAdvancedParameter.Size = new System.Drawing.Size(144, 24);
          this.layoutControlItemAdvancedParameter.TextSize = new System.Drawing.Size(0, 0);
          this.layoutControlItemAdvancedParameter.TextVisible = false;
          // 
@@ -465,9 +471,9 @@ namespace MoBi.UI.Views
          // 
          this.layoutControlItemCanBeVariedInPopulation.Control = this.chkCanBeVariedInPopulation;
          this.layoutControlItemCanBeVariedInPopulation.CustomizationFormText = "layoutControlItemCanBeVariedInPopulation";
-         this.layoutControlItemCanBeVariedInPopulation.Location = new System.Drawing.Point(534, 95);
+         this.layoutControlItemCanBeVariedInPopulation.Location = new System.Drawing.Point(548, 95);
          this.layoutControlItemCanBeVariedInPopulation.Name = "layoutControlItemCanBeVariedInPopulation";
-         this.layoutControlItemCanBeVariedInPopulation.Size = new System.Drawing.Size(178, 24);
+         this.layoutControlItemCanBeVariedInPopulation.Size = new System.Drawing.Size(164, 24);
          this.layoutControlItemCanBeVariedInPopulation.TextSize = new System.Drawing.Size(0, 0);
          this.layoutControlItemCanBeVariedInPopulation.TextVisible = false;
          // 
@@ -504,6 +510,13 @@ namespace MoBi.UI.Views
          this.layoutControl.TabIndex = 0;
          this.layoutControl.Text = "layoutControl";
          // 
+         // panelContainerCriteria
+         // 
+         this.panelContainerCriteria.Location = new System.Drawing.Point(170, 45);
+         this.panelContainerCriteria.Name = "panelContainerCriteria";
+         this.panelContainerCriteria.Size = new System.Drawing.Size(562, 346);
+         this.panelContainerCriteria.TabIndex = 4;
+         // 
          // Root
          // 
          this.Root.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
@@ -514,12 +527,13 @@ namespace MoBi.UI.Views
          this.Root.Size = new System.Drawing.Size(756, 415);
          this.Root.TextVisible = false;
          // 
-         // panelContainerCriteria
+         // layoutGroupContainerCriteria
          // 
-         this.panelContainerCriteria.Location = new System.Drawing.Point(170, 45);
-         this.panelContainerCriteria.Name = "panelContainerCriteria";
-         this.panelContainerCriteria.Size = new System.Drawing.Size(562, 346);
-         this.panelContainerCriteria.TabIndex = 4;
+         this.layoutGroupContainerCriteria.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutItemContainerCriteria});
+         this.layoutGroupContainerCriteria.Location = new System.Drawing.Point(0, 0);
+         this.layoutGroupContainerCriteria.Name = "layoutGroupContainerCriteria";
+         this.layoutGroupContainerCriteria.Size = new System.Drawing.Size(736, 395);
          // 
          // layoutItemContainerCriteria
          // 
@@ -529,13 +543,25 @@ namespace MoBi.UI.Views
          this.layoutItemContainerCriteria.Size = new System.Drawing.Size(712, 350);
          this.layoutItemContainerCriteria.TextSize = new System.Drawing.Size(134, 13);
          // 
-         // layoutGroupContainerCriteria
+         // chkCanBeVariedsss
          // 
-         this.layoutGroupContainerCriteria.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
-            this.layoutItemContainerCriteria});
-         this.layoutGroupContainerCriteria.Location = new System.Drawing.Point(0, 0);
-         this.layoutGroupContainerCriteria.Name = "layoutGroupContainerCriteria";
-         this.layoutGroupContainerCriteria.Size = new System.Drawing.Size(736, 395);
+         this.chkCanBeVaried.AllowClicksOutsideControlArea = false;
+         this.chkCanBeVaried.Location = new System.Drawing.Point(435, 164);
+         this.chkCanBeVaried.Name = "chkCanBeVaried";
+         this.chkCanBeVaried.Properties.AllowFocused = false;
+         this.chkCanBeVaried.Properties.Caption = "uxCheckEdit1";
+         this.chkCanBeVaried.Size = new System.Drawing.Size(133, 20);
+         this.chkCanBeVaried.StyleController = this.layoutControlProperties;
+         this.chkCanBeVaried.TabIndex = 30;
+         // 
+         // chkCanBeVaried
+         // 
+         this.canBeVariedLayoutControlItem.Control = this.chkCanBeVaried;
+         this.canBeVariedLayoutControlItem.Location = new System.Drawing.Point(411, 95);
+         this.canBeVariedLayoutControlItem.Name = "canBeVariedLayoutControlItem";
+         this.canBeVariedLayoutControlItem.Size = new System.Drawing.Size(137, 24);
+         this.canBeVariedLayoutControlItem.TextSize = new System.Drawing.Size(0, 0);
+         this.canBeVariedLayoutControlItem.TextVisible = false;
          // 
          // EditParameterView
          // 
@@ -584,10 +610,12 @@ namespace MoBi.UI.Views
          this.tabCriteria.ResumeLayout(false);
          ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
          this.layoutControl.ResumeLayout(false);
-         ((System.ComponentModel.ISupportInitialize)(this.Root)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.panelContainerCriteria)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutItemContainerCriteria)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.Root)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutGroupContainerCriteria)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemContainerCriteria)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.chkCanBeVaried.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.canBeVariedLayoutControlItem)).EndInit();
          this.ResumeLayout(false);
 
       }
@@ -635,5 +663,7 @@ namespace MoBi.UI.Views
       private DevExpress.XtraLayout.LayoutControlGroup Root;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemContainerCriteria;
       private DevExpress.XtraLayout.LayoutControlGroup layoutGroupContainerCriteria;
+      private UxCheckEdit chkCanBeVaried;
+      private DevExpress.XtraLayout.LayoutControlItem canBeVariedLayoutControlItem;
    }
 }

--- a/src/MoBi.UI/Views/EditParameterView.cs
+++ b/src/MoBi.UI/Views/EditParameterView.cs
@@ -72,6 +72,10 @@ namespace MoBi.UI.Views
             .To(chkCanBeVariedInPopulation)
             .OnValueUpdating += (o, e) => OnEvent(() => _presenter.SetIsVariablePopulation(e.NewValue));
 
+         _screenBinder.Bind(dto => dto.CanBeVaried)
+            .To(chkCanBeVaried)
+            .OnValueUpdating += (o, e) => OnEvent(() => _presenter.SetIsVariable(e.NewValue));
+
          _screenBinder.Bind(dto => dto.IsFavorite)
             .To(chkIsFavorite)
             .OnValueUpdating += (o, e) => OnEvent(() => _presenter.SetIsFavorite(e.NewValue));
@@ -100,6 +104,7 @@ namespace MoBi.UI.Views
          chkPersistable.Text = AppConstants.Captions.Persistable;
          chkPersistable.ToolTip = ToolTips.ParameterView.Persistable;
          chkCanBeVariedInPopulation.Text = AppConstants.Captions.CanBeVariedInPopulation;
+         chkCanBeVaried.Text = AppConstants.Captions.CanBeVaried;
          tabProperties.InitWith(AppConstants.Captions.Properties, ApplicationIcons.Properties);
          tabTags.InitWith(AppConstants.Captions.Tags, ApplicationIcons.Tag);
          tabCriteria.InitWith(AppConstants.Captions.ContainerCriteria, ApplicationIcons.Formula);

--- a/tests/MoBi.Tests/Core/Commands/EditParameterCanBeVariedCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/EditParameterCanBeVariedCommandSpecs.cs
@@ -1,0 +1,69 @@
+﻿using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+
+namespace MoBi.Core.Commands
+{
+   public abstract class concern_for_EditParameterCanBeVariedCommand : ContextSpecification<EditParameterCanBeVariedCommand>
+   {
+      protected IParameter _parameter;
+      protected bool _newValue;
+      private MoBiReactionBuildingBlock _buildingBlock;
+
+      protected override void Context()
+      {
+         _parameter = new Parameter().WithId("Para");
+         _newValue = true;
+         _parameter.CanBeVaried = false;
+         _buildingBlock = new MoBiReactionBuildingBlock();
+         sut = new EditParameterCanBeVariedCommand(_parameter, _newValue, _buildingBlock);
+      }
+   }
+
+   internal class When_asking_for_inverse_command_of_a_EditParameterCanBeVariedCommand : concern_for_EditParameterCanBeVariedCommand
+   {
+      private ICommand<IMoBiContext> _result;
+      private IMoBiContext _context;
+
+      protected override void Context()
+      {
+         base.Context();
+         _context = A.Fake<IMoBiContext>();
+         A.CallTo(() => _context.Get<IParameter>(_parameter.Id)).Returns(_parameter);
+      }
+
+      protected override void Because()
+      {
+         _result = sut.ExecuteAndInvokeInverse(_context);
+      }
+
+      [Observation]
+      public void should_return_an_EditParameterIsVariableCommand()
+      {
+         _result.ShouldBeAnInstanceOf<EditParameterCanBeVariedCommand>();
+      }
+
+      [Observation]
+      public void should_have_switched_the_new_and_old_value()
+      {
+         _parameter.CanBeVaried.ShouldBeFalse();
+      }
+   }
+
+   internal class When_executing_an_EditParameterIsVaraiableCommand : concern_for_EditParameterCanBeVariedCommand
+   {
+      protected override void Because()
+      {
+         sut.Execute(A.Fake<IMoBiContext>());
+      }
+
+      [Observation]
+      public void should_set_can_be_varied_to_new_value()
+      {
+         _parameter.CanBeVaried.ShouldBeEqualTo(_newValue);
+      }
+   }
+}

--- a/tests/MoBi.Tests/Core/Commands/EditParameterCanBeVariedInPopulationCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/EditParameterCanBeVariedInPopulationCommandSpecs.cs
@@ -1,15 +1,14 @@
-﻿using OSPSuite.BDDHelper;
+﻿using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
-using OSPSuite.Utility.Extensions;
-using FakeItEasy;
-using MoBi.Core.Domain.Model;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 
 namespace MoBi.Core.Commands
 {
-   public abstract class concern_for_EditParameterCanBeVariedInPopulationCommandSpecs : ContextSpecification<EditParameterCanBeVariedInPopulationCommand>
+   public abstract class concern_for_EditParameterCanBeVariedInPopulationCommand : ContextSpecification<EditParameterCanBeVariedInPopulationCommand>
    {
       protected IParameter _parameter;
       protected bool _newValue;
@@ -25,7 +24,7 @@ namespace MoBi.Core.Commands
       }
    }
 
-   internal class When_restoring_execution_data : concern_for_EditParameterCanBeVariedInPopulationCommandSpecs
+   internal class When_restoring_execution_data : concern_for_EditParameterCanBeVariedInPopulationCommand
    {
       private IMoBiContext _context;
 
@@ -47,7 +46,7 @@ namespace MoBi.Core.Commands
       }
    }
 
-   internal class When_asking_for_inverse_command_of_a_EditParameterCanBeVariedInPopulationCommand : concern_for_EditParameterCanBeVariedInPopulationCommandSpecs
+   internal class When_asking_for_inverse_command_of_a_EditParameterCanBeVariedInPopulationCommand : concern_for_EditParameterCanBeVariedInPopulationCommand
    {
       private ICommand<IMoBiContext> _result;
       private IMoBiContext _context;
@@ -55,7 +54,7 @@ namespace MoBi.Core.Commands
       protected override void Context()
       {
          base.Context();
-         _context= A.Fake<IMoBiContext>();
+         _context = A.Fake<IMoBiContext>();
          A.CallTo(() => _context.Get<IParameter>(_parameter.Id)).Returns(_parameter);
       }
 
@@ -65,7 +64,7 @@ namespace MoBi.Core.Commands
       }
 
       [Observation]
-      public void should_return_an_EditParameterIsVaraiableInPopulationCommand()
+      public void should_return_an_EditParameterIsVariableInPopulationCommand()
       {
          _result.ShouldBeAnInstanceOf<EditParameterCanBeVariedInPopulationCommand>();
       }
@@ -77,7 +76,7 @@ namespace MoBi.Core.Commands
       }
    }
 
-   internal class When_executing_an_EditParameterIsVaraiableInPopulationCommand : concern_for_EditParameterCanBeVariedInPopulationCommandSpecs
+   internal class When_executing_an_EditParameterIsVaraiableInPopulationCommand : concern_for_EditParameterCanBeVariedInPopulationCommand
    {
       protected override void Because()
       {

--- a/tests/MoBi.Tests/Core/Mapper/ApplicationBuilderToDTOApplicationBuilderMapperSpecs.cs
+++ b/tests/MoBi.Tests/Core/Mapper/ApplicationBuilderToDTOApplicationBuilderMapperSpecs.cs
@@ -1,19 +1,15 @@
 ﻿using System.Linq;
-using OSPSuite.Utility.Container;
-using FakeItEasy;
-
-using OSPSuite.BDDHelper;
-using OSPSuite.BDDHelper.Extensions;
 using MoBi.IntegrationTests;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
-
+using OSPSuite.Utility.Container;
 
 namespace MoBi.Core.Mapper
 {
- 
    public abstract class concern_for_ApplicationBuilderToDTOApplicationBuilderMapperIntegrationTests : ContextForIntegration<IApplicationBuilderToApplicationBuilderDTOMapper>
    {
       protected override void Context()
@@ -40,10 +36,9 @@ namespace MoBi.Core.Mapper
          _applicationBuilder.Add(new ApplicationBuilder().WithName("App2"));
       }
 
-
       protected override void Because()
       {
-        _resultEventGroupBuilderDTO = sut.MapFrom(_applicationBuilder);
+         _resultEventGroupBuilderDTO = sut.MapFrom(_applicationBuilder);
       }
 
       [Observation]
@@ -64,4 +59,4 @@ namespace MoBi.Core.Mapper
          _resultEventGroupBuilderDTO.Parameters.Count().ShouldBeEqualTo(1);
       }
    }
-}	
+}

--- a/tests/MoBi.Tests/Presentation/EditParameterPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditParameterPresenterSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FakeItEasy;
 using MoBi.Core.Commands;
+using MoBi.Core.Events;
 using MoBi.Core.Services;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;
@@ -100,6 +101,26 @@ namespace MoBi.Presentation
       public void should_add_an_EditParameterCanBeVariedInPopulationCommand_to_context()
       {
          A.CallTo(() => _commandCollector.AddCommand(A<EditParameterCanBeVariedInPopulationCommand>._)).MustHaveHappened();
+      }
+   }
+
+   internal class When_set_is_variable_is_called : concern_for_EditParameterPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Edit(_parameter);
+      }
+
+      protected override void Because()
+      {
+         sut.SetIsVariable(true);
+      }
+
+      [Observation]
+      public void should_add_an_EditParameterCanBeVariedInPopulationCommand_to_context()
+      {
+         A.CallTo(() => _commandCollector.AddCommand(A<EditParameterCanBeVariedCommand>._)).MustHaveHappened();
       }
    }
 
@@ -247,6 +268,46 @@ namespace MoBi.Presentation
          var criteria = _creator(_parameter);
          _parameter.ContainerCriteria.ShouldNotBeNull();
          _parameter.ContainerCriteria.ShouldBeEqualTo(criteria);
+      }
+   }
+
+   public class When_handling_the_parameter_changed_event_and_presenter_is_editing_the_changed_parameter : concern_for_EditParameterPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Edit(_parameter);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new ParameterChangedEvent(_parameter));
+      }
+
+      [Observation]
+      public void the_view_should_be_refreshed()
+      {
+         A.CallTo(() => _view.Show(_parameterDTO)).MustHaveHappened(2, Times.Exactly);
+      }
+   }
+
+   public class When_handling_the_parameter_changed_event_and_presenter_is_not_editing_the_changed_parameter : concern_for_EditParameterPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Edit(_parameter);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new ParameterChangedEvent(new Parameter()));
+      }
+
+      [Observation]
+      public void the_view_should_not_be_refreshed()
+      {
+         A.CallTo(() => _view.Show(_parameterDTO)).MustHaveHappened(1, Times.Exactly);
       }
    }
 }


### PR DESCRIPTION
Fixes #294 Parameter CanBeVaried can be edited in MoBi

# Description
Exposing a property in the edit parameter view

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/283460d4-d08b-4dbb-8fc9-de1d03323781)


# Questions (if appropriate):