### PR TITLE
Load individual and expression from PK-Sim snapshots

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1179,6 +1179,8 @@ namespace MoBi.Assets
          public static readonly string ReloadModule = "Reload module";
          public static readonly string Snapshot = "Snapshot";
          public static readonly string Export = "Export";
+         public static readonly string ReloadExpressionProfile = "Reload Expression Profile";
+         public static readonly string ReloadIndividual = "Reload Individual";
 
          public static string AddNew(string objectTypeName) => $"Create {objectTypeName}...";
 

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.57" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.57" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.58" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.58" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.57" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.58" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.77" GeneratePathProperty="true" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,14 +16,14 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.57" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.57" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.58" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.58" />
       <PackageReference Include="OSPSuite.Utility" Version="4.1.1.4" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.57" />
-      <PackageReference Include="OSPSuite.Presentation" Version="13.0.57" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.57" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.57" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.57" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.58" />
+      <PackageReference Include="OSPSuite.Presentation" Version="13.0.58" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.58" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.58" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.58" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -23,17 +23,17 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.57" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.58" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.4" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.77" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.57" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.58" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -30,13 +30,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.4" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.57" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.58" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Core/Services/BuildingBlockVersionUpdater.cs
+++ b/src/MoBi.Core/Services/BuildingBlockVersionUpdater.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using MoBi.Assets;
 using MoBi.Core.Domain;
 using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
@@ -41,11 +40,6 @@ namespace MoBi.Core.Services
 
          if (shouldConvertToPKSimModule(buildingBlock, conversionOption))
             buildingBlock.Module.IsPKSimModule = true;
-
-         if (buildingBlock is IndividualBuildingBlock individual)
-            individual.SnapshotOriginModuleId = null;
-         else if (buildingBlock is ExpressionProfileBuildingBlock expressionProfileBuildingBlock)
-            expressionProfileBuildingBlock.SnapshotOriginModuleId = null;
 
          buildingBlock.Version = newVersion;
 

--- a/src/MoBi.Core/Snapshots/Project.cs
+++ b/src/MoBi.Core/Snapshots/Project.cs
@@ -33,4 +33,8 @@ public class Project : SnapshotBase
    public Simulation[] Simulations { get; set; }
 
    public ReactionDimensionMode ReactionDimensionMode { get; set; }
+
+   public string[] ExpressionProfileSnapshots { get; set; }
+
+   public string[] IndividualBuildingBlockSnapshots { get; set; }
 }

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.57" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.58" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForExpressionProfileBuildingBlock.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForExpressionProfileBuildingBlock.cs
@@ -5,6 +5,7 @@ using MoBi.Presentation.UICommand;
 using OSPSuite.Assets;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Extensions;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.MenuAndBars;
 using OSPSuite.Presentation.Presenters;
@@ -28,7 +29,31 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
             .WithIcon(ApplicationIcons.ExportToExcel)
             .WithCommandFor<ExportExpressionProfilesBuildingBlockToExcelUICommand, ExpressionProfileBuildingBlock>(buildingBlock, _container));
 
+         if (buildingBlock.HasSnapshot)
+            _allMenuItems.Add(createSnapshotMenu(buildingBlock));
+
          return this;
+      }
+
+      private IMenuBarItem createSnapshotMenu(ExpressionProfileBuildingBlock buildingBlock)
+      {
+         return CreateSubMenu.WithCaption(AppConstants.MenuNames.Snapshot)
+            .WithItem(createLoadFromItemFor(buildingBlock))
+            .WithItem(createExportFromItemFor(buildingBlock));
+      }
+
+      private IMenuBarItem createExportFromItemFor(ExpressionProfileBuildingBlock buildingBlock)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.Export.WithEllipsis())
+            .WithCommandFor<ExportExpressionProfileBuildingBlockSnapshotUICommand, ExpressionProfileBuildingBlock>(buildingBlock, _container)
+            .WithIcon(ApplicationIcons.SnapshotExport);
+      }
+
+      private IMenuBarItem createLoadFromItemFor(ExpressionProfileBuildingBlock buildingBlock)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.ReloadExpressionProfile)
+            .WithCommandFor<LoadExpressionProfileBuildingBlockFromSnapshotUICommand, ExpressionProfileBuildingBlock>(buildingBlock, _container)
+            .WithIcon(ApplicationIcons.PKSim);
       }
    }
 }

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForIndividualBuildingBlock.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForIndividualBuildingBlock.cs
@@ -1,6 +1,15 @@
-﻿using MoBi.Core.Domain.Model;
+﻿using MoBi.Assets;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.UICommand;
+using OSPSuite.Assets;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Extensions;
+using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.MenuAndBars;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Utility.Container;
 
 namespace MoBi.Presentation.MenusAndBars.ContextMenus
