### PR TITLE
#1976 remove update command from macrocommand

### DIFF
--- a/src/MoBi.Presentation/Tasks/SimulationUpdateTask.cs
+++ b/src/MoBi.Presentation/Tasks/SimulationUpdateTask.cs
@@ -77,8 +77,6 @@ namespace MoBi.Presentation.Tasks
             CommandType = AppConstants.Commands.AddCommand,
             Description = AppConstants.Commands.AddToProjectDescription(ObjectTypes.Simulation, clonedSimulation.Name)
          };
-         // I Removed this since the simulation will be removed on reversal, and then try to configure it. 
-         // Therefore, it will fail since after removal, the configuration will try to be performed over a null simulation.
          ConfigureSimulation(clonedSimulation);
          macroCommand.Add(new AddSimulationCommand(clonedSimulation).RunCommand(_context));
 


### PR DESCRIPTION
Fixes #1976 

# Description

The undo command is breaking due to the fact that the cloned simulation (added to the project, then configured) is trying to be "unconfigured" alfter the rollback of the add. meaning, the steps in order:
1) Cloned Simulation is Configured
2) Cloned Simulation is added to the project
When rolling back
3) Cloned Simulation is removed from the project
4) Cloned Simulation is trying to rollback config --> It fails since it has already been removed.


## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):