### PR TITLE
Fixes #2090 add pk-sim path as argument to CLI

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.50" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.50" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.51" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.50" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />

--- a/src/MoBi.CLI.Core/CLIRegister.cs
+++ b/src/MoBi.CLI.Core/CLIRegister.cs
@@ -1,4 +1,5 @@
-﻿using MoBi.CLI.Core.Services;
+﻿using MoBi.CLI.Core.RunOptions;
+using MoBi.CLI.Core.Services;
 using OSPSuite.CLI.Core.RunOptions;
 using OSPSuite.CLI.Core.Services;
 using OSPSuite.Core;
@@ -21,7 +22,7 @@ namespace MoBi.CLI.Core
          });
 
          container.Register<IBatchRunner<SnapshotRunOptions>, SnapshotRunner>();
-         container.Register<IBatchRunner<QualificationRunOptions>, QualificationRunner>();
+         container.Register<IBatchRunner<MoBiQualificationRunOptions>, QualificationRunner>();
          container.Register<IPathToPathElementsMapper, PathToPathElementsMapper>();
          container.Register<IDataColumnToPathElementsMapper, DataColumnToPathElementsMapper>();
       }

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,14 +16,14 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.50" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.50" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.51" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.51" />
       <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.50" />
-      <PackageReference Include="OSPSuite.Presentation" Version="13.0.50" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.50" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.50" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.50" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
+      <PackageReference Include="OSPSuite.Presentation" Version="13.0.51" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.51" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.51" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.51" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI.Core/RunOptions/MoBiQualificationRunOptions.cs
+++ b/src/MoBi.CLI.Core/RunOptions/MoBiQualificationRunOptions.cs
@@ -4,6 +4,6 @@ namespace MoBi.CLI.Core.RunOptions
 {
    public class MoBiQualificationRunOptions : QualificationRunOptions
    {
-      public string PKSimExecutablePath { get; set; }
+      public string PKSimPath { get; set; }
    }
 }

--- a/src/MoBi.CLI.Core/RunOptions/MoBiQualificationRunOptions.cs
+++ b/src/MoBi.CLI.Core/RunOptions/MoBiQualificationRunOptions.cs
@@ -1,0 +1,9 @@
+﻿using OSPSuite.CLI.Core.RunOptions;
+
+namespace MoBi.CLI.Core.RunOptions
+{
+   public class MoBiQualificationRunOptions : QualificationRunOptions
+   {
+      public string PKSimExecutablePath { get; set; }
+   }
+}

--- a/src/MoBi.CLI.Core/Services/QualificationRunner.cs
+++ b/src/MoBi.CLI.Core/Services/QualificationRunner.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using MoBi.Assets;
+using MoBi.CLI.Core.RunOptions;
+using MoBi.Core;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Serialization.ORM;
 using MoBi.Core.Snapshots;
