### PR TITLE
Creating a new physical container does not create "MoleculeProperties" node

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
@@ -119,13 +119,7 @@ namespace MoBi.Presentation.Presenter
       {
          var oldContainerMode = _container.Mode;
 
-         if (_isNewEntity)
-         {
-            _container.Mode = newContainerMode;
-            return newContainerMode;
-         }
-
-         if (newContainerMode == ContainerMode.Logical)
+         if (!_isNewEntity && newContainerMode == ContainerMode.Logical)
          {
             var ans = _dialogCreator.MessageBoxYesNo("This action will remove all MoleculeProperties of this container, are you sure?");
             if (ans == ViewResult.No)

--- a/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
@@ -118,8 +118,19 @@ namespace MoBi.Presentation.Presenter
       public ContainerMode ConfirmAndSetContainerMode(ContainerMode newContainerMode)
       {
          var oldContainerMode = _container.Mode;
+         if (_isNewEntity)
+         {
+            _container.Mode = newContainerMode;
 
-         if (!_isNewEntity && newContainerMode == ContainerMode.Logical)
+            if(newContainerMode == ContainerMode.Physical && !hasMoleculeProperties(_container))
+               _container.Add(createMoleculePropertiesContainer());
+            else if (newContainerMode == ContainerMode.Logical && hasMoleculeProperties(_container))
+               _container.RemoveChild(_editTasks.GetMoleculeProperties(_container));
+              
+            return newContainerMode;
+         }
+
+         if (newContainerMode == ContainerMode.Logical)
          {
             var ans = _dialogCreator.MessageBoxYesNo("This action will remove all MoleculeProperties of this container, are you sure?");
             if (ans == ViewResult.No)
@@ -139,21 +150,24 @@ namespace MoBi.Presentation.Presenter
          {
             var moleculeProperties = _editTasks.GetMoleculeProperties(_container);
 
-            if (moleculeProperties!= null)
+            if (hasMoleculeProperties(_container))
                macroCommand.Add(new RemoveContainerFromSpatialStructureCommand(_container, moleculeProperties, (MoBiSpatialStructure)BuildingBlock).RunCommand(_context));
          }
-         else if(_editTasks.GetMoleculeProperties(_container) == null)
+         else if(!hasMoleculeProperties(_container))
          {
-            var moleculeProperties = _context.Create<IContainer>()
-               .WithName(Constants.MOLECULE_PROPERTIES)
-               .WithMode(ContainerMode.Logical);
-
-            macroCommand.Add(new AddContainerToSpatialStructureCommand(_container, moleculeProperties, (MoBiSpatialStructure)BuildingBlock).RunCommand(_context));
+            macroCommand.Add(new AddContainerToSpatialStructureCommand(_container, createMoleculePropertiesContainer(), (MoBiSpatialStructure)BuildingBlock).RunCommand(_context));
          }
 
          AddCommand(macroCommand);
          return newContainerMode;
       }
+
+      private bool hasMoleculeProperties(IContainer container) => _editTasks.GetMoleculeProperties(container) != null;
+
+      private IContainer createMoleculePropertiesContainer() =>
+         _context.Create<IContainer>()
+            .WithName(Constants.MOLECULE_PROPERTIES)
+            .WithMode(ContainerMode.Logical);
 
       public IReadOnlyList<ContainerType> AllContainerTypes { get; } = new[]
       {

--- a/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
@@ -281,7 +281,7 @@ namespace MoBi.Presentation
       [Observation]
       public void should_change_mode()
       {
-         _muscle.Mode.ShouldBeEqualTo(ContainerMode.Logical);
+         A.CallTo(() => _editTasks.SetContainerMode(_spatialStructure, _muscle, ContainerMode.Logical)).MustHaveHappened();
       }
    }
 


### PR DESCRIPTION
Fixes #1984

# Description
We set the mode, but do not add the MoleculeProperties container when the container is new.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):