@@ -9,6 +18,37 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
    {
       public ContextMenuForIndividualBuildingBlock(IMoBiContext context, IObjectTypeResolver objectTypeResolver, IContainer container) : base(context, objectTypeResolver, container)
       {
+      }
+
+      public override IContextMenu InitializeWith(ObjectBaseDTO dto, IPresenter presenter)
+      {
+         base.InitializeWith(dto, presenter);
+         var buildingBlock = _context.Get<IndividualBuildingBlock>(dto.Id);
+
+         if (buildingBlock.HasSnapshot)
+            _allMenuItems.Add(createSnapshotMenu(buildingBlock));
+         return this;
+      }
+
+      private IMenuBarItem createSnapshotMenu(IndividualBuildingBlock buildingBlock)
+      {
+         return CreateSubMenu.WithCaption(AppConstants.MenuNames.Snapshot)
+            .WithItem(createLoadFromItemFor(buildingBlock))
+            .WithItem(createExportFromItemFor(buildingBlock));
+      }
+
+      private IMenuBarItem createExportFromItemFor(IndividualBuildingBlock buildingBlock)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.Export.WithEllipsis())
+            .WithCommandFor<ExportIndividualBuildingBlockSnapshotUICommand, IndividualBuildingBlock>(buildingBlock, _container)
+            .WithIcon(ApplicationIcons.SnapshotExport);
+      }
+
+      private IMenuBarItem createLoadFromItemFor(IndividualBuildingBlock buildingBlock)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.ReloadIndividual)
+            .WithCommandFor<LoadIndividualBuildingBlockFromSnapshotUICommand, IndividualBuildingBlock>(buildingBlock, _container)
+            .WithIcon(ApplicationIcons.PKSim);
       }
    }
 }

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -23,9 +23,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.4" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.57" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.58" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForBuildingBlock.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForBuildingBlock.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
@@ -24,13 +23,15 @@ namespace MoBi.Presentation.Tasks.Interaction
    public interface IInteractionTasksForBuildingBlock<TParent, T> : IInteractionTasksForChildren<TParent, T>,
       IInteractionTasksForBuildingBlock where T : class, IObjectBase where TParent : class
    {
-
+      
    }
 
    public interface IInteractionTasksForProjectBuildingBlock<T> : IInteractionTasksForBuildingBlock<MoBiProject, T> where T : class, IObjectBase
    {
       IMoBiCommand Clone(T buildingBlockToClone);
       IMoBiCommand AddToProject(T buildingBlockToAdd);
+      void ExportBuildingBlockSnapshot(T buildingBlock);
+      T LoadFromSnapshot(string snapshot);
    }
 
    public abstract class InteractionTasksForBuildingBlock<TParent, TBuildingBlock> :

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExpressionProfileBuildingBlock.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExpressionProfileBuildingBlock.cs
@@ -8,6 +8,7 @@ using MoBi.Core.Mappers;
 using MoBi.Core.Services;
 using MoBi.Presentation.Tasks.Edit;
 using OSPSuite.Assets;
+using OSPSuite.Assets.Extensions;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
@@ -38,12 +39,12 @@ namespace MoBi.Presentation.Tasks.Interaction
          IExportDataTableToExcelTask exportDataTableToExcelTask,
          ICloneManagerForBuildingBlock cloneManager,
          IExpressionProfileBuildingBlockToDataTableMapper mapper) :
-         base(interactionTaskContext, 
-            editTask, 
-            formulaTask,  
-            exportDataTableToExcelTask, 
-            cloneManager, 
-            pathAndValueEntityToDistributedParameterMapper, 
+         base(interactionTaskContext,
+            editTask,
+            formulaTask,
+            exportDataTableToExcelTask,
+            cloneManager,
+            pathAndValueEntityToDistributedParameterMapper,
             mapper)
       {
          _editTaskForExpressionProfileBuildingBlock = editTask;
@@ -68,6 +69,12 @@ namespace MoBi.Presentation.Tasks.Interaction
          macroCommand.AddRange(expressionProfileUpdate.Select(parameter => updateCommandFor(buildingBlock, parameter.Path, parameter.UpdatedValue)));
 
          return macroCommand.RunCommand(Context);
+      }
+
+      public ExpressionProfileBuildingBlock LoadFromSnapshot(string snapshot)
+      {
+         // Cloning required to reset object ids
+         return _cloneManagerForBuildingBlock.Clone(_pkSimStarter.LoadExpressionProfileFromSnapshot(snapshot));
       }
 
       private static ICommand updateCommandFor(ExpressionProfileBuildingBlock buildingBlock, ObjectPath path, double? value)
@@ -119,6 +126,11 @@ namespace MoBi.Presentation.Tasks.Interaction
       public override IMoBiCommand GetAddCommand(ExpressionProfileBuildingBlock expressionProfileToAdd, MoBiProject parent, IBuildingBlock buildingBlock)
       {
          return new AddExpressionProfileBuildingBlockToProjectCommand(expressionProfileToAdd);
+      }
+
+      protected override string SnapshotFrom(ExpressionProfileBuildingBlock buildingBlock)
+      {
+         return buildingBlock.Snapshot.FromBase64String();
       }
    }
 }

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForIndividualBuildingBlock.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForIndividualBuildingBlock.cs
@@ -2,7 +2,9 @@
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
 using MoBi.Core.Mappers;
+using MoBi.Core.Services;
 using MoBi.Presentation.Tasks.Edit;
+using OSPSuite.Assets.Extensions;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Services;
@@ -17,6 +19,8 @@ namespace MoBi.Presentation.Tasks.Interaction
 
    public class InteractionTasksForIndividualBuildingBlock : InteractionTasksForProjectPathAndValueEntityBuildingBlocks<IndividualBuildingBlock, IndividualParameter>, IInteractionTasksForIndividualBuildingBlock
    {
+      private readonly IPKSimStarter _pkSimStarter;
+
       //The parameter for the mapper is set to null since we still haven`t implemented it for IndividualBuildingBlock
       public InteractionTasksForIndividualBuildingBlock(IInteractionTaskContext interactionTaskContext,
          IEditTasksForIndividualBuildingBlock editTask,
@@ -24,15 +28,17 @@ namespace MoBi.Presentation.Tasks.Interaction
          IExportDataTableToExcelTask exportDataTableToExcelTask,
          ICloneManagerForBuildingBlock cloneManager,
          IPathAndValueEntityToDistributedParameterMapper pathAndValueEntityToDistributedParameterMapper,
-         IIndividualParametersToIndividualParametersDataTableMapper dataTableMapper) :
-         base(interactionTaskContext, 
-            editTask, 
-            moBiFormulaTask, 
-            exportDataTableToExcelTask, 
+         IIndividualParametersToIndividualParametersDataTableMapper dataTableMapper,
+         IPKSimStarter pkSimStarter) :
+         base(interactionTaskContext,
+            editTask,
+            moBiFormulaTask,
+            exportDataTableToExcelTask,
             cloneManager,
             pathAndValueEntityToDistributedParameterMapper,
             dataTableMapper)
       {
+         _pkSimStarter = pkSimStarter;
       }
 
       public override IMoBiCommand GetRemoveCommand(IndividualBuildingBlock individualBuildingBlockToRemove, MoBiProject parent, IBuildingBlock buildingBlock)
@@ -40,9 +46,20 @@ namespace MoBi.Presentation.Tasks.Interaction
          return new RemoveIndividualBuildingBlockFromProjectCommand(individualBuildingBlockToRemove);
       }
 
