### PR TITLE
Fixes #1957 Replace simulation parameters from qualification plan

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.28" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.28" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.29" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.29" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.28" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.29" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -6,14 +6,14 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="OSPSuite.Assets" Version="13.0.28" />
-		<PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.28" />
+		<PackageReference Include="OSPSuite.Assets" Version="13.0.29" />
+		<PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.29" />
 		<PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-		<PackageReference Include="OSPSuite.Core" Version="13.0.28" />
-		<PackageReference Include="OSPSuite.Presentation" Version="13.0.28" />
-		<PackageReference Include="OSPSuite.R" Version="13.0.28" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.28" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.28" />
+		<PackageReference Include="OSPSuite.Core" Version="13.0.29" />
+		<PackageReference Include="OSPSuite.Presentation" Version="13.0.29" />
+		<PackageReference Include="OSPSuite.R" Version="13.0.29" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.29" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.29" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -23,16 +23,16 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.28" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.29" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.28" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.29" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/Extensions/ParameterExtensions.cs
+++ b/src/MoBi.Core/Extensions/ParameterExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using OSPSuite.Core.Domain;
+
+namespace MoBi.Core.Extensions
+{
+   public static class ParameterExtensions
+   {
+      public static bool ShouldExportToSnapshot(this IParameter parameter)
+      {
+         if (parameter == null)
+            return false;
+
+         if (parameter.IsDefault)
+            return false;
+
+         return parameter.ValueIsDefined();
+      }
+
+      /// <summary>
+      ///    Returns <c>true</c> if the value can be computed and is not NaN otherwise <c>false</c>
+      /// </summary>
+      public static bool ValueIsDefined(this IParameter parameter)
+      {
+         if (!ValueIsComputable(parameter))
+            return false;
+
+         return !double.IsNaN(parameter.Value);
+      }
+
+      /// <summary>
+      ///    Returns <c>true</c> if the value can be computed otherwise <c>false</c>
+      /// </summary>
+      public static bool ValueIsComputable(this IParameter parameter)
+      {
+         try
+         {
+            //let's compute the value. Exception will be thrown if value cannot be calculated
+            var v = parameter.Value;
+            return true;
+         }
+         catch (Exception)
+         {
+            //this is a parameter that cannot be evaluated and should not be exported
+            return false;
+         }
+      }
+   }
+}

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -35,13 +35,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.28" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.29" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/Snapshots/Simulation.cs
+++ b/src/MoBi.Core/Snapshots/Simulation.cs
@@ -1,4 +1,9 @@
-﻿using OSPSuite.Core.Snapshots;
+﻿using OSPSuite.Core.Domain;
+using OSPSuite.Core.Snapshots;
+using System.Collections.Generic;
+using System.Linq;
+using OutputMapping = OSPSuite.Core.Snapshots.OutputMapping;
+using OutputSelections = OSPSuite.Core.Snapshots.OutputSelections;
 
 namespace MoBi.Core.Snapshots;
 
@@ -13,9 +18,21 @@ public class Simulation : SnapshotBase
    public string ParameterIdentificationWorkingDirectory { get; set; }
    public SimulationPredictedVsObservedChart SimulationPredictedVsObservedChart { get; set; }
    public CurveChart SimulationResidualVsTimeChart { get; set; }
-}
 
-public class SimulationPredictedVsObservedChart : CurveChart
-{
-   public float[] DeviationFoldValues { get; set; }
+   public LocalizedParameter[] Parameters { get; set; }
+
+   public LocalizedParameter ParameterByPath(string parameterPath) =>
+      Parameters?.Find(x => string.Equals(x.Path, parameterPath));
+
+   public void AddOrUpdate(LocalizedParameter parameter)
+   {
+      var existingParameter = ParameterByPath(parameter.Path);
+      var localizedParameters = new List<LocalizedParameter>(Parameters ?? Enumerable.Empty<LocalizedParameter>());
+      if (existingParameter != null)
+         localizedParameters.Remove(existingParameter);
+
+      localizedParameters.Add(parameter);
+
+      Parameters = localizedParameters.ToArray();
+   }
 }

--- a/src/MoBi.Core/Snapshots/SimulationPredictedVsObservedChart.cs
+++ b/src/MoBi.Core/Snapshots/SimulationPredictedVsObservedChart.cs
@@ -1,0 +1,8 @@
+﻿using OSPSuite.Core.Snapshots;
+
+namespace MoBi.Core.Snapshots;
+
+public class SimulationPredictedVsObservedChart : CurveChart
+{
+   public float[] DeviationFoldValues { get; set; }
+}

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.28" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.29" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -24,9 +24,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="6.3.1" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.28" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.29" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.28" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.29" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -23,11 +23,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.28" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.29" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -65,13 +65,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.28" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.29" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.28" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.29" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.28" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.29" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/Core/Snapshots/SimulationConfigurationMapperSpecs.cs
+++ b/tests/MoBi.Tests/Core/Snapshots/SimulationConfigurationMapperSpecs.cs
@@ -93,9 +93,9 @@ namespace MoBi.Core.Snapshots
       private MoBiProject _project;
       private SimulationContext _context;
 
-      protected override Task Context()
+      protected override async Task Context()
       {
-         base.Context();
+         await base.Context();
          _project = new MoBiProject();
          _project.AddIndividualBuildingBlock(new IndividualBuildingBlock().WithName("individual"));
          _project.AddExpressionProfileBuildingBlock(new ExpressionProfileBuildingBlock().WithName("expression|human|healthy"));
@@ -117,8 +117,6 @@ namespace MoBi.Core.Snapshots
          var simulationSettings = new OSPSuite.Core.Domain.Builder.SimulationSettings();
          A.CallTo(() => _simulationSettingsMapper.MapToModel(_simulationConfiguration.Settings, _context)).Returns(simulationSettings);
          A.CallTo(() => _simulationConfigurationFactory.Create(simulationSettings)).Returns(new OSPSuite.Core.Domain.Builder.SimulationConfiguration { SimulationSettings = simulationSettings });
-
-         return Task.CompletedTask;
       }
 
       protected override Task Because()

