### PR TITLE
Fixes #1948 Creating a new logical container should not create MoleculeProperties

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
@@ -148,7 +148,7 @@ namespace MoBi.Presentation.Presenter
             if (moleculeProperties!= null)
                macroCommand.Add(new RemoveContainerFromSpatialStructureCommand(_container, moleculeProperties, (MoBiSpatialStructure)BuildingBlock).RunCommand(_context));
          }
-         else
+         else if(_editTasks.GetMoleculeProperties(_container) == null)
          {
             var moleculeProperties = _context.Create<IContainer>()
                .WithName(Constants.MOLECULE_PROPERTIES)

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainerBase.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainerBase.cs
@@ -36,12 +36,16 @@ namespace MoBi.Presentation.Tasks.Interaction
 
       public override IContainer CreateNewEntity(TParent parent)
       {
-         var newEntity = base.CreateNewEntity(parent);
+         var newContainer = base.CreateNewEntity(parent);
+
+         if (newContainer.Mode != ContainerMode.Physical) 
+            return newContainer;
+
          var moleculeProperties = Context.Create<IContainer>()
             .WithName(Constants.MOLECULE_PROPERTIES)
             .WithMode(ContainerMode.Logical);
-         newEntity.Add(moleculeProperties);
-         return newEntity;
+         newContainer.Add(moleculeProperties);
+         return newContainer;
       }
 
       private MoBiSpatialStructure getSpatialStructure(IBuildingBlock buildingBlockWithFormulaCache)


### PR DESCRIPTION
Fixes #1948

# Description
Make sure that we don't try to add a container with the same name.
Make sure that we don't create logical containers with moleculeproperties

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):