### PR TITLE
Fixes #2003 Import applications with rename should change all hidden tags

### DIFF
--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
-using MoBi.Core.Domain.Repository;
 using MoBi.Core.Events;
 using MoBi.Core.Extensions;
 using MoBi.Presentation.Tasks.Edit;
@@ -228,9 +227,12 @@ namespace MoBi.Presentation.Tasks.Interaction
 
       public virtual IMoBiCommand AddTo(TChild childToAdd, TParent parent, IBuildingBlock buildingBlockWithFormulaCache)
       {
+         var oldName = childToAdd.Name;
          var nameIsValid = CorrectName(childToAdd, parent);
          if (!nameIsValid)
             return new MoBiEmptyCommand();
+
+         correctTagsForRename(oldName, childToAdd.Name, childToAdd);
 
          var macroCommand = new MoBiMacroCommand
          {
@@ -248,6 +250,19 @@ namespace MoBi.Presentation.Tasks.Interaction
          throwAddedEvent(childToAdd, parent);
 
          return macroCommand;
+      }
+
+      private void correctTagsForRename(string oldName, string newName, IObjectBase objectBase)
+      {
+         if (string.Equals(oldName, newName))
+            return;
+
+         if (objectBase is IEntity entity)
+            entity.Tags.Replace(oldName, newName);
+
+         // Recurse containers to check their tags and their children tags
+         if (objectBase is IContainer container)
+            container.GetAllChildren<IEntity>().Each(x => correctTagsForRename(oldName, newName, x));
       }
 
       private bool adjustFormula(TChild childToAdd, IBuildingBlock buildingBlockWithFormulaCache, IMoBiMacroCommand macroCommand)

--- a/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForApplicationBuilderAsEventGroupChildSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForApplicationBuilderAsEventGroupChildSpecs.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using MoBi.Presentation.Tasks.Edit;
+using MoBi.Presentation.Tasks.Interaction;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Descriptors;
+
+namespace MoBi.Presentation.Tasks
+{
+   internal abstract class concern_for_InteractionTasksForApplicationBuilderAsEventGroupChild : ContextSpecification<InteractionTasksForApplicationBuilderAsEventGroupChild>
+   {
+      private IEditTaskFor<ApplicationBuilder> _editTask;
+      protected IInteractionTaskContext _interactionTaskContext;
+
+      protected override void Context()
+      {
+         // set up fakes
+         _editTask = A.Fake<IEditTaskFor<ApplicationBuilder>>();
+         _interactionTaskContext = A.Fake<InteractionTaskContext>();
+
+         sut = new InteractionTasksForApplicationBuilderAsEventGroupChild(_interactionTaskContext, _editTask);
+      }
+   }
+
+   internal class When_adding_a_new_application_builder_with_colliding_name : concern_for_InteractionTasksForApplicationBuilderAsEventGroupChild
+   {
+      private ApplicationBuilder _addedApplicationBuilder;
+      private EventGroupBuilder _parentEventGroupBuilder;
+      private EventGroupBuildingBlock _buildingBlock;
+      private IContainer _container;
+      private ApplicationBuilder _existingApplicationBuilder;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _addedApplicationBuilder = new ApplicationBuilder().WithName("application_1");
+         _addedApplicationBuilder.Tags.Add(new Tag("application_1"));
+
+         _existingApplicationBuilder = new ApplicationBuilder().WithName("application_1");
+         _existingApplicationBuilder.Tags.Add(new Tag("application_1"));
+
+         _container = new Container();
+         _container.Tags.Add(new Tag("application_1"));
+         _addedApplicationBuilder.Add(_container);
+
+         _parentEventGroupBuilder = new EventGroupBuilder { _existingApplicationBuilder };
+         _buildingBlock = new EventGroupBuildingBlock { _parentEventGroupBuilder };
+
+         A.CallTo(() => _interactionTaskContext.InteractionTask.CorrectName(_addedApplicationBuilder, A<IEnumerable<string>>._)).Invokes(x => x.Arguments.Get<ApplicationBuilder>(0).Name = "application_2").Returns(true);
+      }
+
+      protected override void Because()
+      {
+         sut.AddTo(_addedApplicationBuilder, _parentEventGroupBuilder, _buildingBlock);
+      }
+
+      [Observation]
+      public void the_builder_is_added_to_the_event_group()
+      {
+         _parentEventGroupBuilder.Contains(_addedApplicationBuilder).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void the_builder_has_been_renamed()
+      {
+         _addedApplicationBuilder.Name.ShouldBeEqualTo("application_2");
+      }
+
+      [Observation]
+      public void tags_that_match_the_name_should_be_changed_in_the_added_application()
+      {
+         _addedApplicationBuilder.Tags.Contains("application_2").ShouldBeTrue();
+         _addedApplicationBuilder.Tags.Contains("application_1").ShouldBeFalse();
+         _container.Tags.Contains("application_2").ShouldBeTrue();
+         _container.Tags.Contains("application_1").ShouldBeFalse();
+      }
+
+      [Observation]
+      public void tags_should_not_be_renamed_in_existing_application()
+      {
+         _existingApplicationBuilder.Tags.Contains("application_2").ShouldBeFalse();
+         _existingApplicationBuilder.Tags.Contains("application_1").ShouldBeTrue();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2003

# Description
For all renamed entities loaded from the file system, we can recursively traverse containers and update tags that exactly match the old name.

Not only for `ApplicationBuilders`

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):