### PR TITLE
Fixes #1958 Qualification Runner: export building block reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.user
 *.userosscache
 *.sln.docstates
-launchSettings.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
@@ -256,6 +255,7 @@ setup/deploy
 setup/MoBi*
 setup/*.zip
 src/**/licenses.licx
+/src/**/launchSettings.json
 
 *.ncrunchproject
 /MoBi.v3.ncrunchsolution

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1176,7 +1176,10 @@ namespace MoBi.Assets
          public static readonly string ImportFromExcel = "Import from Excel®...";
          public static readonly string ShowChanges = "Show Changes";
          public static readonly string StopAllRunningSimulations = "Stop all running simulations";
-         public static readonly string LoadFromSnapshot = "Load from snapshot";
+         public static readonly string ReloadModule = "Reload module";
+         public static readonly string Snapshot = "Snapshot";
+         public static readonly string Export = "Export";
+
          public static string AddNew(string objectTypeName) => $"Create {objectTypeName}...";
 
          public static string AddExistingAs(string objectTypeName, string targetTypeName) => $"Load {objectTypeName} as {targetTypeName}...";
@@ -1696,6 +1699,8 @@ namespace MoBi.Assets
          public static readonly string ConvertToConstantValue = "Convert to constant value";
          public static readonly string GoToSource = "Go to Source";
          public static readonly string Loading = "Loading";
+         public static readonly string SaveModuleSnapshot = "Save module snapshot";
+
          public static string SelectTheBuildingBlockWhereEntitiesWillBeAddedOrUpdated(string typeBeingAdded) => $"Select the building block where {typeBeingAdded} will be added or updated";
          public static readonly string SelectBuildingBlock = "Select Building Block";
          public static readonly string MakeDefault = "Make defaults";

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -1,20 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+      <TargetFramework>netstandard2.0</TargetFramework>
+      <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+      <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+      <PackageTags>open-systems-pharmacology, ospsuite-components</PackageTags>
+      <Description>CLI Core functionalities for MoBi</Description>
+      <Authors>Open-Systems-Pharmacology</Authors>
       <PackageLicenseFile>LICENSE</PackageLicenseFile>
+      <OutputPath>bin\$(Configuration)</OutputPath>
+      <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\MoBi.CLI.Core.xml</DocumentationFile>
+      <NoWarn>1591</NoWarn>
+      <Version Condition="'$(Version)' == ''">13.0.0</Version>
 	</PropertyGroup>
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.47" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.49" />
       <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-      <PackageReference Include="OSPSuite.Presentation" Version="13.0.47" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.47" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.47" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.47" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+      <PackageReference Include="OSPSuite.Presentation" Version="13.0.49" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.49" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.49" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.49" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -23,16 +23,17 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.49" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -30,13 +30,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.49" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Core/Services/PKSimStarter.cs
+++ b/src/MoBi.Core/Services/PKSimStarter.cs
@@ -1,14 +1,16 @@
-﻿using MoBi.Assets;
-using MoBi.Core.Exceptions;
-using MoBi.Core.Serialization.Xml.Services;
-using OSPSuite.Core.Domain.Builder;
-using OSPSuite.Core.Domain.Services;
-using OSPSuite.Core.Serialization.Exchange;
-using OSPSuite.Core.Services;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using MoBi.Assets;
+using MoBi.Core.Exceptions;
+using MoBi.Core.Serialization.Xml.Services;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Qualification;
+using OSPSuite.Core.Serialization.Exchange;
+using OSPSuite.Core.Services;
 using OSPSuite.Utility;
 using OSPSuite.Utility.Extensions;
 
@@ -22,6 +24,19 @@ namespace MoBi.Core.Services
       IBuildingBlock CreateIndividual();
       IReadOnlyList<ExpressionParameterValueUpdate> UpdateExpressionProfileFromDatabase(ExpressionProfileBuildingBlock expressionProfile);
       SimulationTransfer LoadSimulationTransferFromSnapshot(string serializedSnapshot);
