### PR TITLE
2067 snapshot based runners seem to only use a single core v13

### DIFF
--- a/src/MoBi.Core/Events/Events.cs
+++ b/src/MoBi.Core/Events/Events.cs
@@ -22,6 +22,12 @@ namespace MoBi.Core.Events
 
    public class SimulationRunCanceledEvent
    {
+      public IMoBiSimulation Simulation { get; set; }
+
+      public SimulationRunCanceledEvent(IMoBiSimulation simulation)
+      {
+         Simulation = simulation;
+      }
    }
 
    public class SimulationRunStartedEvent

--- a/src/MoBi.Core/Services/CoreSimulationRunner.cs
+++ b/src/MoBi.Core/Services/CoreSimulationRunner.cs
@@ -63,7 +63,6 @@ public class CoreSimulationRunner : ICoreSimulationRunner
 
       MaxParallelism = Environment.ProcessorCount;
       _parallelismGate = new SemaphoreSlim(MaxParallelism, MaxParallelism);
-
    }
 
    public bool IsSimulationRunning(IMoBiSimulation simulation)
@@ -109,6 +108,7 @@ public class CoreSimulationRunner : ICoreSimulationRunner
             cts.Cancel();
             cts.Dispose();
          }
+
          _context.PublishEvent(new SimulationRunCanceledEvent(simulation));
       }
    }
@@ -195,7 +195,7 @@ public class CoreSimulationRunner : ICoreSimulationRunner
    private async Task startSimulationRunAsync(IMoBiSimulation simulation, Action<SimulationRunResults> resultsAction = null)
    {
       var cts = new CancellationTokenSource();
-      if (!_cancellationTokenSources.TryAdd(simulation, cts)) 
+      if (!_cancellationTokenSources.TryAdd(simulation, cts))
          return;
 
       await _parallelismGate.WaitAsync(cts.Token);
@@ -244,6 +244,7 @@ public class CoreSimulationRunner : ICoreSimulationRunner
                ctsToDispose.Dispose();
             }
          }
+
          _context.PublishEvent(new SimulationRunFinishedEvent(simulation));
          _parallelismGate.Release();
       }

--- a/src/MoBi.Core/Services/CoreSimulationRunner.cs
+++ b/src/MoBi.Core/Services/CoreSimulationRunner.cs
@@ -41,7 +41,8 @@ public class CoreSimulationRunner : ICoreSimulationRunner
    protected readonly ConcurrentDictionary<IMoBiSimulation, CancellationTokenSource> _cancellationTokenSources = new();
    private readonly IEntityValidationTask _entityValidationTask;
    private readonly IQuantitySelectionsRetriever _quantitySelectionsRetriever;
-   private ISimModelManager _simModelManager;
+   private readonly SemaphoreSlim _parallelismGate;
+   public int MaxParallelism { get; private set; }
 
    public CoreSimulationRunner(
       IMoBiContext context,
@@ -59,6 +60,10 @@ public class CoreSimulationRunner : ICoreSimulationRunner
       _simModelManagerFactory = simModelManagerFactory;
       _keyPathMapper = keyPathMapper;
       _entityValidationTask = entityValidationTask;
+
+      MaxParallelism = Environment.ProcessorCount;
+      _parallelismGate = new SemaphoreSlim(MaxParallelism, MaxParallelism);
+
    }
 
    public bool IsSimulationRunning(IMoBiSimulation simulation)
@@ -91,7 +96,7 @@ public class CoreSimulationRunner : ICoreSimulationRunner
       {
          cts.Cancel();
          cts.Dispose();
-         _context.PublishEvent(new SimulationRunCanceledEvent());
+         _context.PublishEvent(new SimulationRunCanceledEvent(simulation));
       }
    }
 
@@ -104,9 +109,8 @@ public class CoreSimulationRunner : ICoreSimulationRunner
             cts.Cancel();
             cts.Dispose();
          }
+         _context.PublishEvent(new SimulationRunCanceledEvent(simulation));
       }
-
-      _context.PublishEvent(new SimulationRunCanceledEvent());
    }
 
    private string getNewRepositoryName()
@@ -183,20 +187,6 @@ public class CoreSimulationRunner : ICoreSimulationRunner
       _context.PublishEvent(new ProgressingEvent(args.Progress, args.Progress, AppConstants.SimulationRun));
    }
 