--- a/tests/MoBi.Tests/IntegrationTests/Snapshots/SimulationMapperSpecs.cs
+++ b/tests/MoBi.Tests/IntegrationTests/Snapshots/SimulationMapperSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using MoBi.Core.Domain;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Services;
 using MoBi.Core.Snapshots;
@@ -22,6 +23,7 @@ namespace MoBi.IntegrationTests.Snapshots
       protected MoBiProject _project;
 
       private DataRepository _dataRepository;
+      protected Parameter _parameter;
 
       protected override void Context()
       {
@@ -35,10 +37,22 @@ namespace MoBi.IntegrationTests.Snapshots
             }.WithName("sim")
          }.WithName("sim");
 
-         
          var container = new Container().WithName("container");
-         container.Add(new Parameter().WithName("quantity"));
+         _parameter = new Parameter().WithName("quantity").WithValue(1);
+         container.Add(_parameter);
          _simulation.Model.Root.Add(container);
+
+         
+         _simulation.AddOriginalQuantityValue(new OriginalQuantityValue
+         {
+            Dimension = _parameter.Dimension, 
+            DisplayUnit = _parameter.DisplayUnit, 
+            Path = new ObjectPath(_simulation.Model.Root.Name, container.Name, _parameter.Name),
+            Type = OriginalQuantityValue.Types.Quantity,
+            Value = _parameter.Value
+         });
+
+         _parameter.Value = 5;
 
          _simulationConfigurationFactory = IoC.Resolve<ISimulationConfigurationFactory>();
          _dataRepository = DomainHelperForSpecs.ObservedData().WithName("obsdata");
@@ -82,6 +96,13 @@ namespace MoBi.IntegrationTests.Snapshots
       public void result_charts_are_mapped()
       {
          _result.Chart.ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void parameter_value_changes_should_be_stored()
+      {
+         _result.Parameters.Length.ShouldBeEqualTo(1);
+         _result.Parameters.First().Path.ShouldBeEqualTo(_parameter.EntityPath());
       }
 
       [Observation]

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -43,10 +43,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.28" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.29" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/TestFiles/snapshot_no_pksim_modules.json
+++ b/tests/MoBi.Tests/TestFiles/snapshot_no_pksim_modules.json
@@ -292,7 +292,7 @@
               ]
             }
           ],
-          "RandomSeed": 210087812.0
+          "RandomSeed": 359519921.0
         },
         "IndividualBuildingBlock": "Clone of Man",
         "ExpressionProfiles": [
@@ -311,32 +311,6 @@
       ],
       "SimulationPredictedVsObservedChart": {
         "DeviationFoldValues": [],
-        "Axes": [
-          {
-            "Unit": "µmol/l",
-            "Dimension": "Concentration (mass)",
-            "Caption": "Observed Concentration",
-            "Type": "X",
-            "GridLines": false,
-            "Visible": true,
-            "DefaultColor": "#FFFFFF",
-            "DefaultLineStyle": "None",
-            "Scaling": "Log",
-            "NumberMode": "Normal"
-          },
-          {
-            "Unit": "µmol/l",
-            "Dimension": "Concentration (molar)",
-            "Caption": "Simulated  Concentration",
-            "Type": "Y",
-            "GridLines": false,
-            "Visible": true,
-            "DefaultColor": "#FFFFFF",
-            "DefaultLineStyle": "Solid",
-            "Scaling": "Log",
-            "NumberMode": "Normal"
-          }
-        ],
         "FontAndSize": {
           "Fonts": {
             "AxisSize": 10,
@@ -356,31 +330,6 @@
         }
       },
       "SimulationResidualVsTimeChart": {
-        "Axes": [
-          {
-            "Unit": "h",
-            "Dimension": "Time",
-            "Type": "X",
-            "GridLines": false,
-            "Visible": true,
-            "DefaultColor": "#FFFFFF",
-            "DefaultLineStyle": "None",
-            "Scaling": "Linear",
-            "NumberMode": "Normal"
-          },
-          {
-            "Unit": "",
-            "Dimension": "Dimensionless",
-            "Caption": "Residuals",
-            "Type": "Y",
-            "GridLines": false,
-            "Visible": true,
-            "DefaultColor": "#FFFFFF",
-            "DefaultLineStyle": "Solid",
-            "Scaling": "Linear",
-            "NumberMode": "Normal"
-          }
-        ],
         "FontAndSize": {
           "Fonts": {
             "AxisSize": 10,
@@ -398,7 +347,18 @@
           "BackColor": "#FFFFFF",
           "DiagramBackColor": "#FFFFFF"
         }
-      }
+      },
+      "Parameters": [
+        {
+          "Path": "Organism|ArterialBlood|BloodCells|Volume",
+          "Value": 0.22,
+          "Unit": "l",
+          "ValueOrigin": {
+            "Id": 35,
+            "Source": "Unknown"
+          }
+        }
+      ]
     }
   ],
   "ReactionDimensionMode": "AmountBased"

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.28" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.28" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.29" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.29" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1957

# Description
We did not have the concept of overridden simulation parameters in a snapshot until now. I added that, as well as the implementation from `QualificationRunner`

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):