### PR TITLE
 check for presence of module snapshot before using it in mobi

### DIFF
--- a/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
+++ b/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
@@ -166,8 +166,8 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
 
    private Simulation[] mapSimulations(IReadOnlyList<MoBiSimulation> projectSimulations, ModelProject project) => _simulationMapper.MapToSnapshots(projectSimulations, project).Result;
 
-   private string[] mapPKSimModules(ModelProject project) => project.Modules.Where(x => x.IsPKSimModule).Select(x => x.Snapshot).ToArray();
-   private string[] mapExtensionModules(ModelProject project) => project.Modules.Where(x => !x.IsPKSimModule).Select(serializeToBase64PKML).ToArray();
+   private string[] mapPKSimModules(ModelProject project) => project.Modules.Where(shouldUsePKSimSnapshot).Select(x => x.Snapshot).ToArray();
+   private string[] mapExtensionModules(ModelProject project) => project.Modules.Where(x => !shouldUsePKSimSnapshot(x)).Select(serializeToBase64PKML).ToArray();
    private string[] mapExpressionProfilesBuildingBlocks(ModelProject project) => project.ExpressionProfileCollection.Where(x => !isFromSnapshot(x, project)).Select(serializeToBase64PKML).ToArray();
    private string[] mapIndividualBuildingBlocks(ModelProject project) => project.IndividualsCollection.Where(x => !isFromSnapshot(x, project)).Select(serializeToBase64PKML).ToArray();
 
@@ -181,7 +181,12 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
 
       var module = project.Modules.FindById(snapshotOriginModuleId);
 
-      return module.IsPKSimModule;
+      return shouldUsePKSimSnapshot(module);
+   }
+
+   private static bool shouldUsePKSimSnapshot(Module module)
+   {
+      return module.IsPKSimModule && module.HasSnapshot;
    }
 
    private static bool isFromSnapshot(IndividualBuildingBlock individualBuildingBlock, ModelProject project) => 

--- a/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectMapperSpecs.cs
+++ b/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectMapperSpecs.cs
@@ -17,6 +17,7 @@ using OSPSuite.Core.Serialization.Exchange;
 using OSPSuite.Core.Services;
 using OSPSuite.Core.Snapshots.Mappers;
 using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
 using Classification = OSPSuite.Core.Domain.Classification;
 using OutputMapping = OSPSuite.Core.Domain.OutputMapping;
 using ParameterIdentification = OSPSuite.Core.Domain.ParameterIdentifications.ParameterIdentification;
@@ -203,6 +204,34 @@ namespace MoBi.IntegrationTests.Snapshots
       {
          _result.AllParameterIdentifications.FirstOrDefault().Analyses.Count().ShouldBeEqualTo(1);
          (_result.AllParameterIdentifications.FirstOrDefault().Analyses.First() is ParameterIdentificationTimeProfileChart).ShouldBeTrue();
+      }
+   }
+
+   internal class When_mapping_project_to_snapshot_and_pksim_module_does_not_have_snapshot : concern_for_ProjectMapper
+   {
+      private SnapshotProject _snapshot;
+
+      protected override void Context()
+      {
+         base.Context();
+         _project.Modules.Where(x => x.IsPKSimModule).Each(x => x.Snapshot = string.Empty);
+      }
+
+      protected override void Because()
+      {
+         _snapshot = sut.MapToSnapshot(_project).Result;
+      }
+
+      [Observation]
+      public void the_snapshot_should_contain_extension_modules_snapshots_for_each_extension_module_and_pksim_module_without_a_snapshot()
+      {
+         _snapshot.ExtensionModules.Length.ShouldBeEqualTo(2);
+      }
+
+      [Observation]
+      public void the_snapshot_should_not_contain_pksim_modules()
+      {
+         _snapshot.PKSimModules.Length.ShouldBeEqualTo(0);
       }
    }
 


### PR DESCRIPTION
Fixes #1938

# Description
We need to identify that a pksim module has an embedded snapshot before trying to use it. There are projects with PKSim modules that do not have snapshots.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):