### PR TITLE
Fixes #1909 RHS in spatial structure circular reference not allowed

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditFormulaPathListPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditFormulaPathListPresenter.cs
@@ -124,8 +124,7 @@ namespace MoBi.Presentation.Presenter
          var path = new ObjectPath(newPath.ToPathArray());
          var formulaUsablePath = _formula.FormulaUsablePathBy(dto.Alias);
 
-         if (_circularReferenceChecker.HasCircularReference(path, _formulaOwner))
-            throw new OSPSuiteException(AppConstants.Exceptions.CircularReferenceException(path, _formula));
+         checkForCircularReference(path);
 
          AddCommand(_moBiFormulaTask.ChangePathInFormula(_formula, path, formulaUsablePath, BuildingBlock));
       }
@@ -182,13 +181,13 @@ namespace MoBi.Presentation.Presenter
          AddCommand(_moBiFormulaTask.AddFormulaUsablePath(_formula, path, BuildingBlock));
       }
 
-      private void checkForCircularReference(FormulaUsablePath path)
+      private void checkForCircularReference(ObjectPath path)
       {
          if (hasCircularReference(path))
             throw new OSPSuiteException(AppConstants.Exceptions.CircularReferenceException(path, _formula));
       }
 
-      private bool hasCircularReference(FormulaUsablePath path)
+      private bool hasCircularReference(ObjectPath path)
       {
          return CheckCircularReference && _formulaOwner != null && _circularReferenceChecker.HasCircularReference(path, _formulaOwner);
       }

--- a/tests/MoBi.Tests/Presentation/EditFormulaPathListPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditFormulaPathListPresenterSpecs.cs
@@ -93,6 +93,34 @@ namespace MoBi.Presentation
       protected override bool CreatesCircularRef => false;
    }
 
+   internal class When_setting_a_path_that_creates_a_circular_reference_but_the_presenter_is_forbidden_to_check : When_setting_a_path
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.CheckCircularReference = false;
+      }
+
+      protected override void Because()
+      {
+         sut.SetFormulaUsablePath(_aNewPath, _formulaUsablePathDTO);
+      }
+
+      [Observation]
+      public void the_formula_task_sets_the_formula()
+      {
+         A.CallTo(() => _moBiFormulaTask.ChangePathInFormula(A<IFormula>._, A<ObjectPath>._, A<FormulaUsablePath>._, A<IBuildingBlock>._)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_circular_reference_checker_is_not_used_to_check_for_circular_references()
+      {
+         A.CallTo(() => _circularReferenceChecker.HasCircularReference(A<ObjectPath>._, _parameter)).MustNotHaveHappened();
+      }
+
+      protected override bool CreatesCircularRef => true;
+   }
+
    internal class When_setting_a_path_that_creates_a_circular_reference : When_setting_a_path
    {
       [Observation]


### PR DESCRIPTION
Fixes #1909

# Description
There are cases where the circular reference checker should not be used. RHS is one case.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):