@@ -23,11 +25,12 @@ using SnapshotProject = MoBi.Core.Snapshots.Project;
 
 namespace MoBi.CLI.Core.Services
 {
-   public class QualificationRunner : QualificationRunner<SnapshotProject, ModelProject>
+   public class QualificationRunner : QualificationRunner<SnapshotProject, ModelProject, MoBiQualificationRunOptions>
    {
       private readonly IMoBiContext _context;
       private readonly IProjectPersistor _projectPersistor;
       private readonly ISimulationPersistor _simulationPersistor;
+      private readonly IApplicationSettings _applicationSettings;
       private readonly ISnapshotTask _moBiSnapshotTask;
 
       public QualificationRunner(IMoBiContext context,
@@ -36,17 +39,28 @@ namespace MoBi.CLI.Core.Services
          IDataRepositoryExportTask dataRepositoryExportTask,
          IJsonSerializer jsonSerializer,
          ISnapshotTask snapshotTask,
-         ISimulationPersistor simulationPersistor) : base(logger, dataRepositoryExportTask, jsonSerializer, snapshotTask)
+         ISimulationPersistor simulationPersistor,
+         IApplicationSettings applicationSettings) : base(logger, dataRepositoryExportTask, jsonSerializer, snapshotTask)
       {
          _context = context;
          _projectPersistor = projectPersistor;
          _simulationPersistor = simulationPersistor;
+         _applicationSettings = applicationSettings;
          _moBiSnapshotTask = snapshotTask;
       }
 
       protected override void LoadProjectContext(ModelProject project)
       {
          _context.LoadFrom(project);
+      }
+
+      public override Task RunBatchAsync(MoBiQualificationRunOptions runOptions)
+      {
+         // For any process that will access PK-Sim services, use the path from the command line if specified
+         if (!string.IsNullOrEmpty(runOptions.PKSimExecutablePath)) 
+            _applicationSettings.PKSimPath = runOptions.PKSimExecutablePath;
+         
+         return base.RunBatchAsync(runOptions);
       }
 
       protected override IEnumerable<PlotMapping> RetrievePlotDefinitionsForSimulation(SimulationPlot simulationPlot, SnapshotProject snapshotProject)
@@ -103,10 +117,9 @@ namespace MoBi.CLI.Core.Services
 
       protected override string ProjectExtension => AppConstants.Filter.MOBI_PROJECT_EXTENSION;
 
-      protected override SimulationExportMode ExportMode(QualificationRunOptions runOptions) => SimulationExportMode.Pkml;
+      protected override SimulationExportMode ExportMode(MoBiQualificationRunOptions runOptions) => SimulationExportMode.Pkml;
 
-      protected override Task<(ModelProject, InputMapping[])> LoadProjectAndExportInputs(QualificationRunOptions runOptions, SnapshotProject snapshot, QualificationConfiguration qualificationConfiguration) =>
-         _moBiSnapshotTask.LoadProjectFromSnapshotAndExportInputsAsync(snapshot, runOptions.Run, qualificationConfiguration);
+      protected override Task<(ModelProject, InputMapping[])> LoadProjectAndExportInputs(MoBiQualificationRunOptions runOptions, SnapshotProject snapshot, QualificationConfiguration qualificationConfiguration) => _moBiSnapshotTask.LoadProjectFromSnapshotAndExportInputsAsync(snapshot, runOptions.Run, qualificationConfiguration);
 
       protected override Task<SimulationMapping[]> ExportSimulationsIn(ModelProject project, ExportRunOptions exportRunOptions)
       {

--- a/src/MoBi.CLI.Core/Services/QualificationRunner.cs
+++ b/src/MoBi.CLI.Core/Services/QualificationRunner.cs
@@ -57,8 +57,8 @@ namespace MoBi.CLI.Core.Services
       public override Task RunBatchAsync(MoBiQualificationRunOptions runOptions)
       {
          // For any process that will access PK-Sim services, use the path from the command line if specified
-         if (!string.IsNullOrEmpty(runOptions.PKSimExecutablePath)) 
-            _applicationSettings.PKSimPath = runOptions.PKSimExecutablePath;
+         if (!string.IsNullOrEmpty(runOptions.PKSimPath)) 
+            _applicationSettings.PKSimPath = runOptions.PKSimPath;
          
          return base.RunBatchAsync(runOptions);
       }

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -23,17 +23,17 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.50" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.51" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.50" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.51" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.CLI/QualificationRunCommand.cs
+++ b/src/MoBi.CLI/QualificationRunCommand.cs
@@ -24,7 +24,7 @@ namespace MoBi.CLI
       public bool ExportProjectFiles { get; set; } = false;
 
       [Option('p', "pksim", Required = false, HelpText = "The file path where PK-Sim can be found for qualifications that use PK-Sim modules. Default is to use the value from user settings in MoBi")]
-      public string PKSimExecutablePath { get; set; }
+      public string PKSimPath { get; set; }
 
       public override MoBiQualificationRunOptions ToRunOptions()
       {
@@ -34,7 +34,7 @@ namespace MoBi.CLI
             Validate = Validate,
             Run = Run,
             ExportProjectFiles = ExportProjectFiles,
-            PKSimExecutablePath = PKSimExecutablePath
+            PKSimPath = PKSimPath
          };
       }
 
@@ -46,7 +46,7 @@ namespace MoBi.CLI
          sb.AppendLine($"Configuration file: {ConfigurationFile}");
          sb.AppendLine($"Run simulations: {Run}");
          sb.AppendLine($"Export project files: {ExportProjectFiles}");
-         sb.AppendLine($"Path to PK-Sim: {PKSimExecutablePath}");
+         sb.AppendLine($"Path to PK-Sim: {PKSimPath}");
          return sb.ToString();
       }
    }

