### PR TITLE
Fixes #1732 Consistent naming of Building Blocks

### DIFF
--- a/src/MoBi.Presentation/UICommand/RenameFromContextMenuCommand.cs
+++ b/src/MoBi.Presentation/UICommand/RenameFromContextMenuCommand.cs
@@ -2,14 +2,13 @@ using System.Linq;
 using MoBi.Presentation.Tasks.Edit;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
-using OSPSuite.Core.Services;
 using OSPSuite.Presentation.UICommands;
 
 namespace MoBi.Presentation.UICommand
 {
    public class RenameFromContextMenuCommand<T> : ObjectUICommand<T> where T : class, IObjectBase
    {
-      protected IEditTaskFor<T> _editTask;
+      private readonly IEditTaskFor<T> _editTask;
 
       public RenameFromContextMenuCommand(IEditTaskFor<T> editTask)
       {
@@ -19,8 +18,7 @@ namespace MoBi.Presentation.UICommand
       protected override void PerformExecute()
       {
          var parent = Enumerable.Empty<IObjectBase>();
-         var entity = Subject as IEntity;
-         if (entity != null)
+         if (Subject is IEntity entity)
             parent = entity.ParentContainer;
 
          _editTask.Rename(Subject, parent, Subject as IBuildingBlock);

--- a/src/MoBi.UI/Views/BaseModuleContentView.Designer.cs
+++ b/src/MoBi.UI/Views/BaseModuleContentView.Designer.cs
@@ -35,6 +35,7 @@
          this.layoutControlGroup1 = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutControlItem9 = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.lblDescription = new DevExpress.XtraEditors.LabelControl();
          this.cbDefaultMergeBehavior = new OSPSuite.UI.Controls.UxComboBoxEdit();
          this.tbInitialConditionsName = new DevExpress.XtraEditors.TextEdit();
          this.tbParameterValuesName = new DevExpress.XtraEditors.TextEdit();
@@ -61,10 +62,9 @@
          this.moleculesItem = new DevExpress.XtraLayout.LayoutControlItem();
          this.parameterValuesNameItem = new DevExpress.XtraLayout.LayoutControlItem();
          this.initialConditionsNameItem = new DevExpress.XtraLayout.LayoutControlItem();
-         this.mergeBehaviorItem = new DevExpress.XtraLayout.LayoutControlItem();
-         this.lblDescription = new DevExpress.XtraEditors.LabelControl();
-         this.layoutControlItem1 = new DevExpress.XtraLayout.LayoutControlItem();
          this.mergeBehaviorGroup = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.layoutControlItem1 = new DevExpress.XtraLayout.LayoutControlItem();
+         this.mergeBehaviorItem = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.tablePanel)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.checkEdit1.Properties)).BeginInit();
@@ -99,9 +99,9 @@
          ((System.ComponentModel.ISupportInitialize)(this.moleculesItem)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.parameterValuesNameItem)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.initialConditionsNameItem)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.mergeBehaviorItem)).BeginInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.mergeBehaviorGroup)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.mergeBehaviorItem)).BeginInit();
          this.SuspendLayout();
          // 
          // tablePanel
@@ -163,11 +163,20 @@
          this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
          this.layoutControl.Location = new System.Drawing.Point(0, 0);
          this.layoutControl.Name = "layoutControl";
-         this.layoutControl.OptionsCustomizationForm.DesignTimeCustomizationFormPositionAndSize = new System.Drawing.Rectangle(1244, 200, 650, 1069);
+         this.layoutControl.OptionsCustomizationForm.DesignTimeCustomizationFormPositionAndSize = new System.Drawing.Rectangle(1808, 289, 650, 1069);
          this.layoutControl.Root = this.Root;
          this.layoutControl.Size = new System.Drawing.Size(580, 401);
          this.layoutControl.TabIndex = 39;
          this.layoutControl.Text = "uxLayoutControl1";
+         // 
+         // lblDescription
+         // 
+         this.lblDescription.Location = new System.Drawing.Point(24, 93);
+         this.lblDescription.Name = "lblDescription";
+         this.lblDescription.Size = new System.Drawing.Size(63, 13);
+         this.lblDescription.StyleController = this.layoutControl;
+         this.lblDescription.TabIndex = 17;
+         this.lblDescription.Text = "lblDescription";
          // 
          // cbDefaultMergeBehavior
          // 
@@ -198,7 +207,7 @@
          // 
          // cbMolecules
          // 
-         this.cbMolecules.Location = new System.Drawing.Point(24, 203);
+         this.cbMolecules.Location = new System.Drawing.Point(24, 179);
          this.cbMolecules.Name = "cbMolecules";
          this.cbMolecules.Properties.Caption = "cbMolecules";
          this.cbMolecules.Size = new System.Drawing.Size(532, 20);
@@ -252,7 +261,7 @@
          // 
          // cbReactions
          // 
-         this.cbReactions.Location = new System.Drawing.Point(24, 179);
+         this.cbReactions.Location = new System.Drawing.Point(24, 203);
          this.cbReactions.Name = "cbReactions";
          this.cbReactions.Properties.Caption = "cbReactions";
          this.cbReactions.Size = new System.Drawing.Size(532, 20);
@@ -315,9 +324,9 @@
             this.eventGroupItem,
             this.initialConditionsItem,
             this.parameterValuesItem,
-            this.moleculesItem,
             this.parameterValuesNameItem,