+
+      /// <summary>
+      ///    Loads the project from the snapshot. If there are any PK-Sim modules, they are rebuilt through a local installation
+      ///    of PK-Sim.
+      ///    If any of the PK-Sim building blocks should have markdown exported it will be done during the module rebuild.
+      /// </summary>
+      /// <param name="serializedSnapshot">The PK-Sim project snapshot</param>
+      /// <param name="qualificationConfiguration">
+      ///    The configuration containing any building block inputs that should have report
+      ///    markdown exported while the module is rebuilt in PK-Sim
+      /// </param>
+      /// <returns>A SimulationTransfer containing the module and any input mappings that were exported</returns>
+      (SimulationTransfer simulationTransfer, InputMapping[] inputMappings) LoadSimulationTransferFromSnapshotAndExportInputs(string serializedSnapshot, QualificationConfiguration qualificationConfiguration);
    }
 
    public class PKSimStarter : IPKSimStarter
@@ -31,6 +46,7 @@ namespace MoBi.Core.Services
       private const string CREATE_TRANSPORTER_EXPRESSION_PROFILE = "CreateTransporterExpressionProfile";
       private const string CREATE_INDIVIDUAL = "CreateIndividual";
       private const string CREATE_SIMULATION_TRANSFER = "CreateSimulationTransfer";
+      private const string CREATE_SIMULATION_TRANSFER_AND_EXPORT_INPUTS = "CreateSimulationTransferAndExportInputs";
       private const string GET_EXPRESSION_DATABASE_QUERY = "GetExpressionDatabaseQuery";
       private const string PKSIM_UI_STARTER_EXPRESSION_PROFILE_CREATOR = "PKSim.UI.Starter.ExpressionProfileCreator";
       private const string PKSIM_UI_STARTER_INDIVIDUAL_CREATOR = "PKSim.UI.Starter.IndividualCreator";
@@ -112,14 +128,26 @@ namespace MoBi.Core.Services
 
       public SimulationTransfer LoadSimulationTransferFromSnapshot(string serializedSnapshot)
       {
-         var element = executeMethod(getMethod(PKSIM_UI_STARTER_SIMULATION_TRANSFER_CONSTRUCTOR, CREATE_SIMULATION_TRANSFER), [serializedSnapshot]) as string;
-         var transfer = _serializationService.Deserialize<SimulationTransfer>(element, _projectRetriever.Current);
-         var simulationConfiguration = transfer.Simulation.Configuration;
+         var transfer = executeMethod(getMethod(PKSIM_UI_STARTER_SIMULATION_TRANSFER_CONSTRUCTOR, CREATE_SIMULATION_TRANSFER), [serializedSnapshot]) as SimulationTransfer;
 
+         setModuleOriginId(transfer.Simulation.Configuration);
+
+         return transfer;
+      }
+
+      public (SimulationTransfer simulationTransfer, InputMapping[] inputMappings) LoadSimulationTransferFromSnapshotAndExportInputs(string serializedSnapshot, QualificationConfiguration qualificationConfiguration)
+      {
+         var (transfer, mappings) = executeMethod(getMethod(PKSIM_UI_STARTER_SIMULATION_TRANSFER_CONSTRUCTOR, CREATE_SIMULATION_TRANSFER_AND_EXPORT_INPUTS), [serializedSnapshot, qualificationConfiguration]) is ValueTuple<SimulationTransfer, InputMapping[]> ? ((SimulationTransfer transfer, InputMapping[] mappings))executeMethod(getMethod(PKSIM_UI_STARTER_SIMULATION_TRANSFER_CONSTRUCTOR, CREATE_SIMULATION_TRANSFER_AND_EXPORT_INPUTS), [serializedSnapshot, qualificationConfiguration]) : (null, null);
+
+         setModuleOriginId(transfer.Simulation.Configuration);
+         return (transfer, mappings);
+      }
+
+      private static void setModuleOriginId(SimulationConfiguration simulationConfiguration)
+      {
          var module = simulationConfiguration.ModuleConfigurations.Single().Module;
          simulationConfiguration.ExpressionProfiles.Each(x => x.SnapshotOriginModuleId = module.Id);
          simulationConfiguration.Individual.SnapshotOriginModuleId = module.Id;
-         return transfer;
       }
 
       private object executeMethod(MethodInfo method, object[] parameters = null)

