### PR TITLE
Fixes #2094 MoBi.CLI.exe cannot run from MoBi folder

### DIFF
--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -2,18 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-
-    <TargetFrameworks>net8</TargetFrameworks>
-     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-     <Authors>Open-Systems-Pharmacology</Authors>
-     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-     <NoWarn>1591, 3246</NoWarn>
-     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
-     <Version Condition="'$(Version)' == ''">13.0.0</Version>
-     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
-     <IsPackable>false</IsPackable>
+    <UseWindowsForms>True</UseWindowsForms>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <Authors>Open-Systems-Pharmacology</Authors>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>1591, 3246</NoWarn>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+    <Version Condition="'$(Version)' == ''">13.0.0</Version>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
    <ItemGroup>


### PR DESCRIPTION
Fixes #2094

# Description
Fixes from #2089 made it so that we could no longer run MoBi from the MoBi folder. Yikes!

So it turns out that `System.Drawing.Common` is not needed in MoBi because the project uses WinForms. In MoBi.CLI it's needed because we target a console application. We are placing the MoBi.CLI.exe in the MoBi folder by just bringing it over as a dependent project. That copies everything, but not `System.Drawing.Common` since it's not needed for MoBi. Then, if you start MoBi.CLI it complains that this `System.Drawing.Common` cannot be found.

The previous PR adds `System.Drawing.Common` to MoBi to ensure that it's there and that the versions are the same for all projects that need it. But then, MoBi could not start due to this dependency conflict.

The only way I could determine to resolve the dependency issue is that MoBi.CLI should target the same runtime as MoBi. Up to now that's always been the case because we did not have separate `net472`. It was the same for all apps. It's only after upgrading to net8 that we made the distinction between CLI and GUI runtimes.

This issue is caused by the dependency `OSPSuite.Assets.Images` has on DevExpress for SVGImage for making icons. 

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):