--- a/src/MoBi.CLI/QualificationRunCommand.cs
+++ b/src/MoBi.CLI/QualificationRunCommand.cs
@@ -1,12 +1,12 @@
-﻿using System.Text;
-using CommandLine;
+﻿using CommandLine;
 using MoBi.CLI.Commands;
-using OSPSuite.CLI.Core.RunOptions;
+using MoBi.CLI.Core.RunOptions;
+using System.Text;
 
 namespace MoBi.CLI
 {
    [Verb("qualification", HelpText = "Start qualification run workflow")]
-   public class QualificationRunCommand : CLICommand<QualificationRunOptions>
+   public class QualificationRunCommand : CLICommand<MoBiQualificationRunOptions>
    {
       public override string Name { get; } = "Qualification";
       public override bool LogCommandName { get; } = false;
@@ -23,14 +23,18 @@ namespace MoBi.CLI
       [Option('e', "exp", Required = false, HelpText = "Should the qualification runner also export the project files (snapshot and MoBi project file). Default is false")]
       public bool ExportProjectFiles { get; set; } = false;
 
-      public override QualificationRunOptions ToRunOptions()
+      [Option('p', "pksim", Required = false, HelpText = "The file path where PK-Sim can be found for qualifications that use PK-Sim modules. Default is to use the value from user settings in MoBi")]
+      public string PKSimExecutablePath { get; set; }
+
+      public override MoBiQualificationRunOptions ToRunOptions()
       {
-         return new QualificationRunOptions
+         return new MoBiQualificationRunOptions
          {
             ConfigurationFile = ConfigurationFile,
             Validate = Validate,
             Run = Run,
-            ExportProjectFiles = ExportProjectFiles
+            ExportProjectFiles = ExportProjectFiles,
+            PKSimExecutablePath = PKSimExecutablePath
          };
       }
 
@@ -42,6 +46,7 @@ namespace MoBi.CLI
          sb.AppendLine($"Configuration file: {ConfigurationFile}");
          sb.AppendLine($"Run simulations: {Run}");
          sb.AppendLine($"Export project files: {ExportProjectFiles}");
+         sb.AppendLine($"Path to PK-Sim: {PKSimExecutablePath}");
          return sb.ToString();
       }
    }

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -30,13 +30,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.50" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.51" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Core/Services/PKSimStarter.cs
+++ b/src/MoBi.Core/Services/PKSimStarter.cs
@@ -205,12 +205,13 @@ namespace MoBi.Core.Services
 
       private string retrievePKSimExecutablePath()
       {
-         //Installed properly via Setup? return standard path
-         if (FileHelper.FileExists(_configuration.PKSimPath))
-            return _configuration.PKSimPath;
-
+         // Specified explicitly via user settings? Use overridden path
          if (FileHelper.FileExists(_applicationSettings.PKSimPath))
             return _applicationSettings.PKSimPath;
+
+         // Installed properly via Setup? Use standard path
+         if (FileHelper.FileExists(_configuration.PKSimPath))
+            return _configuration.PKSimPath;
 
          throw new MoBiException(AppConstants.PKSim.NotInstalled);
       }

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.50" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.51" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -23,9 +23,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.2" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.50" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.50" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.51" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.4" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.3" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.50" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -67,13 +67,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.50" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.50" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.51" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.2" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.50" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/CLI/QualificationRunnerSpecs.cs
+++ b/tests/MoBi.Tests/CLI/QualificationRunnerSpecs.cs
@@ -72,7 +72,7 @@ namespace MoBi.CLI
 
          _runOptions = new MoBiQualificationRunOptions
          {
-            PKSimExecutablePath = "C:/Test.exe"
+            PKSimPath = "C:/Test.exe"
          };
          
          _qualificationConfiguration = new QualificationConfiguration();
@@ -201,7 +201,7 @@ namespace MoBi.CLI
       [Observation]
       public void the_application_settings_pk_sim_path_is_overridden()
       {
-         _applicationSettings.PKSimPath.ShouldBeEqualTo(_runOptions.PKSimExecutablePath);
+         _applicationSettings.PKSimPath.ShouldBeEqualTo(_runOptions.PKSimPath);
       }
 
       [Observation]

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.50" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.51" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.74" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.50" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.50" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.51" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.51" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #2090

# Description
Option to override user settings for PK sim exe path during qualification.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):