+      public IndividualBuildingBlock LoadFromSnapshot(string snapshot)
+      {
+         // Cloning required to reset object ids
+         return _cloneManagerForBuildingBlock.Clone(_pkSimStarter.LoadIndividualFromSnapshot(snapshot));
+      }
+
       public override IMoBiCommand GetAddCommand(IndividualBuildingBlock individualBuildingBlockToAdd, MoBiProject parent, IBuildingBlock buildingBlock)
       {
          return new AddIndividualBuildingBlockToProjectCommand(individualBuildingBlockToAdd);
+      }
+
+      protected override string SnapshotFrom(IndividualBuildingBlock buildingBlock)
+      {
+         return buildingBlock.Snapshot.FromBase64String();
       }
    }
 }

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForProjectPathAndValueEntityBuildingBlocks.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForProjectPathAndValueEntityBuildingBlocks.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Data;
+using System.IO;
+using MoBi.Assets;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
@@ -29,13 +31,13 @@ namespace MoBi.Presentation.Tasks.Interaction
          IExportDataTableToExcelTask exportDataTableToExcelTask,
          ICloneManagerForBuildingBlock cloneManager,
          IPathAndValueEntityToDistributedParameterMapper pathAndValueEntityToDistributedParameterMapper,
-         IMapper<TBuildingBlock, List<DataTable>> dataTableMapper) : 
-         base(interactionTaskContext, 
-            editTask, 
-            moBiFormulaTask, 
-            exportDataTableToExcelTask, 
+         IMapper<TBuildingBlock, List<DataTable>> dataTableMapper) :
+         base(interactionTaskContext,
+            editTask,
+            moBiFormulaTask,
+            exportDataTableToExcelTask,
             dataTableMapper,
-            pathAndValueEntityToDistributedParameterMapper, 
+            pathAndValueEntityToDistributedParameterMapper,
             cloneManager)
       {
       }
@@ -51,6 +53,20 @@ namespace MoBi.Presentation.Tasks.Interaction
 
          return AddToProject(clone);
       }
+
+      public void ExportBuildingBlockSnapshot(TBuildingBlock buildingBlock)
+      {
+         var filePath = InteractionTask.AskForFileToSave(AppConstants.Captions.SaveModuleSnapshot, Constants.Filter.JSON_FILE_FILTER, Constants.DirectoryKey.MODEL_PART, buildingBlock.Name);
+         if (string.IsNullOrEmpty(filePath))
+            return;
+
+         using (var writer = new StreamWriter(filePath))
+         {
+            writer.Write(SnapshotFrom(buildingBlock));
+         }
+      }
+
+      protected abstract string SnapshotFrom(TBuildingBlock buildingBlock);
 
       public IMoBiCommand AddToProject(TBuildingBlock buildingBlockToAdd) => AddTo(buildingBlockToAdd, Context.CurrentProject, null);
 

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -162,7 +162,7 @@ namespace MoBi.Presentation.Tasks
          if (exitIf(anySimulationInChangedState, Captions.SnapshotOfProjectWithChangedSimulation))
             return Task.CompletedTask;
 
-         if(exitIf(pkSimModulesWithoutSnapshots.Any(), PKSimModulesWithoutSnapshots(pkSimModulesWithoutSnapshots)))
+         if (exitIf(pkSimModulesWithoutSnapshots.Any(), PKSimModulesWithoutSnapshots(pkSimModulesWithoutSnapshots)))
             return Task.CompletedTask;
 
          return _snapshotTask.ExportModelToSnapshotAsync(project);
@@ -180,6 +180,7 @@ namespace MoBi.Presentation.Tasks
             if (project == null)
                return;
 
+            _context.Register(project);
             notifyProjectLoaded();
          }
       }

--- a/src/MoBi.Presentation/UICommand/ExportExpressionProfileBuildingBlockSnapshotUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/ExportExpressionProfileBuildingBlockSnapshotUICommand.cs
@@ -1,0 +1,18 @@
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class ExportExpressionProfileBuildingBlockSnapshotUICommand : ObjectUICommand<ExpressionProfileBuildingBlock>
+   {
+      private readonly IInteractionTasksForExpressionProfileBuildingBlock _interactionTasksForExpressionProfileBuildingBlock;
+
+      public ExportExpressionProfileBuildingBlockSnapshotUICommand(IInteractionTasksForExpressionProfileBuildingBlock interactionTasksForExpressionProfileBuildingBlock)
+      {
+         _interactionTasksForExpressionProfileBuildingBlock = interactionTasksForExpressionProfileBuildingBlock;
+      }
+
+      protected override void PerformExecute() => _interactionTasksForExpressionProfileBuildingBlock.ExportBuildingBlockSnapshot(Subject);
+   }
+}

--- a/src/MoBi.Presentation/UICommand/ExportIndividualBuildingBlockSnapshotUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/ExportIndividualBuildingBlockSnapshotUICommand.cs
@@ -1,0 +1,19 @@
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class ExportIndividualBuildingBlockSnapshotUICommand : ObjectUICommand<IndividualBuildingBlock>
+   {
+      private readonly IInteractionTasksForIndividualBuildingBlock _interactionTasksForIndividualBuildingBlock;
+
+      public ExportIndividualBuildingBlockSnapshotUICommand(IInteractionTasksForIndividualBuildingBlock interactionTasksForIndividualBuildingBlock)
+      {
+         _interactionTasksForIndividualBuildingBlock = interactionTasksForIndividualBuildingBlock;
+      }
+
+      protected override void PerformExecute() =>
+         _interactionTasksForIndividualBuildingBlock.ExportBuildingBlockSnapshot(Subject);
+   }
+}

