### PR TITLE
Do not merge until 12.1 is released! mobi portable   the pk sim executable path option is not respected

### DIFF
--- a/src/MoBi.Presentation/Tasks/PKSimStarter.cs
+++ b/src/MoBi.Presentation/Tasks/PKSimStarter.cs
@@ -142,12 +142,13 @@ namespace MoBi.Presentation.Tasks
 
       private string retrievePKSimExecutablePath()
       {
-         //Installed properly via Setup? return standard path
-         if (FileHelper.FileExists(_configuration.PKSimPath))
-            return _configuration.PKSimPath;
-
+         // Specified explicitly via user settings? Use overridden path
          if (FileHelper.FileExists(_applicationSettings.PKSimPath))
             return _applicationSettings.PKSimPath;
+
+         // Installed properly via Setup? Use standard path
+         if (FileHelper.FileExists(_configuration.PKSimPath))
+            return _configuration.PKSimPath;
 
          throw new MoBiException(AppConstants.PKSim.NotInstalled);
       }

--- a/tests/MoBi.Tests/Presentation/PKSimStarterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/PKSimStarterSpecs.cs
@@ -30,6 +30,44 @@ namespace MoBi.Presentation
       }
    }
 
+   public class When_exporting_a_simulation_file_to_PKSim_and_the_application_was_installed_using_the_setup_but_overridden : concern_for_PKSimStarter
+   {
+      private readonly string _pkSimConfigPath = "PKSimConfigPath";
+      private Func<string, bool> _oldFileHelper;
+      private readonly string _pkSimUserSettingsPath = "PKSimUserSettingsPath";
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         _oldFileHelper = FileHelper.FileExists;
+         FileHelper.FileExists = s => s == _pkSimConfigPath || s == _pkSimUserSettingsPath;
+      }
+
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _configuration.PKSimPath).Returns(_pkSimConfigPath);
+         A.CallTo(() => _applicationSettings.PKSimPath).Returns(_pkSimUserSettingsPath);
+      }
+
+      protected override void Because()
+      {
+         sut.StartPopulationSimulationWithSimulationFile(_simulationFile);
+      }
+
+      [Observation]
+      public void should_start_override_PKSim_with_the_simulation_file()
+      {
+         A.CallTo(() => _startableProcessFactory.CreateStartableProcess(_pkSimUserSettingsPath, A<string[]>._)).MustHaveHappened();
+      }
+
+      public override void GlobalCleanup()
+      {
+         base.GlobalCleanup();
+         FileHelper.FileExists = _oldFileHelper;
+      }
+   }
+
    public class When_exporting_a_simulation_file_to_PKSim_and_the_application_was_installed_using_the_setup : concern_for_PKSimStarter
    {
       private readonly string _pkSimConfigPath = "PKSimConfigPath";


### PR DESCRIPTION
Fixes #2036 

# Description
The starter should always try to find the overridden pksim from user settings first, and if not found, or not present, use the installed version.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):