### PR TITLE
#1929 typing container disabled when selecting parent path

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
@@ -208,7 +208,7 @@ namespace MoBi.Presentation.Presenter
          _view.BindTo(_containerDTO);
          _tagsPresenter.Edit(container);
          _view.ContainerPropertiesEditable = !container.IsMoleculeProperties();
-         _view.IsNameEditable = _isNewEntity;
+         _view.NameEditable = _isNewEntity;
       }
 
       public override object Subject => _container;

--- a/src/MoBi.Presentation/Views/IEditContainerView.cs
+++ b/src/MoBi.Presentation/Views/IEditContainerView.cs
@@ -9,7 +9,7 @@ namespace MoBi.Presentation.Views
       void BindTo(ContainerDTO dto);
       void AddTagsView(IView view);
       bool ReadOnly { get; set; }
-      bool ContainerPropertiesEditable { get; set; }
-      bool IsNameEditable { get; set; }
+      bool ContainerPropertiesEditable { set; }
+      bool NameEditable { set; }
    }
 }

--- a/src/MoBi.UI/Views/EditContainerView.cs
+++ b/src/MoBi.UI/Views/EditContainerView.cs
@@ -15,7 +15,6 @@ using OSPSuite.Presentation.Extensions;
 using OSPSuite.Presentation.Views;
 using OSPSuite.UI.Controls;
 using OSPSuite.UI.Extensions;
-using OSPSuite.Utility.Extensions;
 using ToolTips = MoBi.Assets.ToolTips;
 
 namespace MoBi.UI.Views
@@ -174,7 +173,6 @@ namespace MoBi.UI.Views
 
       public bool ContainerPropertiesEditable
       {
-         get => cbContainerType.Enabled;
          set
          {
             if (_readOnly && value)
@@ -187,16 +185,14 @@ namespace MoBi.UI.Views
          }
       }
 
-      public bool IsNameEditable
+      public bool NameEditable
       {
-         get => btName.Enabled;
          set
          {
-            btName.Enabled = value;
+            // This control gets readonly to prevent direct typing of the name
+            // is stays enabled to allow the use of the button
             btName.ReadOnly = !value;
-            if (value)
-               return;
-            editNameButton.Visible = false;
+            editNameButton.Visible = btName.ReadOnly;
          }
       }
 


### PR DESCRIPTION
Fixes #1929 

# Description

 In the Create Container dialogue: If you first choose the Parent Container instead of typing the name, it's not possible to enter a name for the container anymore. Since no name has been entered the ... button doesn't show either.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):