--- a/src/MoBi.Presentation/UICommand/LoadExpressionProfileBuildingBlockFromSnapshotUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/LoadExpressionProfileBuildingBlockFromSnapshotUICommand.cs
@@ -1,0 +1,33 @@
+using MoBi.Core.Commands;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Services;
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Services;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class LoadExpressionProfileBuildingBlockFromSnapshotUICommand : PKSimStarterSnapshotUICommand<ExpressionProfileBuildingBlock>
+   {
+      private readonly IInteractionTasksForExpressionProfileBuildingBlock _interactionTasks;
+
+      public LoadExpressionProfileBuildingBlockFromSnapshotUICommand(
+         IMoBiProjectRetriever projectRetriever,
+         IHeavyWorkManager heavyWorkManager,
+         IInteractionTasksForExpressionProfileBuildingBlock interactionTasks,
+         IMoBiContext context) : base(projectRetriever, heavyWorkManager, context)
+      {
+         _interactionTasks = interactionTasks;
+      }
+
+      protected override IMoBiCommand AddToProject(ExpressionProfileBuildingBlock expressionProfileBuildingBlock)
+      {
+         return _interactionTasks.AddToProject(expressionProfileBuildingBlock);
+      }
+
+      protected override ExpressionProfileBuildingBlock LoadFromSnapshot()
+      {
+         return _interactionTasks.LoadFromSnapshot(Subject.Snapshot);
+      }
+   }
+}

--- a/src/MoBi.Presentation/UICommand/LoadIndividualBuildingBlockFromSnapshotUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/LoadIndividualBuildingBlockFromSnapshotUICommand.cs
@@ -1,0 +1,33 @@
+using MoBi.Core.Commands;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Services;
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Services;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class LoadIndividualBuildingBlockFromSnapshotUICommand : PKSimStarterSnapshotUICommand<IndividualBuildingBlock>
+   {
+      private readonly IInteractionTasksForIndividualBuildingBlock _interactionTasks;
+
+      public LoadIndividualBuildingBlockFromSnapshotUICommand(
+         IMoBiProjectRetriever projectRetriever,
+         IHeavyWorkManager heavyWorkManager,
+         IInteractionTasksForIndividualBuildingBlock interactionTasks,
+         IMoBiContext context) : base(projectRetriever, heavyWorkManager, context)
+      {
+         _interactionTasks = interactionTasks;
+      }
+
+      protected override IMoBiCommand AddToProject(IndividualBuildingBlock buildingBlock)
+      {
+         return _interactionTasks.AddToProject(buildingBlock);
+      }
+
+      protected override IndividualBuildingBlock LoadFromSnapshot()
+      {
+         return _interactionTasks.LoadFromSnapshot(Subject.Snapshot);
+      }
+   }
+}

