### PR TITLE
Fixes #1874 Cannot add expression profiles to new simulation

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditIndividualAndExpressionConfigurationsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditIndividualAndExpressionConfigurationsPresenter.cs
@@ -141,6 +141,9 @@ namespace MoBi.Presentation.Presenter
 
       public int CompareSelectedNodes(ITreeNode node1, ITreeNode node2)
       {
+         if (node1 == null || node2 == null)
+            return 0;
+
          var expression1 = node1.TagAsObject as ExpressionProfileBuildingBlock;
          var expression2 = node2.TagAsObject as ExpressionProfileBuildingBlock;
 


### PR DESCRIPTION
Fixes #1874

# Description
Must have been from DevExpress update

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):