### PR TITLE
#2008 when starting 1 simulation in paralell

### DIFF
--- a/src/MoBi.Core/Services/ISimulationRunner.cs
+++ b/src/MoBi.Core/Services/ISimulationRunner.cs
@@ -9,5 +9,6 @@ namespace MoBi.Core.Services
       void StopSimulation(IMoBiSimulation simulation);
       void StopAllSimulations();
       bool IsSimulationRunning(IMoBiSimulation simulation);
+      bool IsAnySimulationRunning();
    }
 }

--- a/src/MoBi.Presentation/Presenter/Main/MenuAndToolBarPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/MenuAndToolBarPresenter.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
+using MoBi.Core.Services;
 using MoBi.Presentation.MenusAndBars;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain.Builder;
@@ -62,10 +63,10 @@ namespace MoBi.Presentation.Presenter.Main
       private bool _sensitivityRunning;
       private readonly List<ParameterIdentification> _runningParameterIdentifications = new List<ParameterIdentification>();
       private readonly IActiveSubjectRetriever _activeSubjectRetriever;
-
+      private readonly ISimulationRunner _simulationRunner;
       public MenuAndToolBarPresenter(IMenuAndToolBarView view, IMenuBarItemRepository menuBarItemRepository,
          IButtonGroupRepository buttonGroupRepository, IMRUProvider mruProvider, ISkinManager skinManager,
-         IMoBiContext context, IActiveSubjectRetriever activeSubjectRetriever)
+         IMoBiContext context, IActiveSubjectRetriever activeSubjectRetriever, ISimulationRunner simulationRunner)
          : base(view, menuBarItemRepository, mruProvider)
       {
          _skinManager = skinManager;
@@ -73,6 +74,7 @@ namespace MoBi.Presentation.Presenter.Main
          _menuBarItemRepository = menuBarItemRepository;
          _buttonGroupRepository = buttonGroupRepository;
          _activeSubjectRetriever = activeSubjectRetriever;
+         _simulationRunner = simulationRunner;
       }
 
       protected override void AddRibbonPages()
@@ -287,7 +289,7 @@ namespace MoBi.Presentation.Presenter.Main
       {
          enableDefaultItems();
          projectItemsAreEnabled = true;
-         _menuBarItemRepository[MenuBarItemIds.Stop].Enabled = false;
+         _menuBarItemRepository[MenuBarItemIds.Stop].Enabled = _simulationRunner.IsAnySimulationRunning();
          _menuBarItemRepository[MenuBarItemIds.Run].Enabled = true;
          _menuBarItemRepository[MenuBarItemIds.RunWithSettings].Enabled = true;
          _menuBarItemRepository[MenuBarItemIds.CalculateScaleFactors].Enabled = true;

--- a/src/MoBi.Presentation/Tasks/SimulationRunner.cs
+++ b/src/MoBi.Presentation/Tasks/SimulationRunner.cs
@@ -12,7 +12,6 @@ using MoBi.Core.Events;
 using MoBi.Core.Extensions;
 using MoBi.Core.Services;
 using MoBi.Presentation.Presenter;
-using OSPSuite.Assets;
 using OSPSuite.Core.Commands;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
@@ -40,7 +39,6 @@ namespace MoBi.Presentation.Tasks
       private readonly IEntityValidationTask _entityValidationTask;
       private readonly ConcurrentDictionary<IMoBiSimulation, CancellationTokenSource> _cancellationTokenSources = new ConcurrentDictionary<IMoBiSimulation, CancellationTokenSource>();
 
-
       public SimulationRunner(IMoBiContext context,
          IMoBiApplicationController applicationController,
          IOutputSelectionsRetriever outputSelectionsRetriever,
@@ -58,7 +56,6 @@ namespace MoBi.Presentation.Tasks
          _simModelManagerFactory = simModelManagerFactory;
          _keyPathMapper = keyPathMapper;
          _entityValidationTask = entityValidationTask;
-
       }
 
       public bool IsSimulationRunning(IMoBiSimulation simulation)
@@ -89,7 +86,6 @@ namespace MoBi.Presentation.Tasks
 
          await startSimulationRunAsync(simulation);
       }
-
 
       private void addPersitableParametersToOutputSelection(IMoBiSimulation simulation)
       {
@@ -180,6 +176,7 @@ namespace MoBi.Presentation.Tasks
                   ctsToDispose.Dispose();
                }
             }
+
             removeEvents();
             _context.PublishEvent(new SimulationRunFinishedEvent(simulation));
          }
@@ -282,6 +279,11 @@ namespace MoBi.Presentation.Tasks
          if (_simModelManager == null) return;
          _simModelManager.SimulationProgress += onSimulationProgress;
          _simModelManager.Terminated += onSimulationFinished;
+      }
+
+      public bool IsAnySimulationRunning()
+      {
+         return _cancellationTokenSources.Values.Any(cts => !cts.IsCancellationRequested);
       }
    }
 }

--- a/tests/MoBi.Tests/Presentation/Tasks/SimulationRunnerSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/SimulationRunnerSpecs.cs
@@ -484,5 +484,12 @@ namespace MoBi.Presentation.Tasks
       {
          A.CallTo(() => _context.PublishEvent(A<SimulationRunCanceledEvent>._)).MustHaveHappened();
       }
+
+
+      [Observation]
+      public void is_any_simulation_running_must_be_false()
+      {
+         sut.IsAnySimulationRunning().ShouldBeFalse();
+      }
    }
 }


### PR DESCRIPTION
Fixes #2008

# Description

When starting >1 simulation runs in parallel: STOP button is deactivated after the 1st simulation run is finished

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):