### PR TITLE
Fixes #1794 Can't open existing project, Error: '', hexadecimal value 0x1F, is an invalid character

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -29,13 +29,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.1.65" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/Serialization/Xml/Services/CalculationMethodsRepositoryPersistor.cs
+++ b/src/MoBi.Core/Serialization/Xml/Services/CalculationMethodsRepositoryPersistor.cs
@@ -2,6 +2,7 @@ using System.Xml.Linq;
 using OSPSuite.Utility.Extensions;
 using MoBi.Core.Domain.Model;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Serialization;
 
 namespace MoBi.Core.Serialization.Xml.Services
 {
@@ -29,7 +30,7 @@ namespace MoBi.Core.Serialization.Xml.Services
 
       public void Load()
       {
-         var xml = XElement.Load(_configuration.CalculationMethodRepositoryFile);
+         var xml = XElementSerializer.PermissiveLoad(_configuration.CalculationMethodRepositoryFile);
          int version = _xmlSerializationService.VersionFrom(xml);
          _xmlSerializationService.Deserialize<ICoreCalculationMethodRepository>(xml, _context.CurrentProject, version).All().Each(_calculationMethodRepository.AddCalculationMethod);
       }
@@ -37,7 +38,7 @@ namespace MoBi.Core.Serialization.Xml.Services
       public void Save()
       {
          var xml = _xmlSerializationService.SerializeModelPart(_calculationMethodRepository);
-         xml.Save(_configuration.CalculationMethodRepositoryFile);
+         xml.PermissiveSave(_configuration.CalculationMethodRepositoryFile);
       }
    }
 }

--- a/src/MoBi.Core/XmlHelper.cs
+++ b/src/MoBi.Core/XmlHelper.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
+using OSPSuite.Core.Serialization;
 
 namespace MoBi.Core
 {
@@ -84,9 +85,8 @@ namespace MoBi.Core
       public static XElement ElementFromBytes(byte[] serializationByte)
       {
          using (var stream = new MemoryStream(serializationByte))
-         using (var reader = new StreamReader(stream, Encoding.UTF8, false))
          {
-            return XElement.Load(reader);
+            return XElementSerializer.PermissiveLoad(stream);
          }
       }
    }

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.1.65" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -24,9 +24,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="6.3.1" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Tasks/SerializationTask.cs
+++ b/src/MoBi.Presentation/Tasks/SerializationTask.cs
@@ -11,6 +11,7 @@ using MoBi.Core.Serialization.Services;
 using MoBi.Core.Serialization.Xml.Services;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Serialization;
 using OSPSuite.Core.Serialization.Exchange;
 using OSPSuite.Core.Services;
 using OSPSuite.Utility.Extensions;
@@ -110,7 +111,7 @@ namespace MoBi.Presentation.Tasks
       public void SaveModelPart<T>(T entityToSerialize, string filename)
       {
          var xelPart = _xmlSerializationService.SerializeModelPart(entityToSerialize);
-         xelPart.Save(filename);
+         xelPart.PermissiveSave(filename);
       }
 
       public T Load<T>(string fileName, bool resetIds = false)
@@ -120,12 +121,13 @@ namespace MoBi.Presentation.Tasks
 
       public IEnumerable<T> LoadMany<T>(string fileName, bool resetIds = false)
       {
-         _projectConverterLogger.Clear();
-
-         XElement xelRoot = XElement.Load(fileName);
          if (string.IsNullOrEmpty(fileName))
             return Enumerable.Empty<T>();
 
+         _projectConverterLogger.Clear();
+
+         var xelRoot = XElementSerializer.PermissiveLoad(fileName);
+         
          var possibleElementsToDeserialize = retrieveElementsToDeserializeFromFile<T>(xelRoot, fileName).ToList();
 
          var selection = possibleElementsToDeserialize.Count > 1

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -22,11 +22,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.UI" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.UI" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -65,13 +65,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.1.59" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.1.65" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -43,10 +43,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.UI" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.UI" Version="12.1.65" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.1.59" />
-    <PackageReference Include="OSPSuite.UI" Version="12.1.59" />
+    <PackageReference Include="OSPSuite.Core" Version="12.1.65" />
+    <PackageReference Include="OSPSuite.UI" Version="12.1.65" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1794

# Description
Uses more permissive XML serialization for storing PKML


## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):