### PR TITLE
Fixes #1717 When loading a pkml with observed data, the data are not shown in the simulation chart

### DIFF
--- a/src/MoBi.Presentation/Presenter/ChartPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ChartPresenter.cs
@@ -48,12 +48,13 @@ namespace MoBi.Presentation.Presenter
       ///    Shows the specified chart with underlying data.
       /// </summary>
       /// <param name="chart">The chart to display</param>
-      /// <param name="dataRepositories">The data used in the chart</param>
+      /// <param name="plottedData">The data used in the chart</param>
+      /// <param name="notPlottedData">Data that is added to the data browser, but is not used in the chart</param>
       /// <param name="defaultTemplate">If specified, this template will be used to initialize the chart</param>
       /// <remarks>
       ///    This method ensures the correct order of parameter setting
       /// </remarks>
-      void Show(CurveChart chart, IReadOnlyList<DataRepository> dataRepositories, CurveChartTemplate defaultTemplate = null);
+      void Show(CurveChart chart, IReadOnlyList<DataRepository> plottedData, IReadOnlyList<DataRepository> notPlottedData, CurveChartTemplate defaultTemplate = null);
 
       void UpdateTemplatesFor(IWithChartTemplates withChartTemplates);
       event EventHandler<ObservedDataAddedToChartEventArgs> OnObservedDataAddedToChart;
@@ -271,7 +272,7 @@ namespace MoBi.Presentation.Presenter
          _initialized = true;
       }
 
-      public void Show(CurveChart chart, IReadOnlyList<DataRepository> dataRepositories, CurveChartTemplate defaultTemplate = null)
+      public void Show(CurveChart chart, IReadOnlyList<DataRepository> plottedData, IReadOnlyList<DataRepository> notPlottedData, CurveChartTemplate defaultTemplate = null)
       {
          try
          {
@@ -280,9 +281,10 @@ namespace MoBi.Presentation.Presenter
 
             //do not validate template when showing a chart as the chart might well be without curves when initialized for the first time.
             var currentTemplate = defaultTemplate ?? _chartTemplatingTask.TemplateFrom(chart, validateTemplate: false);
-            replaceSimulationRepositories(dataRepositories);
+            replaceSimulationRepositories(plottedData);
             LoadFromTemplate(currentTemplate, triggeredManually: false, propagateChartChangeEvent: false);
-            addObservedDataIfNeeded(dataRepositories);
+            addObservedDataIfNeeded(plottedData);
+            ChartEditorPresenter.AddDataRepositories(notPlottedData);
          }
          finally
          {

--- a/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
@@ -177,9 +177,9 @@ namespace MoBi.Presentation.Presenter
       {
          CurveChartTemplate defaultTemplate = null;
 
-         var data = new List<DataRepository>();
+         var plottedData = new List<DataRepository>();
          if (_simulation.ResultsDataRepository != null)
-            data.Add(_simulation.ResultsDataRepository);
+            plottedData.Add(_simulation.ResultsDataRepository);
 
 
          //This whole initialization of Chart in presenter is really ugly.
@@ -212,8 +212,15 @@ namespace MoBi.Presentation.Presenter
          if (_simulation.Chart.Curves.Count == 0)
             defaultTemplate = _simulation.DefaultChartTemplate;
 
-         addObservedDataRepositories(data, _simulation.Chart.Curves);
-         _chartPresenter.Show(_simulation.Chart, data, defaultTemplate);
+         addObservedDataRepositories(plottedData, _simulation.Chart.Curves);
+         var notPlottedData = mappedObservedDataExcept(plottedData, _simulation.OutputMappings);
+         
+         _chartPresenter.Show(_simulation.Chart, plottedData, notPlottedData, defaultTemplate);
+      }
+
+      private IReadOnlyList<DataRepository> mappedObservedDataExcept(IReadOnlyList<DataRepository> plottedData, OutputMappings outputMappings)
+      {
+         return outputMappings.AllDataRepositoryMappedFor(_simulation).Except(plottedData).ToList();
       }
 
       public void Handle(SimulationRunFinishedEvent eventToHandle)

--- a/src/MoBi.Presentation/Presenter/ProjectChartPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ProjectChartPresenter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using MoBi.Core.Services;
 using MoBi.Presentation.Views;
@@ -9,7 +10,7 @@ namespace MoBi.Presentation.Presenter
 {
    public interface IProjectChartPresenter : ISingleStartPresenter<CurveChart>
    {
-      void Show(CurveChart chart, IReadOnlyList<DataRepository> data);
+      void Show(CurveChart chart, IReadOnlyList<DataRepository> plottedData);
    }
 
    public class ProjectChartPresenter : SubjectPresenter<IProjectChartView, IProjectChartPresenter, CurveChart>, IProjectChartPresenter
@@ -30,14 +31,11 @@ namespace MoBi.Presentation.Presenter
          Show(chart, new List<DataRepository>());
       }
 
-      public override object Subject
-      {
-         get { return _chartPresenter.Chart; }
-      }
+      public override object Subject => _chartPresenter.Chart;
 
-      public void Show(CurveChart chart, IReadOnlyList<DataRepository> data)
+      public void Show(CurveChart chart, IReadOnlyList<DataRepository> plottedData)
       {
-         _chartPresenter.Show(chart, data);
+         _chartPresenter.Show(chart, plottedData, notPlottedData: Array.Empty<DataRepository>());
          _chartPresenter.UpdateTemplatesFor(_projectRetriever.Current);
          UpdateCaption();
          View.Display();

--- a/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
@@ -117,7 +117,7 @@ namespace MoBi.Presentation
       }
    }
 
-   public class When_the_simulation_simulation_presenter_is_handling_a_favorite_selected_event : concern_for_EditSimulationPresenter
+   public class When_the_simulation_presenter_is_handling_a_favorite_selected_event : concern_for_EditSimulationPresenter
    {
       private IMoBiSimulation _simulation;
       private IView _favoritesView;
@@ -143,7 +143,7 @@ namespace MoBi.Presentation
       }
    }
 
