### PR TITLE
Fixes #2103 Adding a sum formula in the events BB: Unhandled exception occurs

### DIFF
--- a/src/MoBi.Presentation/DTO/FormulaBuilderDTO.cs
+++ b/src/MoBi.Presentation/DTO/FormulaBuilderDTO.cs
@@ -7,7 +7,12 @@ namespace MoBi.Presentation.DTO
 {
    public class FormulaBuilderDTO : ObjectBaseDTO
    {
-      public static FormulaBuilderDTO NULL = new FormulaBuilderDTO {Description = AppConstants.NullFormulaDescription, Name = AppConstants.Captions.FormulaNotAvailable};
+      public static FormulaBuilderDTO NULL = new FormulaBuilderDTO
+      {
+         Description = AppConstants.NullFormulaDescription, 
+         Name = AppConstants.Captions.FormulaNotAvailable,
+         ObjectPaths = new List<FormulaUsablePathDTO>()
+      };
 
       private FormulaBuilderDTO()
       {

--- a/src/MoBi.Presentation/Presenter/EditEventBuilderPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditEventBuilderPresenter.cs
@@ -239,7 +239,7 @@ namespace MoBi.Presentation.Presenter
 
       public void SetFormulaFor(EventAssignmentBuilderDTO eventAssignmentBuilderDTO, FormulaBuilderDTO formulaBuilderDTO)
       {
-         var newFormula = _context.Get<ExplicitFormula>(formulaBuilderDTO.Id);
+         var newFormula = _context.Get<Formula>(formulaBuilderDTO.Id);
          var eventAssignmentBuilder = _context.Get<EventAssignmentBuilder>(eventAssignmentBuilderDTO.Id);
          AddCommand(
             new EditObjectBasePropertyInBuildingBlockCommand(eventAssignmentBuilder.PropertyName(b => b.Formula), newFormula, eventAssignmentBuilder.Formula, eventAssignmentBuilder, BuildingBlock).RunCommand(_context));

--- a/tests/MoBi.Tests/Presentation/EditEventBuilderPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditEventBuilderPresenterSpecs.cs
@@ -146,7 +146,7 @@ public class When_setting_a_new_formula_for_an_event_assignment : concern_for_Ed
       [Observation]
       public void should_retrieve_domain_objects()
       {
-         A.CallTo(() => _context.Get<ExplicitFormula>(_formulaDTO.Id)).MustHaveHappened();
+         A.CallTo(() => _context.Get<Formula>(_formulaDTO.Id)).MustHaveHappened();
          A.CallTo(() => _context.Get<EventAssignmentBuilder>(_assignmentDTO.Id)).MustHaveHappened();
       }
    }


### PR DESCRIPTION
Fixes #2103

# Description
The earliest error is that the formula cannot be set in the event because the context.Get was not generic enough. It only worked for ExplicitFormulas.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):