### PR TITLE
Issues while importing initial conditions

### DIFF
--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForInitialConditionsBuildingBlock.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForInitialConditionsBuildingBlock.cs
@@ -1,4 +1,6 @@
-﻿using MoBi.Assets;
+﻿using System.Collections.Generic;
+using MoBi.Assets;
+using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Tasks.Interaction;
@@ -12,6 +14,7 @@ using OSPSuite.Presentation.MenuAndBars;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation.MenusAndBars.ContextMenus
 {
@@ -34,7 +37,7 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
             .WithIcon(ApplicationIcons.ExportToExcel)
             .WithCommandFor<ExportInitialConditionsBuildingBlockToExcelUICommand, InitialConditionsBuildingBlock>(buildingBlock, _container));
 
-         _allMenuItems.Add(createExtendBuildingBlockCommand(buildingBlock));
+         createExtendBuildingBlockCommands(buildingBlock).Each(x => _allMenuItems.Add(x));
          return this;
       }
 
@@ -45,11 +48,15 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
             .WithCommandFor<ClonePathAndValueEntityBuildingBlockUICommand<InitialConditionsBuildingBlock, InitialCondition, IInitialConditionsTask<InitialConditionsBuildingBlock>>, InitialConditionsBuildingBlock>(buildingBlock, _container);
       }
 
-      private IMenuBarItem createExtendBuildingBlockCommand(InitialConditionsBuildingBlock buildingBlock)
+      private IEnumerable<IMenuBarItem> createExtendBuildingBlockCommands(InitialConditionsBuildingBlock buildingBlock)
       {
-         return CreateMenuButton.WithCaption(AppConstants.MenuNames.ExtendFrom(ObjectTypes.InitialConditionsBuildingBlock))
+         yield return CreateMenuButton.WithCaption(AppConstants.MenuNames.ExtendFrom(ObjectTypes.InitialConditionsBuildingBlock))
             .WithIcon(ApplicationIcons.LoadIconFor(nameof(InitialConditionsBuildingBlock)))
             .WithCommandFor<ExtendInitialConditionsFromInitialConditionsUICommand, InitialConditionsBuildingBlock>(buildingBlock, _container);
+
+         yield return CreateMenuButton.WithCaption(AppConstants.MenuNames.ExtendFrom(ObjectTypes.ExpressionProfileBuildingBlock))
+            .WithIcon(ApplicationIcons.LoadIconFor(nameof(ExpressionProfileBuildingBlock)))
+            .WithCommandFor<ExtendInitialConditionsFromExpressionProfileUICommand, InitialConditionsBuildingBlock>(buildingBlock, _container);
       }
    }
 }

--- a/src/MoBi.Presentation/Tasks/SerializationTask.cs
+++ b/src/MoBi.Presentation/Tasks/SerializationTask.cs
@@ -194,8 +194,6 @@ namespace MoBi.Presentation.Tasks
          if (expectedElementName.Equals(AppConstants.XmlNames.MoleculeBuildingBlock)) return AppConstants.XmlNames.Molecules;
          if (expectedElementName.Equals(AppConstants.XmlNames.ObserverBuildingBlock)) return AppConstants.XmlNames.Observers;
          if (expectedElementName.Equals(AppConstants.XmlNames.EventGroupBuildingBlock)) return AppConstants.XmlNames.EventGroups;
-         if (expectedElementName.Equals(AppConstants.XmlNames.InitialConditionsBuildingBlock)) return AppConstants.XmlNames.InitialConditions;
-         if (expectedElementName.Equals(AppConstants.XmlNames.ParameterValuesBuildingBlock)) return AppConstants.XmlNames.ParameterValues;
          if (expectedElementName.Equals(AppConstants.XmlNames.MoBiReactionBuildingBlock)) return AppConstants.XmlNames.Reactions;
          if (expectedElementName.Equals(AppConstants.XmlNames.ReactionBuildingBlock)) return AppConstants.XmlNames.Reactions;
          if (expectedElementName.Equals(AppConstants.XmlNames.MoBiSpatialStructure)) return AppConstants.XmlNames.SpatialStructure;

--- a/src/MoBi.Presentation/UICommand/ExtendInitialConditionsFromExpressionProfileUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/ExtendInitialConditionsFromExpressionProfileUICommand.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class ExtendInitialConditionsFromExpressionProfileUICommand : ExtendBuildingBlockFromPathAndValuesUICommand<ExpressionProfileBuildingBlock, Module, InitialConditionsBuildingBlock, InitialCondition>
+   {
+      public ExtendInitialConditionsFromExpressionProfileUICommand(
+         IInitialConditionsTask<ExpressionProfileBuildingBlock> interactionTasksForSource, 
+         IInitialConditionsTask<InitialConditionsBuildingBlock> interactionTasksForTarget, 
+         IMoBiContext context) : base(interactionTasksForSource, interactionTasksForTarget, context)
+      {
+      }
+
+      protected override IReadOnlyList<InitialCondition> MapAll(IReadOnlyList<ExpressionProfileBuildingBlock> buildingBlocks)
+      {
+         return buildingBlocks.SelectMany(x => x.InitialConditions).ToList();
+      }
+   }
+}

--- a/src/MoBi.Presentation/UICommand/ExtendParameterValuesFromPathAndValuesUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/ExtendParameterValuesFromPathAndValuesUICommand.cs
@@ -7,7 +7,6 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
-using OSPSuite.Utility;
 using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation.UICommand


### PR DESCRIPTION
Fixes #2030 Initial conditions BB - Extend from BB and select an Expression Profile
Fixes #2031 Load Initial Conditions BB - select an exported Expression Profile

# Description
Serializer accepted non-matching xml elements because of a bug in the serialization task.
Allow users to extend initial conditions from expression profile because it contains initial conditions.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):