--- a/src/MoBi.Presentation/UICommand/PKSimStarterSnapshotUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/PKSimStarterSnapshotUICommand.cs
@@ -1,0 +1,42 @@
+using MoBi.Assets;
+using MoBi.Core.Commands;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Services;
+using OSPSuite.Core.Extensions;
+using OSPSuite.Core.Services;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   public abstract class PKSimStarterSnapshotUICommand<TSubject> : ObjectUICommand<TSubject> where TSubject : class
+   {
+      protected readonly IMoBiProjectRetriever _projectRetriever;
+      private readonly IHeavyWorkManager _heavyWorkManager;
+      private readonly IMoBiContext _context;
+
+      protected PKSimStarterSnapshotUICommand(IMoBiProjectRetriever projectRetriever, IHeavyWorkManager heavyWorkManager, IMoBiContext context)
+      {
+         _projectRetriever = projectRetriever;
+         _heavyWorkManager = heavyWorkManager;
+         _context = context;
+      }
+
+      protected override void PerformExecute()
+      {
+         TSubject objectToLoad = null;
+
+         _heavyWorkManager.Start(() =>
+            {
+               objectToLoad = LoadFromSnapshot();
+            }, AppConstants.Captions.Loading.WithEllipsis()
+         );
+
+         if (objectToLoad != null)
+            _context.AddToHistory(AddToProject(objectToLoad));
+      }
+
+      protected abstract IMoBiCommand AddToProject(TSubject objectToLoad);
+
+      protected abstract TSubject LoadFromSnapshot();
+   }
+}

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.57" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.58" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.5" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.4" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.57" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.58" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -67,13 +67,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.57" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.58" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.77" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.57" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.58" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.57" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.58" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.R.Tests/Data/test.json
+++ b/tests/MoBi.R.Tests/Data/test.json
@@ -1,0 +1,1224 @@
+{
+  "Name": "Henrist oral Hot stage extrusion as table",
+  "Version": 81,
+  "Individuals": [
+    {
+      "Name": "Man",
+      "Seed": 5217250,
+      "OriginData": {
+        "CalculationMethods": [
+          "SurfaceAreaPlsInt_VAR1",
+          "Body surface area - Mosteller"
+        ],
+        "Species": "Human",
+        "Population": "European_ICRP_2002",
+        "Gender": "MALE",
+        "Age": {
+          "Value": 30.0,
+          "Unit": "year(s)"
+        }
+      },
+      "ExpressionProfiles": []
+    }
+  ],
+  "Compounds": [
+    {
+      "Name": "Theophylline",
+      "IsSmallMolecule": true,
+      "PlasmaProteinBindingPartner": "Albumin",
+      "Lipophilicity": [
+        {
+          "Name": "Measurement logMA",
+          "Parameters": [
+            {
+              "Name": "Lipophilicity",
+              "Value": 0.89,
+              "Unit": "Log Units",
+              "ValueOrigin": {
+                "Source": "Publication",
+                "Description": "Thelen K, Coboeken K, Willmann S, et al. Evolution of a detailed physiological model to simulate the gastrointestinal transit and absorption process in humans, Part 1:Oral solutions. J Pharm Sci. 2011 Dec;100(12):5324-45"
+              }
+            }
+          ]
+        }
+      ],
+      "FractionUnbound": [
+        {
+          "Name": "Measurement",
+          "Species": "Human",
+          "Parameters": [
+            {
+              "Name": "Fraction unbound (plasma, reference value)",
+              "Value": 0.44,
+              "ValueOrigin": {
+                "Source": "Publication",
+                "Description": "Thelen K, Coboeken K, Willmann S, et al. Evolution of a detailed physiological model to simulate the gastrointestinal transit and absorption process in humans, Part 1:Oral solutions. J Pharm Sci. 2011 Dec;100(12):5324-45"
+              }
+            }
+          ]
+        }
+      ],
+      "Solubility": [
+        {
+          "Name": "Measurement",
+          "Parameters": [
+            {
+              "Name": "Solubility at reference pH",
+              "Value": 14300.0,
+              "Unit": "mg/l",
+              "ValueOrigin": {
+                "Source": "Publication",
+                "Description": "Thelen K, Coboeken K, Willmann S, et al. Evolution of a detailed physiological model to simulate the gastrointestinal transit and absorption process in humans, Part 1:Oral solutions. J Pharm Sci. 2011 Dec;100(12):5324-45"
+              }
+            },
+            {
+              "Name": "Reference pH",
+              "Value": 6.5,
+              "ValueOrigin": {
+                "Source": "Publication",
+                "Description": "Thelen K, Coboeken K, Willmann S, et al. Evolution of a detailed physiological model to simulate the gastrointestinal transit and absorption process in humans, Part 1:Oral solutions. J Pharm Sci. 2011 Dec;100(12):5324-45"
+              }
+            }
+          ]
+        }
+      ],
+      "PkaTypes": [
+        {
+          "Type": "Acid",
+          "Pka": 8.8
+        }
+      ],
+      "Processes": [
+        {
+          "InternalName": "MetabolizationSpecific_FirstOrder",
+          "DataSource": "adjusted",
+          "Molecule": "CYP1A2",
+          "Parameters": [
+            {
+              "Name": "Enzyme concentration",
+              "Value": 1.0,
+              "Unit": "µmol/l",
+              "ValueOrigin": {}
+            },
+            {
+              "Name": "Specific clearance",
+              "Value": 0.00843,
+              "Unit": "1/min",
+              "ValueOrigin": {
+                "Source": "ParameterIdentification",
+                "Method": "ManualFit",
+                "Description": "adjusted to match IV Kaumeier data"
+              }
+            }
+          ],
+          "Description": "Metabolic enzyme activity is described as first order process. Specific clearance is calculated from specific rates determined in an in vitro assay.\r\n\r\nadjusted to match IV Kaumeier data"
+        },
+        {
+          "InternalName": "GlomerularFiltration",
+          "DataSource": "GFR",
+          "Species": "Human",
+          "Parameters": [
+            {
+              "Name": "GFR fraction",
+              "Value": 0.15,
+              "ValueOrigin": {}
+            }
+          ]
+        }
+      ],
+      "CalculationMethods": [
+        "Cellular partition coefficient method - Rodgers and Rowland",
+        "Cellular permeability - PK-Sim Standard"
+      ],
+      "Parameters": [
+        {
+          "Name": "Molecular weight",
+          "Value": 180.17,
+          "Unit": "g/mol",
+          "ValueOrigin": {}
+        }
+      ],
+      "Description": "Version 1.1"
+    }
+  ],
+  "Formulations": [
+    {
+      "Name": "Hot stage extrusion as table",
+      "FormulationType": "Formulation_Table",
+      "Parameters": [
+        {
+          "Name": "Fraction (dose)",
+          "Value": 0.0,
+          "ValueOrigin": {},
+          "TableFormula": {
+            "Name": "Henrist1999 Diss ExpForm",
+            "XName": "Time",
+            "XDimension": "Time",
+            "XUnit": "min",
+            "YName": "Henrist1999 Diss ExpForm",
+            "YDimension": "Fraction",
+            "YUnit": "%",
+            "UseDerivedValues": true,
+            "Points": [
+              {
+                "X": 0.0,
+                "Y": 0.0,
+                "RestartSolver": false
+              },
+              {
+                "X": 25.0,
+                "Y": 17.0027,
+                "RestartSolver": false
+              },
+              {
+                "X": 60.0,
+                "Y": 26.484999999999996,
+                "RestartSolver": false
+              },
+              {
+                "X": 120.0,
+                "Y": 40.8719,
+                "RestartSolver": false
+              },
+              {
+                "X": 240.0,
+                "Y": 61.471399999999996,
+                "RestartSolver": false
+              },
+              {
+                "X": 360.0,
+                "Y": 72.5886,
+                "RestartSolver": false
+              },
+              {
+                "X": 480.0,
+                "Y": 81.7439,
+                "RestartSolver": false
+              },
+              {
+                "X": 720.0,
+                "Y": 92.2071,
+                "RestartSolver": false
+              },
+              {
+                "X": 960.0,
+                "Y": 97.4387,
+                "RestartSolver": false
+              },
+              {
+                "X": 1200.0,
+                "Y": 100.0,
+                "RestartSolver": false
+              }
+            ]
+          }
+        },
+        {
+          "Name": "Use as suspension",
+          "Value": 1.0,
+          "ValueOrigin": {}
+        }
+      ],
+      "Description": "Henrist D, Lefebvre RA, Remon JP. 1999. Bioavailability of starch based hot stage extrusion formulations. Int J Pharm 187:185–191."
+    }
+  ],
+  "Protocols": [
+    {
+      "Name": "oral 300mg",
+      "ApplicationType": "Oral",
+      "DosingInterval": "Single",
+      "Parameters": [
+        {
+          "Name": "Start time",
+          "Value": 0.0,
+          "Unit": "h",
+          "ValueOrigin": {}
+        },
+        {
+          "Name": "InputDose",
+          "Value": 300.0,
+          "Unit": "mg",
+          "ValueOrigin": {}
+        },
+        {
+          "Name": "Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg",
+          "ValueOrigin": {}
+        }
+      ],
+      "Description": "Henrist D, Lefebvre RA, Remon JP. 1999. Bioavailability of\r\nstarch based hot stage extrusion formulations. Int J Pharm\r\n187:185–191."
+    }
+  ],
+  "Simulations": [
+    {
+      "Name": "Henrist oral Hot stage extrusion as table",
+      "Model": "4Comp",
+      "ObservedData": [
+        "Hot stage extrusion",
+        "Henrist 1999.Hot stage extrusion oral.Subj 1",
+        "Henrist 1999.Hot stage extrusion oral.Subj 2",
+        "Henrist 1999.Hot stage extrusion oral.Subj 3",
+        "Henrist 1999.Hot stage extrusion oral.Subj 4",
+        "Henrist 1999.Hot stage extrusion oral.Subj 5",
+        "Henrist 1999.Hot stage extrusion oral.Subj 6",
+        "Henrist 1999.Hot stage extrusion oral.Subj 7"
+      ],
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h",
+              "ValueOrigin": {}
+            },
+            {
+              "Name": "End time",
+              "Value": 24.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {}
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "Events|oral 300mg|Hot stage extrusion as table|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg",
+          "ValueOrigin": {}
+        }
+      ],
+      "OutputSelections": [
+        "Organism|PeripheralVenousBlood|Theophylline|Plasma (Peripheral Venous Blood)",
+        "Organism|Lumen|Theophylline|Fraction dissolved"
+      ],
+      "Individual": "Man",
+      "Compounds": [
+        {
+          "Name": "Theophylline",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Processes": [
+            {
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
+            }
+          ],
+          "Protocol": {
+            "Name": "oral 300mg",
+            "Formulations": [
+              {
+                "Name": "Hot stage extrusion as table",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "HasResults": false
+    }
+  ],
+  "ObservedData": [
+    {
+      "Name": "Hot stage extrusion",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Diss ExpForm",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Diss ExpForm",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Undefined",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Undefined",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "% dissolved",
+          "QuantityInfo": {
+            "Path": "Data|ObservedData|Undefined|Undefined|Theophylline|% dissolved"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            0.1700273,
+            0.2648501,
+            0.4087193,
+            0.6147139,
+            0.7258855,
+            0.8174387,
+            0.9220708,
+            0.9743869,
+            1.000545,
+            1.007085
+          ],
+          "Dimension": "Fraction"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Data|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          0.41666666,
+          1.0,
+          2.0,
+          4.0,
+          6.0,
+          8.0,
+          12.0,
+          16.0,
+          20.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 1",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc ",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 1|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            1.762712,
+            2.59887,
+            3.8870063,
+            4.745763,
+            6.666667,
+            7.073446,
+            6.305085,
+            5.378531,
+            4.79096,
+            4.248588,
+            2.621469
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 1|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          14.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 2",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 2",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc (1)",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 2|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (1)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            0.38418078,
+            1.514124,
+            3.502825,
+            4.81356,
+            6.711864,
+            6.711864,
+            6.282486,
+            5.468926,
+            4.4971747,
+            4.022599,
+            1.9435031
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 2|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          14.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 3",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 3",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc (2)",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 3|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (2)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            2.124294,
+            4.429379,
+            5.853107,
+            6.870057,
+            7.322034,
+            6.644068,
+            5.672317,
+            4.926554,
+            4.2033896,
+            3.59322,
+            1.694915
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 3|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          14.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 4",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 4",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc (3)",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 4|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (3)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            2.508475,
+            4.0677967,
+            5.920904,
+            6.6892657,
+            6.531074,
+            6.033898,
+            4.745763,
+            3.9774008,
+            3.0056498,
+            1.19774
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 4|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 5",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 5",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc (4)",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 5|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (4)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            0.7457627,
+            1.966102,
+            3.706215,
+            3.096045,
+            5.0847464,
+            5.3559318,
+            4.3163843,
+            3.7740111,
+            3.050848,
+            1.107345
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 5|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 6",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 6",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc (5)",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 6|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (5)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            3.141243,
+            4.1807914,
+            5.7853107,
+            6.124294,
+            5.423729,
+            4.903955,
+            3.9548023,
+            3.3898308,
+            2.621469,
+            2.214689,
+            0.8813559
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 6|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          14.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 7",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 7",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc (6)",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 7|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (6)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            2.2824862,
+            3.9548023,
+            5.7853107,
+            6.101695,
+            5.242938,
+            3.7740111,
+            3.209039,
+            2.508475,
+            2.033898,
+            0.7457627
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 7|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          8.0,
+          10.0,
+          12.0,
+          14.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    }
+  ]
+}

--- a/tests/MoBi.Tests/Core/BuildingBlockVersionUpdaterSpecs.cs
+++ b/tests/MoBi.Tests/Core/BuildingBlockVersionUpdaterSpecs.cs
@@ -29,54 +29,6 @@ namespace MoBi.Core
       }
    }
 