-   private void removeEvents()
-   {
-      if (_simModelManager == null) return;
-      _simModelManager.SimulationProgress -= onSimulationProgress;
-      _simModelManager.Terminated -= onSimulationFinished;
-   }
-
-   private void addEvents()
-   {
-      if (_simModelManager == null) return;
-      _simModelManager.SimulationProgress += onSimulationProgress;
-      _simModelManager.Terminated += onSimulationFinished;
-   }
-
    private void addPersistableParametersToOutputSelection(IMoBiSimulation simulation)
    {
       _quantitySelectionsRetriever.UpdatePersistableOutputsIn(simulation);
@@ -205,19 +195,31 @@ public class CoreSimulationRunner : ICoreSimulationRunner
    private async Task startSimulationRunAsync(IMoBiSimulation simulation, Action<SimulationRunResults> resultsAction = null)
    {
       var cts = new CancellationTokenSource();
-      if (!_cancellationTokenSources.TryAdd(simulation, cts)) //this will prevent from running one that is already running
+      if (!_cancellationTokenSources.TryAdd(simulation, cts)) 
          return;
 
+      await _parallelismGate.WaitAsync(cts.Token);
       _context.PublishEvent(new SimulationRunStartedEvent(simulation));
       _context.PublishEvent(new ProgressInitEvent(100, AppConstants.SimulationRun));
-      _simModelManager = _simModelManagerFactory.Create();
+      var simModelManager = _simModelManagerFactory.Create();
+
+      void onProgress(object sender, SimulationProgressEventArgs args)
+      {
+         _context.PublishEvent(new ProgressingEvent(args.Progress, args.Progress, AppConstants.SimulationRun));
+      }
+
+      void onFinished(object sender, EventArgs eventArgs)
+      {
+         _context.PublishEvent(new ProgressDoneWithMessageEvent(AppConstants.SimulationRun));
+      }
+
+      simModelManager.SimulationProgress += onProgress;
+      simModelManager.Terminated += onFinished;
 
       try
       {
-         addEvents();
          updatePersistableFor(simulation);
-
-         var simulationRunResults = await _simModelManager.RunSimulationAsync(simulation, cts.Token);
+         var simulationRunResults = await simModelManager.RunSimulationAsync(simulation, cts.Token);
 
          simulation.HasChanged = true;
          resultsAction?.Invoke(simulationRunResults);
@@ -242,9 +244,8 @@ public class CoreSimulationRunner : ICoreSimulationRunner
                ctsToDispose.Dispose();
             }
          }
-
-         removeEvents();
          _context.PublishEvent(new SimulationRunFinishedEvent(simulation));
+         _parallelismGate.Release();
       }
    }
 

--- a/src/MoBi.Presentation/Presenter/Main/StatusBarPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/StatusBarPresenter.cs
@@ -41,10 +41,10 @@ namespace MoBi.Presentation.Presenter.Main
       private readonly IMoBiConfiguration _moBiConfiguration;
       public event EventHandler StatusChanged = delegate { };
       private int _numberOfReportsBeingCreated;
-      private readonly ConcurrentDictionary<string, bool> _simulations = new ConcurrentDictionary<string, bool>(); 
+      private readonly ConcurrentDictionary<string, bool> _simulations = new ConcurrentDictionary<string, bool>();
 
       private int activeSimulations => _simulations.Count(x => x.Value);
-      
+
       public StatusBarPresenter(IStatusBarView view, IMoBiConfiguration moBiConfiguration)
       {
          _view = view;
@@ -165,7 +165,11 @@ namespace MoBi.Presentation.Presenter.Main
 
       public void Handle(SimulationRunCanceledEvent eventToHandle)
       {
-         resetCountersAndHideBar();
+         _simulations[eventToHandle.Simulation.Id] = false;
+         if (activeSimulations == 0)
+         {
+            resetCountersAndHideBar();
+         }
       }
 
       private void hideProgressBar()

--- a/src/MoBi.Presentation/Tasks/SimulationRunner.cs
+++ b/src/MoBi.Presentation/Tasks/SimulationRunner.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Threading;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Services;
@@ -16,7 +14,7 @@ namespace MoBi.Presentation.Tasks
    {
       private readonly IMoBiApplicationController _applicationController;
       private readonly IOutputSelectionsRetriever _outputSelectionsRetriever;
-   
+
       public SimulationRunner(IMoBiContext context,
          IMoBiApplicationController applicationController,
          IOutputSelectionsRetriever outputSelectionsRetriever,

--- a/src/MoBi.Presentation/Tasks/SimulationRunner.cs
+++ b/src/MoBi.Presentation/Tasks/SimulationRunner.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Services;
@@ -14,7 +16,7 @@ namespace MoBi.Presentation.Tasks
    {
       private readonly IMoBiApplicationController _applicationController;
       private readonly IOutputSelectionsRetriever _outputSelectionsRetriever;
-
+   
       public SimulationRunner(IMoBiContext context,
          IMoBiApplicationController applicationController,
          IOutputSelectionsRetriever outputSelectionsRetriever,


### PR DESCRIPTION
Fixes #2067 

# Description

add paralelism to use multiple cores when multiple simulation is running

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):