### PR TITLE
Fixes #1792 Mean/Deviation/Percentile parameters are selectable in PI/SA

### DIFF
--- a/src/MoBi.Core/Services/ParameterAnalysableParameterSelector.cs
+++ b/src/MoBi.Core/Services/ParameterAnalysableParameterSelector.cs
@@ -8,9 +8,12 @@ namespace MoBi.Core.Services
       public override bool CanUseParameter(IParameter parameter)
       {
          return parameter.CanBeVaried
+                && !parameterIsSubParameter(parameter)
                 && !ParameterIsTable(parameter)
                 && !ParameterIsCategorial(parameter);
       }
+
+      private bool parameterIsSubParameter(IParameter parameter) => parameter.ParentContainer is DistributedParameter;
 
       public override ParameterGroupingMode DefaultParameterSelectionMode => ParameterGroupingModes.Simple;
    }

--- a/tests/MoBi.Tests/Core/ParameterAnalysableParameterSelectorSpecs.cs
+++ b/tests/MoBi.Tests/Core/ParameterAnalysableParameterSelectorSpecs.cs
@@ -56,5 +56,14 @@ namespace MoBi.Core
          _parameter.Name = "Hello Parameter";
          sut.CanUseParameter(_parameter).ShouldBeTrue();
       }
+
+      [Observation]
+      public void should_return_false_if_distributed_sub_parameter()
+      {
+         _parameter.CanBeVaried = true;
+         _parameter.Name = "Hello Parameter";
+         new DistributedParameter { _parameter };
+         sut.CanUseParameter(_parameter).ShouldBeFalse();
+      }
    }
 }	


### PR DESCRIPTION
Fixes #1792

# Description

Disable selectability of distributed sub-parameters

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):