-   public class When_the_simulation_simulation_presenter_is_handling_a_simulation_completed_event : concern_for_EditSimulationPresenter
+   public class When_the_simulation_presenter_is_handling_a_simulation_completed_event : concern_for_EditSimulationPresenter
    {
       private SimulationRunFinishedEvent _simulationRunFinishedEvent;
       private IMoBiSimulation _simulation;
@@ -175,7 +175,7 @@ namespace MoBi.Presentation
       }
    }
 
-   public class When_the_simulation_simulation_presenter_is_notified_that_the_edit_simulation_was_reloaded : concern_for_EditSimulationPresenter
+   public class When_the_simulation_presenter_is_notified_that_the_edit_simulation_was_reloaded : concern_for_EditSimulationPresenter
    {
       private IMoBiSimulation _simulation;
 
@@ -206,7 +206,7 @@ namespace MoBi.Presentation
    }
 
    public class
-      When_the_simulation_simulation_presenter_is_notified_that_a_simulation_run_is_finished_for_the_edited_simulation :
+      When_the_simulation_presenter_is_notified_that_a_simulation_run_is_finished_for_the_edited_simulation :
       concern_for_EditSimulationPresenter
    {
       private IMoBiSimulation _simulation;
@@ -236,11 +236,11 @@ namespace MoBi.Presentation
       [Observation]
       public void should_show_simulation_chart()
       {
-         A.CallTo(() => _chartPresenter.Show(_chart, A<IReadOnlyList<DataRepository>>._, A<CurveChartTemplate>._)).MustHaveHappened();
+         A.CallTo(() => _chartPresenter.Show(_chart, A<IReadOnlyList<DataRepository>>._, A<IReadOnlyList<DataRepository>>._, A<CurveChartTemplate>._)).MustHaveHappened();
       }
    }
 
-   public class When_the_simulation_simulation_presenter_is_loading_the_diagram : concern_for_EditSimulationPresenter
+   public class When_the_simulation_presenter_is_loading_the_diagram : concern_for_EditSimulationPresenter
    {
       private IMoBiSimulation _simulation;
 
@@ -263,11 +263,13 @@ namespace MoBi.Presentation
       }
    }
 
-   public class When_the_simulation_simulation_presenter_is_editing_a_simulation_with_data : concern_for_EditSimulationPresenter
+   public class When_the_simulation_presenter_is_editing_a_simulation_with_data : concern_for_EditSimulationPresenter
    {
       private IMoBiSimulation _simulation;
       private DataRepository _observedDataRepository;
-      private IEnumerable<DataRepository> _data;
+      private IEnumerable<DataRepository> _plottedData;
+      private IEnumerable<DataRepository> _notPlottedData;
+      private DataRepository _mappedData;
 
       protected override void Context()
       {
@@ -277,12 +279,25 @@ namespace MoBi.Presentation
          var chart = new CurveChart();
 
          _observedDataRepository = new DataRepository();
+
          chart.AddCurve(createObservedCurve(_observedDataRepository));
+
+         _mappedData = new DataRepository();
+         _mappedData.Add(new BaseGrid("basegrid", DimensionFactoryForSpecs.TimeDimension));
+         _simulation.OutputMappings.Add(new OutputMapping
+         {
+            WeightedObservedData = new WeightedObservedData(_mappedData),
+            OutputSelection = new SimulationQuantitySelection(_simulation, new QuantitySelection())
+         });
 
          _simulation.Chart = chart;
 
-         A.CallTo(() => _chartPresenter.Show(chart, A<IReadOnlyList<DataRepository>>._, null))
-            .Invokes(x => _data = x.GetArgument<IEnumerable<DataRepository>>(1));
+         A.CallTo(() => _chartPresenter.Show(chart, A<IReadOnlyList<DataRepository>>._, A<IReadOnlyList<DataRepository>>._, null))
+            .Invokes(x =>
+            {
+               _notPlottedData = x.GetArgument<IEnumerable<DataRepository>>(2);
+               _plottedData = x.GetArgument<IEnumerable<DataRepository>>(1);
+            });
       }
 
       protected override void Because()
@@ -299,14 +314,20 @@ namespace MoBi.Presentation
       [Observation]
       public void should_display_result_data()
       {
-         A.CallTo(() => _chartPresenter.Show(A<CurveChart>._, A<IReadOnlyList<DataRepository>>._, A<CurveChartTemplate>._))
+         A.CallTo(() => _chartPresenter.Show(A<CurveChart>._, A<IReadOnlyList<DataRepository>>._, A<IReadOnlyList<DataRepository>>._, A<CurveChartTemplate>._))
             .MustHaveHappened();
       }
 
       [Observation]
-      public void should_Add_Observer_Data_repository()
+      public void should_plot_observed_data_repository()
       {
-         _data.ShouldContain(_observedDataRepository);
+         _plottedData.ShouldContain(_observedDataRepository);
+      }
+
+      [Observation]
+      public void should_add_observed_data_to_editor()
+      {
+         _notPlottedData.ShouldContain(_mappedData);
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #1717

# Description
Any time you close and open a chart, data that is not 'Used' in the chart is removed from the databrowser. This makes sure that when data are mapped in a simulation, the data is shown in the data browser

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):