--- a/src/MoBi.Core/Snapshots/Services/SnapshotTask.cs
+++ b/src/MoBi.Core/Snapshots/Services/SnapshotTask.cs
@@ -3,6 +3,7 @@ using MoBi.Core.Domain.Model;
 using MoBi.Core.Services;
 using MoBi.Core.Snapshots.Mappers;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Qualification;
 using OSPSuite.Core.Services;
 using OSPSuite.Core.Snapshots;
 using OSPSuite.Core.Snapshots.Mappers;
@@ -11,7 +12,25 @@ using SnapshotContext = OSPSuite.Core.Snapshots.Mappers.SnapshotContext;
 
 namespace MoBi.Core.Snapshots.Services;
 
-public interface ISnapshotTask : ISnapshotTask<MoBiProject, Project>;
+public interface ISnapshotTask : ISnapshotTask<MoBiProject, Project>
+{
+   /// <summary>
+   ///    Loads the project from the snapshot. If there are any PK-Sim modules, they are rebuilt through a local installation
+   ///    of PK-Sim.
+   ///    If any of the PK-Sim building blocks should have markdown exported it will be done during the module rebuild.
+   /// </summary>
+   /// <param name="snapshot">The MoBi project snapshot</param>
+   /// <param name="runSimulations">
+   ///    True if the simulations specified in the snapshot should be run during the project
+   ///    creation
+   /// </param>
+   /// <param name="qualificationConfiguration">
+   ///    The configuration containing any building block inputs that should have report
+   ///    markdown exported while the module is rebuilt in PK-Sim
+   /// </param>
+   /// <returns>The newly created MoBi project and the result of the markdown export as an array of InputMapping</returns>
+   Task<(MoBiProject, InputMapping[])> LoadProjectFromSnapshotAndExportInputsAsync(Project snapshot, bool runSimulations, QualificationConfiguration qualificationConfiguration);
+}
 
 public class SnapshotTask : SnapshotTask<MoBiProject, Project>, ISnapshotTask
 {
@@ -42,4 +61,10 @@ public class SnapshotTask : SnapshotTask<MoBiProject, Project>, ISnapshotTask
    protected override SnapshotContext GetSnapshotContext() => new(_projectRetriever.Current, SnapshotVersions.Current);
 
    protected override MoBiProject GetProject() => _projectRetriever.Current;
+
+   public Task<(MoBiProject, InputMapping[])> LoadProjectFromSnapshotAndExportInputsAsync(Project snapshot, bool runSimulations, QualificationConfiguration qualificationConfiguration)
+   {
+      _moBiContext.NewProject();
+      return _projectMapper.MapToModelAndExportInputs(snapshot, new ProjectContext(_moBiContext.CurrentProject, runSimulations), qualificationConfiguration);
+   }
 }

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.49" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForModule.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForModule.cs
@@ -44,15 +44,29 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          _allMenuItems.Add(createRemoveItemFor(module));
          _allMenuItems.Add(createCloneItem(module));
 
-         if(module.HasSnapshot)
-            _allMenuItems.Add(createLoadFromSnapshotItem(module));
+         if (module.HasSnapshot) 
+            _allMenuItems.Add(createSnapshotMenu(module));
          
          return this;
       }
 
