### PR TITLE
Fixes #1880 Show parameters from Individual/Copy Path: only parametername is copied.

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
@@ -179,7 +179,13 @@ namespace MoBi.Presentation.Presenter
 
       public void EnableContainerCriteriaSupport() => _editParameterPresenter.EnableContainerCriteriaSupport();
 
-      public void CopyPathForParameter(ParameterDTO parameter) => _view.CopyToClipBoard(_entityPathResolver.PathFor(parameter.Parameter));
+      public void CopyPathForParameter(ParameterDTO parameter)
+      {
+         if(!parameter.IsIndividualPreview)
+            _view.CopyToClipBoard(_entityPathResolver.PathFor(parameter.Parameter));
+         else
+            _view.CopyToClipBoard(_individualParameterCache[parameter].Path.PathAsString);
+      }
 
       private void createParameterCache()
       {

--- a/tests/MoBi.Tests/Presentation/EditParametersInContainerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditParametersInContainerPresenterSpecs.cs
@@ -444,7 +444,45 @@ namespace MoBi.Presentation
       }
    }
 
-   public class When_copying_parameter_path : concern_for_EditParametersInContainerPresenter
+   public class When_copying_parameter_path_for_individual_parameter : concern_for_EditParametersInContainerPresenter
+   {
+      private ParameterDTO _parameterDTO;
+      private IndividualParameter _individualParameter;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameterDTO = new ParameterDTO(_parameter)
+         {
+            IsIndividualPreview = true
+         };
+
+         _individualParameter = new IndividualParameter {Path = new ObjectPath("Organism", "Container", "Organ", "ADC")};
+         var individualBuildingBlock = new IndividualBuildingBlock { _individualParameter };
+         var organism = new Container().WithName("Organism");
+         var container = new Container().WithName("Container");
+         var organ = new Container().WithName("Organ");
+         organism.Add(container);
+         container.Add(organ);
+         sut.Edit(organ);
+         sut.SelectedIndividual = individualBuildingBlock;
+         A.CallTo(() => _individualParameterToParameterDTOMapper.MapFrom(individualBuildingBlock, _individualParameter)).Returns(_parameterDTO);
+         sut.UpdatePreview();
+      }
+
+      protected override void Because()
+      {
+         sut.CopyPathForParameter(_parameterDTO);
+      }
+
+      [Observation]
+      public void should_copy_resolved_path_to_clipboard()
+      {
+         A.CallTo(() => _view.CopyToClipBoard(_individualParameter.Path)).MustHaveHappened();
+      }
+   }
+
+   public class When_copying_parameter_path_for_container_parameter : concern_for_EditParametersInContainerPresenter
    {
       private string _expectedPath;
       private ParameterDTO _parameterDTO;


### PR DESCRIPTION
Fixes #1880

# Description
When the parameter is a preview of an individual parameter we have to get the path a different way

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):