-   internal class When_the_expression_is_updated_and_it_was_imported_from_snapshot : concern_for_BuildingBlockVersionUpdater
-   {
-      private ExpressionProfileBuildingBlock _expression;
-      protected override void Context()
-      {
-         base.Context();
-         _expression = new ExpressionProfileBuildingBlock
-         {
-            SnapshotOriginModuleId = "5"
-         };
-      }
-
-      protected override void Because()
-      {
-         sut.UpdateBuildingBlockVersion(_expression, true, PKSimModuleConversion.SetAsExtensionModule);
-      }
-
-      [Observation]
-      public void the_snapshot_origin_should_be_removed()
-      {
-         _expression.SnapshotOriginModuleId.ShouldBeNull();
-      }
-   }
-
-   internal class When_the_individual_is_updated_and_it_was_imported_from_snapshot : concern_for_BuildingBlockVersionUpdater
-   {
-      private IndividualBuildingBlock _individual;
-      protected override void Context()
-      {
-         base.Context();
-         _individual = new IndividualBuildingBlock
-         {
-            SnapshotOriginModuleId = "5"
-         };
-      }
-
-      protected override void Because()
-      {
-         sut.UpdateBuildingBlockVersion(_individual, true, PKSimModuleConversion.SetAsExtensionModule);
-      }
-
-      [Observation]
-      public void the_snapshot_origin_should_be_removed()
-      {
-         _individual.SnapshotOriginModuleId.ShouldBeNull();
-      }
-   }
-
    internal class When_the_building_block_version_updater_is_updating_the_building_block_version_used_in_a_building_block : concern_for_BuildingBlockVersionUpdater
    {
       private IBuildingBlock _changeBuildingBlock;

--- a/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectLoadSpecs.cs
+++ b/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectLoadSpecs.cs
@@ -5,40 +5,25 @@ using MoBi.Core.Services;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
-using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
-using OSPSuite.Core.Serialization.Exchange;
 using OSPSuite.Utility.Container;
 
 namespace MoBi.IntegrationTests.Snapshots
 {
    public class When_loading_a_snapshot : ContextWithLoadedSnapshot
    {
-      private SimulationTransfer _simulationTransfer;
-
       public override void GlobalContext()
       {
          base.GlobalContext();
          var starter = IoC.Resolve<IPKSimStarter>();
-         _simulationTransfer = new SimulationTransfer
-         {
-            Simulation = new MoBiSimulation
-            {
-               Configuration = new SimulationConfiguration
-               {
-                  Individual = new IndividualBuildingBlock().WithName("pksim Individual"),
-                  SimulationSettings = new SimulationSettings()
-               }
-            }
-         };
 
-         _simulationTransfer.Simulation.Configuration.AddModuleConfiguration(new ModuleConfiguration(new Module
+         var module = new Module
          {
             IsPKSimModule = true,
             Name = "Henrist oral Hot stage extrusion as table"
-         }, new InitialConditionsBuildingBlock(), new ParameterValuesBuildingBlock()));
+         };
 
-         A.CallTo(() => starter.LoadSimulationTransferFromSnapshot(A<string>._)).Returns(_simulationTransfer);
+         A.CallTo(() => starter.LoadModuleFromSnapshot(A<string>._)).Returns(module);
 
          // EntityValidationTask is a fake
          var validationTask = IoC.Resolve<IEntityValidationTask>();
@@ -86,7 +71,7 @@ namespace MoBi.IntegrationTests.Snapshots
       [Observation]
       public void the_individual_building_blocks_are_loaded()
       {
-         _project.IndividualsCollection.Count.ShouldBeEqualTo(2);
+         _project.IndividualsCollection.Count.ShouldBeEqualTo(1);
       }
    }
 }

--- a/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectMapperSpecs.cs
+++ b/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectMapperSpecs.cs
@@ -42,7 +42,6 @@ namespace MoBi.IntegrationTests.Snapshots
       private ParameterIdentificationMapper _parameterIdentificationMapper;
       private IPKSimStarter _pkSimStarter;
       private ISimulationSettingsFactory _simulationSettingsFactory;
-      protected SimulationTransfer _simulationTransfer;
       private SimulationMapper _simulationMapper;
 
       protected override void Context()
@@ -72,32 +71,21 @@ namespace MoBi.IntegrationTests.Snapshots
 
          var snapshotIndividualBuildingBlock = new IndividualBuildingBlock
          {
-            SnapshotOriginModuleId = pksimModule.Id,
+            Snapshot = "dummy",
             Id = "pksimInd"
          };
 
          var snapshotExpressionProfile = new ExpressionProfileBuildingBlock
          {
             Type = ExpressionTypes.MetabolizingEnzyme,
-            SnapshotOriginModuleId = pksimModule.Id,
+            Snapshot = "dummy",
             Id = "pksimexpression"
          };
 
-         _simulationTransfer = new SimulationTransfer();
-         var moduleConfiguration = new ModuleConfiguration(new Module { IsPKSimModule = true }, new InitialConditionsBuildingBlock(), new ParameterValuesBuildingBlock());
-         _simulationTransfer.Simulation = new MoBiSimulation
-         {
-            Configuration = new SimulationConfiguration
-            {
-               Individual = snapshotIndividualBuildingBlock
-            }
-         };
+         var transferModule = new Module { IsPKSimModule = true };
 
-         _simulationTransfer.Simulation.Configuration.AddExpressionProfile(snapshotExpressionProfile);
-         _simulationTransfer.Simulation.Configuration.AddModuleConfiguration(moduleConfiguration);
-
-         A.CallTo(() => _pkSimStarter.LoadSimulationTransferFromSnapshot(pksimModule.Snapshot)).Returns(_simulationTransfer);
-         A.CallTo(() => _pkSimStarter.LoadSimulationTransferFromSnapshotAndExportInputs(pksimModule.Snapshot, A<QualificationConfiguration>._)).Returns((_simulationTransfer, Array.Empty<InputMapping>()));
+         A.CallTo(() => _pkSimStarter.LoadModuleFromSnapshot(pksimModule.Snapshot)).Returns(transferModule);
+         A.CallTo(() => _pkSimStarter.LoadModuleFromSnapshotAndExportInputs(pksimModule.Snapshot, A<QualificationConfiguration>._)).Returns((transferModule, Array.Empty<InputMapping>()));
 
          var dataRepository = DomainHelperForSpecs.ObservedData();
          _project.AddObservedData(dataRepository);
@@ -175,13 +163,13 @@ namespace MoBi.IntegrationTests.Snapshots
       [Observation]
       public void the_project_should_contain_expression_snapshots_for_each_expression()
       {
-         _result.ExpressionProfileCollection.Count.ShouldBeEqualTo(_snapshot.ExpressionProfileBuildingBlocks.Length + _simulationTransfer.Simulation.Configuration.ExpressionProfiles.Count);
+         _result.ExpressionProfileCollection.Count.ShouldBeEqualTo(_snapshot.ExpressionProfileBuildingBlocks.Length + _snapshot.ExpressionProfileSnapshots.Length);
       }
 
       [Observation]
       public void the_project_should_contain_individual_snapshots_for_each_individual()
       {
-         _result.IndividualsCollection.Count.ShouldBeEqualTo(_snapshot.IndividualBuildingBlocks.Length + (_simulationTransfer.Simulation.Configuration.Individual == null ? 0 : 1));
+         _result.IndividualsCollection.Count.ShouldBeEqualTo(_snapshot.IndividualBuildingBlocks.Length + _snapshot.IndividualBuildingBlockSnapshots.Length);
       }
 
       [Observation]
@@ -233,15 +221,15 @@ namespace MoBi.IntegrationTests.Snapshots
       }
 
       [Observation]