-            this.initialConditionsNameItem});
+            this.initialConditionsNameItem,
+            this.moleculesItem});
          this.createBuildingBlocksGroup.Location = new System.Drawing.Point(0, 110);
          this.createBuildingBlocksGroup.Name = "createBuildingBlocksGroup";
          this.createBuildingBlocksGroup.Size = new System.Drawing.Size(560, 237);
@@ -343,7 +352,7 @@
          // reactionsItem
          // 
          this.reactionsItem.Control = this.cbReactions;
-         this.reactionsItem.Location = new System.Drawing.Point(0, 24);
+         this.reactionsItem.Location = new System.Drawing.Point(0, 48);
          this.reactionsItem.Name = "reactionsItem";
          this.reactionsItem.Size = new System.Drawing.Size(536, 24);
          this.reactionsItem.TextSize = new System.Drawing.Size(0, 0);
@@ -388,7 +397,7 @@
          // moleculesItem
          // 
          this.moleculesItem.Control = this.cbMolecules;
-         this.moleculesItem.Location = new System.Drawing.Point(0, 48);
+         this.moleculesItem.Location = new System.Drawing.Point(0, 24);
          this.moleculesItem.Name = "moleculesItem";
          this.moleculesItem.Size = new System.Drawing.Size(536, 24);
          this.moleculesItem.TextSize = new System.Drawing.Size(0, 0);
@@ -410,22 +419,14 @@
          this.initialConditionsNameItem.Size = new System.Drawing.Size(368, 24);
          this.initialConditionsNameItem.TextSize = new System.Drawing.Size(130, 13);
          // 
-         // defaultMergeBehaviorItem
+         // mergeBehaviorGroup
          // 
-         this.mergeBehaviorItem.Control = this.cbDefaultMergeBehavior;
-         this.mergeBehaviorItem.Location = new System.Drawing.Point(0, 0);
-         this.mergeBehaviorItem.Name = "mergeBehaviorItem";
-         this.mergeBehaviorItem.Size = new System.Drawing.Size(536, 24);
-         this.mergeBehaviorItem.TextSize = new System.Drawing.Size(130, 13);
-         // 
-         // lblDescription
-         // 
-         this.lblDescription.Location = new System.Drawing.Point(24, 93);
-         this.lblDescription.Name = "lblDescription";
-         this.lblDescription.Size = new System.Drawing.Size(63, 13);
-         this.lblDescription.StyleController = this.layoutControl;
-         this.lblDescription.TabIndex = 17;
-         this.lblDescription.Text = "lblDescription";
+         this.mergeBehaviorGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutControlItem1,
+            this.mergeBehaviorItem});
+         this.mergeBehaviorGroup.Location = new System.Drawing.Point(0, 24);
+         this.mergeBehaviorGroup.Name = "mergeBehaviorGroup";
+         this.mergeBehaviorGroup.Size = new System.Drawing.Size(560, 86);
          // 
          // layoutControlItem1
          // 
@@ -436,14 +437,13 @@
          this.layoutControlItem1.TextSize = new System.Drawing.Size(0, 0);
          this.layoutControlItem1.TextVisible = false;
          // 
-         // defaultMergeBehaviorGroup
+         // mergeBehaviorItem
          // 
-         this.mergeBehaviorGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
-            this.layoutControlItem1,
-            this.mergeBehaviorItem});
-         this.mergeBehaviorGroup.Location = new System.Drawing.Point(0, 24);
-         this.mergeBehaviorGroup.Name = "mergeBehaviorGroup";
-         this.mergeBehaviorGroup.Size = new System.Drawing.Size(560, 86);
+         this.mergeBehaviorItem.Control = this.cbDefaultMergeBehavior;
+         this.mergeBehaviorItem.Location = new System.Drawing.Point(0, 0);
+         this.mergeBehaviorItem.Name = "mergeBehaviorItem";
+         this.mergeBehaviorItem.Size = new System.Drawing.Size(536, 24);
+         this.mergeBehaviorItem.TextSize = new System.Drawing.Size(130, 13);
          // 
          // BaseModuleContentView
          // 
@@ -488,9 +488,9 @@
          ((System.ComponentModel.ISupportInitialize)(this.moleculesItem)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.parameterValuesNameItem)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.initialConditionsNameItem)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.mergeBehaviorItem)).EndInit();
-         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.mergeBehaviorGroup)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.mergeBehaviorItem)).EndInit();
          this.ResumeLayout(false);
          this.PerformLayout();
 

--- a/src/MoBi.UI/Views/BaseModuleContentView.cs
+++ b/src/MoBi.UI/Views/BaseModuleContentView.cs
@@ -36,7 +36,7 @@ namespace MoBi.UI.Views
          moduleNameItem.Text = $"{Module} {Captions.Name}".FormatForLabel();
 
          cbSpatialStructure.Text = SpatialStructure;
-         cbEventGroup.Text = Event;
+         cbEventGroup.Text = AppConstants.Captions.Events;
          cbReactions.Text = Reactions;
          cbMolecules.Text = Molecules;
          cbObservers.Text = Observer;


### PR DESCRIPTION
Fixes #1732

# Description
Reorder between `molecules` and `reactions` when you modify a module (add/create) and change the type from `Event` to `Events`.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/22b63e31-47b1-4e7c-befa-9ce8a559dba4)

# Questions (if appropriate):