### PR TITLE
Fixes #1962 Warning for pksim modules that don't have a pksim snapshot

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -2024,6 +2024,16 @@ namespace MoBi.Assets
             return sb.ToString();
          }
 
+         public static string PKSimModulesWithoutSnapshots(IReadOnlyList<string> moduleNames)
+         {
+            var sb = new StringBuilder();
+            sb.AppendLine();
+            sb.Append($"The following PK-Sim modules will be exported as PKML and not PK-Sim snapshots because the are too old");
+            sb.AppendLine();
+            sb.Append(namesList(moduleNames));
+            return OSPSuite.Assets.Captions.DoYouWantToProceed(sb.ToString());
+         }
+
          public static string CouldNotAddExpressionProfilesDuplicatingProtein(IReadOnlyList<string> proteinNames)
          {
             var sb = new StringBuilder();

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -2028,7 +2028,7 @@ namespace MoBi.Assets
          {
             var sb = new StringBuilder();
             sb.AppendLine();
-            sb.Append($"The following PK-Sim modules will be exported as PKML and not PK-Sim snapshots because the are too old");
+            sb.Append($"The following PK-Sim modules will be exported as extension modules (PKML) and not PK-Sim modules (snapshots) because they are too old");
             sb.AppendLine();
             sb.Append(namesList(moduleNames));
             return OSPSuite.Assets.Captions.DoYouWantToProceed(sb.ToString());

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -17,6 +17,7 @@ using OSPSuite.Core.Serialization.Exchange;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Services;
 using OSPSuite.Utility.Extensions;
+using static MoBi.Assets.AppConstants.Captions;
 
 namespace MoBi.Presentation.Tasks
 {
@@ -156,7 +157,12 @@ namespace MoBi.Presentation.Tasks
 
          var anySimulationInChangedState = project.All<MoBiSimulation>().Any(x => x.OriginalQuantityValues.Any());
 
+         var pkSimModulesWithoutSnapshots = project.Modules.Where(x => x.IsPKSimModule && !x.HasSnapshot).AllNames();
+
          if (exitIf(anySimulationInChangedState, Captions.SnapshotOfProjectWithChangedSimulation))
+            return Task.CompletedTask;
+
+         if(exitIf(pkSimModulesWithoutSnapshots.Any(), PKSimModulesWithoutSnapshots(pkSimModulesWithoutSnapshots)))
             return Task.CompletedTask;
 
          return _snapshotTask.ExportModelToSnapshotAsync(project);

--- a/tests/MoBi.Tests/Presentation/ProjectTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ProjectTaskSpecs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using DevExpress.Utils.Extensions;
 using FakeItEasy;
 using MoBi.Assets;
 using MoBi.Core.Domain.Builder;
@@ -41,7 +42,7 @@ namespace MoBi.Presentation
       private ISbmlTask _sbmlTask;
       protected IReactionBuildingBlockFactory _reactionBuildingBlockFactory;
       private IMoBiApplicationController _applicationController;
-      private ISnapshotTask _snapshotTask;
+      protected ISnapshotTask _snapshotTask;
 
       protected override void Context()
       {
@@ -61,6 +62,69 @@ namespace MoBi.Presentation
          
          sut = new ProjectTask(_context, _serializationTask, _dialogCreator, _mruProvider, _heavyWorkManager,
             new SimulationLoader(_cloneManager, _nameCorrector, _context), _sbmlTask, _snapshotTask, _applicationController);
+      }
+   }
+
+   internal class When_exporting_a_snapshot_and_declining_export_with_pksim_modules_that_do_not_have_snapshot : concern_for_ProjectTask
+   {
+      private string _moduleName;
+
+      protected override void Context()
+      {
+         base.Context();
+         _moduleName = "module";
+         var project = new MoBiProject();
+         var module = new Module().WithName(_moduleName);
+         module.IsPKSimModule = true;
+         project.AddModule(module);
+
+         A.CallTo(() => _context.CurrentProject).Returns(project);
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>.That.Matches(x => Equals(x, AppConstants.Captions.PKSimModulesWithoutSnapshots(new[] { _moduleName }))), ViewResult.Yes)).Returns(ViewResult.No);
+      }
+
+      protected override void Because()
+      {
+         sut.ExportCurrentProjectToSnapshot();
+      }
+
+      [Observation]
+      public void the_project_should_not_be_exported()
+      {
+         A.CallTo(() => _snapshotTask.ExportModelToSnapshotAsync(_context.CurrentProject)).MustNotHaveHappened();
+      }
+   }
+
+   internal class When_exporting_a_snapshot_and_confirming_export_with_pksim_modules_that_do_not_have_snapshot : concern_for_ProjectTask
+   {
+      private string _moduleName;
+
+      protected override void Context()
+      {
+         base.Context();
+         _moduleName = "module";
+         var project = new MoBiProject();
+         var module = new Module().WithName(_moduleName);
+         module.IsPKSimModule = true;
+         project.AddModule(module);
+
+         A.CallTo(() => _context.CurrentProject).Returns(project);
+      }
+
+      protected override void Because()
+      {
+         sut.ExportCurrentProjectToSnapshot();
+      }
+
+      [Observation]
+      public void the_project_should_be_exported()
+      {
+         A.CallTo(() => _snapshotTask.ExportModelToSnapshotAsync(_context.CurrentProject)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_dialog_must_confirm_that_pksim_modules_without_snapshots_should_be_exported()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>.That.Matches(x => Equals(x, AppConstants.Captions.PKSimModulesWithoutSnapshots(new[] { _moduleName }))), ViewResult.Yes)).MustHaveHappened();
       }
    }
 


### PR DESCRIPTION
Fixes #1962

# Description
User confirmation that export should proceed when a project has PK-Sim modules that do not contain a snapshot

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
<img width="631" height="238" alt="image" src="https://github.com/user-attachments/assets/8fef6c90-5f70-4060-b2dd-5fdc7f42a514" />

# Questions (if appropriate):