-      public void the_project_should_contain_expression_snapshots_for_each_expression()
+      public void the_project_should_contain_expression_snapshots_for_each_expression_in_the_project()
       {
-         _result.ExpressionProfileCollection.Count.ShouldBeEqualTo(_snapshot.ExpressionProfileBuildingBlocks.Length + _simulationTransfer.Simulation.Configuration.ExpressionProfiles.Count);
+         _result.ExpressionProfileCollection.Count.ShouldBeEqualTo(_snapshot.ExpressionProfileSnapshots.Length + _snapshot.ExpressionProfileBuildingBlocks.Length);
       }
 
       [Observation]
-      public void the_project_should_contain_individual_snapshots_for_each_individual()
+      public void the_project_should_contain_individual_snapshots_for_each_individual_in_the_project()
       {
-         _result.IndividualsCollection.Count.ShouldBeEqualTo(_snapshot.IndividualBuildingBlocks.Length + (_simulationTransfer.Simulation.Configuration.Individual == null ? 0 : 1));
+         _result.IndividualsCollection.Count.ShouldBeEqualTo(_snapshot.IndividualBuildingBlockSnapshots.Length + _snapshot.IndividualBuildingBlocks.Length);
       }
 
       [Observation]

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.57" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.58" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.77" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForExpressionProfileBuildingBlockSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForExpressionProfileBuildingBlockSpecs.cs
@@ -275,5 +275,25 @@ namespace MoBi.Presentation.Tasks
             A.CallTo(() => _editFormulaPresenter.Init(_clonedParameter, _clonedBuildingBlock, A<UsingFormulaDecoder>._)).MustHaveHappened();
          }
       }
