### PR TITLE
311 security dialogue missing when parameter identification is running

### DIFF
--- a/src/MoBi.Core/Services/ISimulationRunner.cs
+++ b/src/MoBi.Core/Services/ISimulationRunner.cs
@@ -1,4 +1,5 @@
 ﻿using MoBi.Core.Domain.Model;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace MoBi.Core.Services
@@ -11,5 +12,6 @@ namespace MoBi.Core.Services
       bool IsSimulationRunning(IMoBiSimulation simulation);
       bool IsAnySimulationRunning();
       bool IsSimulationIdle(IMoBiSimulation simulation);
+      IEnumerable<IMoBiSimulation> RunningSimulations();
    }
 }

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -5,9 +5,11 @@ using MoBi.Core.Domain.Model;
 using MoBi.Core.Exceptions;
 using MoBi.Core.Services;
 using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.Assets;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Domain.Services.ParameterIdentifications;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Serialization.Exchange;
 using OSPSuite.Core.Services;
@@ -40,6 +42,8 @@ namespace MoBi.Presentation.Tasks
       private readonly IHeavyWorkManager _heavyWorkManager;
       private readonly ISimulationLoader _simulationLoader;
       private readonly ISbmlTask _sbmlTask;
+      private readonly IParameterIdentificationRunner _parameterIdentificationRunner;
+      private readonly ISimulationRunner _simulationRunner;
 
       public ProjectTask(
          IMoBiContext context,
@@ -48,8 +52,9 @@ namespace MoBi.Presentation.Tasks
          IMRUProvider mruProvider,
          IHeavyWorkManager heavyWorkManager,
          ISimulationLoader simulationLoader,
-         ISbmlTask sbmlTask
-      )
+         ISbmlTask sbmlTask,
+         IParameterIdentificationRunner parameterIdentificationRunner,
+         ISimulationRunner simulationRunner)
       {
          _context = context;
          _simulationLoader = simulationLoader;
@@ -58,6 +63,8 @@ namespace MoBi.Presentation.Tasks
          _mruProvider = mruProvider;
          _serializationTask = serializationTask;
          _dialogCreator = dialogCreator;
+         _parameterIdentificationRunner = parameterIdentificationRunner;
+         _simulationRunner = simulationRunner;
       }
 
       public void OpenProjectFrom(string path)
@@ -244,6 +251,18 @@ namespace MoBi.Presentation.Tasks
          if (_context.CurrentProject == null)
             return true;
 
+         if (_parameterIdentificationRunner.IsRunning)
+         {
+            showRunningParameterIdentificationWarnings();
+            shouldClose = false;
+         }
+
+         if (_simulationRunner.IsAnySimulationRunning())
+         {
+            showRunningSimulationsWarnings();
+            shouldClose = false;
+         }
+
          if (_context.CurrentProject.HasChanged)
             shouldClose = askForSaveProject();
 
@@ -264,6 +283,18 @@ namespace MoBi.Presentation.Tasks
 
       // Check if TemplateBuildingBlock ID is set, and if not set it to th e used Building Block
       // Needed when importing from PK-Sim 
+
+      private void showRunningParameterIdentificationWarnings()
+      {
+         var parameterIdentifications = _parameterIdentificationRunner.RunningParameterIdentifications.ToList();
+         _dialogCreator.MessageBoxInfo(Captions.ParameterIdentification.ParameterIdentificationsAreRunning(parameterIdentifications.AllNames()));
+      }
+
+      private void showRunningSimulationsWarnings()
+      {
+         var simulations = _simulationRunner.RunningSimulations().ToList();
+         _dialogCreator.MessageBoxInfo(Captions.ParameterIdentification.SimulationsAreRunning(simulations.AllNames()));
+      }
 
       private bool askForSaveProject()
       {

--- a/src/MoBi.Presentation/Tasks/SimulationRunner.cs
+++ b/src/MoBi.Presentation/Tasks/SimulationRunner.cs
@@ -292,5 +292,10 @@ namespace MoBi.Presentation.Tasks
       {
          return _cancellationTokenSources.Values.Any(cts => !cts.IsCancellationRequested);
       }
+
+      public IEnumerable<IMoBiSimulation> RunningSimulations()
+      {
+         return _cancellationTokenSources.Where(kvp => !kvp.Value.IsCancellationRequested).Select(kvp => kvp.Key);
+      }
    }
 }

--- a/tests/MoBi.Tests/Presentation/ProjectTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ProjectTaskSpecs.cs
@@ -16,6 +16,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Domain.Services.ParameterIdentifications;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Serialization.Exchange;
 using OSPSuite.Core.Services;
@@ -39,6 +40,8 @@ namespace MoBi.Presentation
       private IHeavyWorkManager _heavyWorkManager;
       private ISbmlTask _sbmlTask;
       protected IReactionBuildingBlockFactory _reactionBuildingBlockFactory;
+      protected IParameterIdentificationRunner _parameterIdentificationRunner;
+      protected ISimulationRunner _simulationRunner;
 
       protected override void Context()
       {
@@ -53,8 +56,11 @@ namespace MoBi.Presentation
          _spatialStructureFactory = A.Fake<IMoBiSpatialStructureFactory>();
          _sbmlTask = A.Fake<ISbmlTask>();
          _reactionBuildingBlockFactory = A.Fake<IReactionBuildingBlockFactory>();
+         _parameterIdentificationRunner = A.Fake<IParameterIdentificationRunner>();
+         _simulationRunner = A.Fake<ISimulationRunner>();
+
          sut = new ProjectTask(_context, _serializationTask, _dialogCreator, _mruProvider, _heavyWorkManager,
-            new SimulationLoader(_cloneManager, _nameCorrector, _context), _sbmlTask);
+            new SimulationLoader(_cloneManager, _nameCorrector, _context), _sbmlTask, _parameterIdentificationRunner, _simulationRunner);
       }
    }
 


### PR DESCRIPTION
Fixes #311 

# Description

When a PI is running and we try to delete it, it should not let us and warn the user that it is running.
Furhtermore when running (both PI or Simulation) the app should not be closed without warning. 

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):