-      private IMenuBarItem createLoadFromSnapshotItem(Module module)
+      private IMenuBarItem createSnapshotMenu(Module module)
       {
-         return CreateMenuButton.WithCaption(AppConstants.MenuNames.LoadFromSnapshot)
+         return CreateSubMenu.WithCaption(AppConstants.MenuNames.Snapshot)
+            .WithItem(createLoadFromItemFor(module))
+            .WithItem(createExportFromItemFor(module));
+      }
+
+      private IMenuBarItem createExportFromItemFor(Module module)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.Export.WithEllipsis())
+            .WithCommandFor<ExportModuleSnapshotUICommand, Module>(module, _container)
+            .WithIcon(ApplicationIcons.SnapshotExport);
+      }
+
+      private IMenuBarItem createLoadFromItemFor(Module module)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.ReloadModule)
             .WithCommandFor<LoadModuleFromSnapshotUICommand, Module>(module, _container)
             .WithIcon(ApplicationIcons.PKSim);
       }

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -23,9 +23,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.2" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/UICommand/ExportModuleSnapshotUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/ExportModuleSnapshotUICommand.cs
@@ -1,0 +1,20 @@
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class ExportModuleSnapshotUICommand : ObjectUICommand<Module>
+   {
+      private readonly IInteractionTasksForModule _interactionTasksForModule;
+
+      public ExportModuleSnapshotUICommand(IInteractionTasksForModule interactionTasksForModule)
+      {
+         _interactionTasksForModule = interactionTasksForModule;
+      }
+      protected override void PerformExecute()
+      {
+         _interactionTasksForModule.ExportModuleSnapshot(Subject);
+      }
+   }
+}

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.49" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.4" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -67,13 +67,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.47" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.49" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.2" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/src/MoBi/Properties/launchSettings.json
+++ b/src/MoBi/Properties/launchSettings.json
@@ -3,6 +3,12 @@
     "MoBi": {
       "commandName": "Project",
       "commandLineArgs": "--dev"
+    },
+    "MoBi Qualification": {
+      "commandName": "Executable",
+      "executablePath": "C:\\repos\\OSPSuite\\MoBi\\src\\MoBi.CLI\\bin\\Debug\\net8\\MoBi.CLI.exe",
+      "commandLineArgs": "qualification -i ./configuration.json",
+      "workingDirectory": "c:\\snapshots"
     }
   }
 }

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/CLI/QualificationRunnerSpecs.cs
+++ b/tests/MoBi.Tests/CLI/QualificationRunnerSpecs.cs
@@ -125,7 +125,7 @@ namespace MoBi.CLI
          _project = new MoBiProject().WithName(PROJECT_NAME);
          A.CallTo(() => _snapshotTask.LoadSnapshotFromFileAsync<SnapshotProject>(_qualificationConfiguration.SnapshotFile)).Returns(_projectSnapshot);
          A.CallTo(() => _snapshotTask.LoadSnapshotFromFileAsync<SnapshotProject>(_parameterReferenceSnapshotFile)).Returns(_parameterReferenceSnapshot);
-         A.CallTo(() => _snapshotTask.LoadProjectFromSnapshotAsync(_projectSnapshot, _runOptions.Run)).Returns(_project);
+         A.CallTo(() => _snapshotTask.LoadProjectFromSnapshotAndExportInputsAsync(_projectSnapshot, _runOptions.Run, _qualificationConfiguration)).Returns((_project, []));
          FileHelper.FileExists = s => s.IsOneOf(_qualificationConfiguration.SnapshotFile, _runOptions.ConfigurationFile, _parameterReferenceSnapshotFile);
       }
    }

--- a/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectLoadSpecs.cs
+++ b/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectLoadSpecs.cs
@@ -12,7 +12,7 @@ using OSPSuite.Utility.Container;
 
 namespace MoBi.IntegrationTests.Snapshots
 {
-   public class When_loading_a_snapshot_ : ContextWithLoadedSnapshot
+   public class When_loading_a_snapshot : ContextWithLoadedSnapshot
    {
       private SimulationTransfer _simulationTransfer;
 

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.49" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.47" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.47" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.49" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.49" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1958 Export building blocks for qualification runs
Fixes #1407 Saving PK-Sim module as a snapshot.

# Description
Exporting PK-Sim building block markdown for PK-Sim building blocks in a PK-Sim module.
I also added the snapshot export because I needed to see the module json during this implementation

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):