+
+      public class When_loading_from_snapshot_string: concern_for_InteractionTasksForExpressionProfileBuildingBlock
+      {
+         protected override void Because()
+         {
+            sut.LoadFromSnapshot("");
+         }
+
+         [Observation]
+         public void the_starter_creates_the_expression_profile()
+         {
+            A.CallTo(() => _pkSimStarter.LoadExpressionProfileFromSnapshot("")).MustHaveHappened();
+         }
+
+         [Observation]
+         public void the_object_is_cloned_before_returning()
+         {
+            A.CallTo(() => _cloneManager.Clone(A<ExpressionProfileBuildingBlock>._)).MustHaveHappened();
+         }
+      }
    }
 }

--- a/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForModuleSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForModuleSpecs.cs
@@ -3,6 +3,7 @@ using FakeItEasy;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Exceptions;
+using MoBi.Core.Services;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Edit;
@@ -20,13 +21,15 @@ namespace MoBi.Presentation.Tasks
       protected IInteractionTaskContext _context;
       private IInitialConditionsTask<InitialConditionsBuildingBlock> _initialConditionsTask;
       private IParameterValuesTask _parameterValuesTask;
+      private IPKSimStarter _pkSimStarter;
 
       protected override void Context()
       {
+         _pkSimStarter = A.Fake<IPKSimStarter>();
          _context = A.Fake<IInteractionTaskContext>();
          _initialConditionsTask = A.Fake<IInitialConditionsTask<InitialConditionsBuildingBlock>>();
          _parameterValuesTask = A.Fake<IParameterValuesTask>();
-         sut = new InteractionTasksForModule(_context, new EditTaskForModule(_context), _parameterValuesTask, _initialConditionsTask);
+         sut = new InteractionTasksForModule(_context, new EditTaskForModule(_context), _parameterValuesTask, _initialConditionsTask, _pkSimStarter);
       }
    }
 

--- a/tests/MoBi.Tests/Presentation/Tasks/ModuleLoaderSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/ModuleLoaderSpecs.cs
@@ -24,7 +24,7 @@ namespace MoBi.Presentation.Tasks
       protected IInteractionTasksForModule _moduleTask;
       protected IInteractionTaskContext _interactionTaskContext;
       protected Module _addedModule;
-      private ICloneManagerForSimulation _cloneManager;
+      protected ICloneManagerForSimulation _cloneManager;
       protected SimulationConfiguration _clonedConfiguration;
 
       protected override void Context()

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.57" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.57" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.58" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.58" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #2101 Rebuild Expression Profile from snapshot
Fixes #646 Rebuild Individual from Snapshot

# Description
Part 1 of 2 or maybe 3.

We want to recreate individual/experssion bb's from pksim snapshots separately from loading the module snapshot.

There will be a part 2 at least where we deal with values that have changed in MoBi after the building block is added to the project.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):