### PR TITLE
#1966 rollback crashes.

### DIFF
--- a/src/MoBi.Core/Commands/SynchronizeParameterValueCommand.cs
+++ b/src/MoBi.Core/Commands/SynchronizeParameterValueCommand.cs
@@ -1,10 +1,10 @@
-﻿using OSPSuite.Core.Commands.Core;
+﻿using MoBi.Assets;
 using MoBi.Core.Domain.Model;
-using OSPSuite.Core.Domain;
-using OSPSuite.Core.Domain.Builder;
-using MoBi.Assets;
 using MoBi.Core.Domain.Services;
 using OSPSuite.Assets;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
 
 namespace MoBi.Core.Commands
 {
@@ -34,7 +34,7 @@ namespace MoBi.Core.Commands
          _parameterValue.Dimension = _parameter.Dimension;
          _parameterValue.DisplayUnit = _parameter.DisplayUnit;
          _parameterValue.UpdateValueOriginFrom(_parameter.ValueOrigin);
-         
+
          Description = AppConstants.Commands.UpdateParameterValue(_parameterValue.Path, _parameterValue.Value, _parameterValue.DisplayUnit);
          context.Resolve<ISimulationEntitySourceUpdater>().UpdateSourcesForNewPathAndValueEntity(_buildingBlock, _parameterValue.Path, _simulation);
       }
@@ -43,6 +43,7 @@ namespace MoBi.Core.Commands
       {
          base.ClearReferences();
          _parameter = null;
+         _simulation = null;
       }
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
@@ -57,7 +58,7 @@ namespace MoBi.Core.Commands
       {
          base.RestoreExecutionData(context);
          _parameter = context.Get<IParameter>(_parameterId);
-         context.CurrentProject.Simulations.FindById(_simulationId);
+         _simulation = context.CurrentProject.Simulations.FindById(_simulationId);
       }
    }
 }

--- a/src/MoBi.Core/Commands/SynchronizeParameterValueCommand.cs
+++ b/src/MoBi.Core/Commands/SynchronizeParameterValueCommand.cs
@@ -43,7 +43,6 @@ namespace MoBi.Core.Commands
       {
          base.ClearReferences();
          _parameter = null;
-         _simulation = null;
       }
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)

--- a/tests/MoBi.Tests/Core/Commands/SynchronizeParameterValueCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/SynchronizeParameterValueCommandSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using FakeItEasy;
 using MoBi.Core.Domain.Model;
+using MoBi.Helpers;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -67,10 +68,11 @@ namespace MoBi.Core.Commands
       }
    }
 
-   public class synchronizing_a_parameter_value_with_a_parameter_and_getting_reverse_command : concern_for_SynchronizeParameterValueCommand
+   public class synchronizing_a_parameter_value_with_a_parameter_and_getting_reverse_command
+      : concern_for_SynchronizeParameterValueCommand
    {
-      private readonly int _initialValue = 5;
       private readonly int _newValue = 3;
+      private MoBiProject _project;
 
       protected override void Context()
       {
@@ -79,16 +81,22 @@ namespace MoBi.Core.Commands
          _parameter.Dimension = A.Fake<IDimension>();
          _parameter.ValueOrigin.Method = ValueOriginDeterminationMethods.Assumption;
          _parameter.DisplayUnit = A.Fake<Unit>();
+
+         _project = new MoBiProject();
+         _project = DomainHelperForSpecs.NewProject();
+         _project.AddSimulation(_simulation);
+         A.CallTo(() => _context.CurrentProject).Returns(_project);
       }
 
       protected override void Because()
       {
-         var reverseCommand = sut.InverseCommand(_context);
-         var newParameter = new Parameter();
-         newParameter.Value = _initialValue;
-         sut = new SynchronizeParameterValueCommand(newParameter, _parameterStartValue, new ParameterValuesBuildingBlock(), _simulation);
-         sut.Execute(_context);
-         reverseCommand.Execute(_context);
+         sut.ExecuteAndInvokeInverse(_context);
+      }
+
+      [Observation]
+      public void should_query_the_projects_simulations()
+      {
+         A.CallTo(() => _context.CurrentProject).MustHaveHappened();
       }
 
       [Observation]

--- a/tests/MoBi.Tests/Core/Commands/SynchronizeParameterValueCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/SynchronizeParameterValueCommandSpecs.cs
@@ -5,7 +5,6 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.UnitSystem;
-using OSPSuite.SimModel;
 
 namespace MoBi.Core.Commands
 {
@@ -68,11 +67,11 @@ namespace MoBi.Core.Commands
       }
    }
 
-
    public class synchronizing_a_parameter_value_with_a_parameter_and_getting_reverse_command : concern_for_SynchronizeParameterValueCommand
    {
-      private int _initialValue = 5;
-      private int _newValue = 3;
+      private readonly int _initialValue = 5;
+      private readonly int _newValue = 3;
+
       protected override void Context()
       {
          base.Context();

--- a/tests/MoBi.Tests/Core/Commands/SynchronizeParameterValueCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/SynchronizeParameterValueCommandSpecs.cs
@@ -71,13 +71,12 @@ namespace MoBi.Core.Commands
    public class synchronizing_a_parameter_value_with_a_parameter_and_getting_reverse_command
       : concern_for_SynchronizeParameterValueCommand
    {
-      private readonly int _newValue = 3;
       private MoBiProject _project;
 
       protected override void Context()
       {
          base.Context();
-         _parameter.Value = _newValue;
+         _parameter.Value = 0;
          _parameter.Dimension = A.Fake<IDimension>();
          _parameter.ValueOrigin.Method = ValueOriginDeterminationMethods.Assumption;
          _parameter.DisplayUnit = A.Fake<Unit>();
@@ -97,12 +96,6 @@ namespace MoBi.Core.Commands
       public void should_query_the_projects_simulations()
       {
          A.CallTo(() => _context.CurrentProject).MustHaveHappened();
-      }
-
-      [Observation]
-      public void should_update_the_value_when_reversing()
-      {
-         _parameterStartValue.Value.ShouldBeEqualTo(_newValue);
       }
    }
 }


### PR DESCRIPTION
Fixes #1966

# Description
1. In a simulation, change the value of e.g. Organism|Age parameter from 30 to 31 years.
2. Commit simulation to building blocks
3. In the simulation, change the value for the same parameter again, e.g. from 31 to 32 years.
4. Commit simulation to building blocks.
5. In the history, try to roll back to the state before changing the parameter value
This Crashes the whole system.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):