### PR TITLE
Fixes #2142 Deleting of observed data takes too long

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.2.17" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.17" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2.19" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.19" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2.17" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.19" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -32,13 +32,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.2.17" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.2.19" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/Services/SimulationLoader.cs
+++ b/src/MoBi.Core/Services/SimulationLoader.cs
@@ -130,7 +130,7 @@ namespace MoBi.Core.Services
          var project = _context.CurrentProject;
 
          allObservedData.Where(observedData => !project.AllObservedData.ExistsById(observedData.Id))
-            .Each(x => loadCommand.AddCommand(new AddObservedDataToProjectCommand(x)));
+            .Each(x => loadCommand.AddCommand(new AddObservedDataToProjectCommand(new[] { x })));
       }
 
       private IMoBiSimulation cloneSimulation(IMoBiSimulation simulation)

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.2.17" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2.19" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -24,9 +24,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.17" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.19" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/ChartPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ChartPresenter.cs
@@ -342,9 +342,21 @@ namespace MoBi.Presentation.Presenter
 
       public void Handle(ObservedDataRemovedEvent eventToHandle)
       {
-         var dataRepository = eventToHandle.DataRepository;
-         editorPresenter.RemoveDataRepositories(new[] { dataRepository });
+         if (!canHandle(eventToHandle))
+            return;
+            
+         editorPresenter.RemoveDataRepositories(eventToHandle.DataRepositories);
          displayPresenter.Refresh();
+      }
+
+      private bool canHandle(ObservedDataRemovedEvent eventToHandle)
+      {
+         return eventToHandle.DataRepositories.Any(isEditing);
+      }
+
+      private bool isEditing(DataRepository dataRepository)
+      {
+         return dataRepository.Columns.Any(x => editorPresenter.AllDataColumns.Contains(x));
       }
 
       public override void ReleaseFrom(IEventPublisher eventPublisher)

--- a/src/MoBi.Presentation/Presenter/ChartPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ChartPresenter.cs
@@ -349,15 +349,9 @@ namespace MoBi.Presentation.Presenter
          displayPresenter.Refresh();
       }
 
-      private bool canHandle(ObservedDataRemovedEvent eventToHandle)
-      {
-         return eventToHandle.DataRepositories.Any(isEditing);
-      }
+      private bool canHandle(ObservedDataRemovedEvent eventToHandle) => eventToHandle.DataRepositories.Any(isEditing);
 
-      private bool isEditing(DataRepository dataRepository)
-      {
-         return dataRepository.Columns.Any(x => editorPresenter.AllDataColumns.Contains(x));
-      }
+      private bool isEditing(DataRepository dataRepository) => dataRepository.Columns.Any(x => editorPresenter.AllDataColumns.Contains(x));
 
       public override void ReleaseFrom(IEventPublisher eventPublisher)
       {

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -23,11 +23,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.17" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.19" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.5" />
    </ItemGroup>
   <ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -65,13 +65,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2.17" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.19" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2.17" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2.19" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -43,10 +43,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2.17" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2.19" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/SimulationChartPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SimulationChartPresenterSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using FakeItEasy;
 using MoBi.Core.Domain.Model;
 using MoBi.Presentation.Presenter;
@@ -11,6 +12,7 @@ using OSPSuite.Core.Chart;
 using OSPSuite.Core.Chart.Mappers;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
+using OSPSuite.Core.Events;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.Nodes;
@@ -81,8 +83,7 @@ namespace MoBi.Presentation
             observedDataNode
          };
 
-         _chartDisplayPresenter = new ChartDisplayPresenter(_chartDisplayView, _curveBinderFactory, _contextMenuFactoryForProjectItem, _axisBinderFactory, _dataModeMapper, _chartExportTask, _applicationSettings, _applicationController, _dialogCreator);
-
+         _chartDisplayPresenter = CreateDisplayPresenter();
 
          A.CallTo(() => _chartPresenterContext.DisplayPresenter).Returns(_chartDisplayPresenter);
 
@@ -90,6 +91,11 @@ namespace MoBi.Presentation
          _chartDisplayPresenter.Edit(new CurveChart());
 
          A.CallTo(() => _dragEvent.Data<IEnumerable<ITreeNode>>()).Returns(_treeNodes);
+      }
+
+      protected virtual IChartDisplayPresenter CreateDisplayPresenter()
+      {
+         return new ChartDisplayPresenter(_chartDisplayView, _curveBinderFactory, _contextMenuFactoryForProjectItem, _axisBinderFactory, _dataModeMapper, _chartExportTask, _applicationSettings, _applicationController, _dialogCreator);
       }
    }
 
@@ -114,6 +120,73 @@ namespace MoBi.Presentation
       public void the_event_must_have_been_called_once()
       {
          _observedDataAddedEventCounter.ShouldBeEqualTo(1);
+      }
+   }
+
+   public class When_handling_observed_data_removed_event_and_the_data_is_in_the_chart : concern_for_SimulationChartPresenter
+   {
+      private DataRepository _dataRepository;
+      private IProject _project;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dataRepository = new DataRepository("id")
+         {
+            new DataColumn(),
+            new DataColumn()
+         };
+         _project = new MoBiProject();
+         A.CallTo(() => _chartPresenterContext.EditorPresenter.AllDataColumns).Returns(_dataRepository.Columns.ToList());
+      }
+
+      protected override IChartDisplayPresenter CreateDisplayPresenter()
+      {
+         return A.Fake<IChartDisplayPresenter>();
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new ObservedDataRemovedEvent(new[] { _dataRepository }, _project));
+      }
+
+      [Observation]
+      public void the_display_is_not_refreshed()
+      {
+         A.CallTo(() => _chartDisplayPresenter.Refresh()).MustHaveHappened();
+      }
+   }
+
+   public class When_handling_observed_data_removed_event_and_the_data_is_not_in_the_chart : concern_for_SimulationChartPresenter
+   {
+      private DataRepository _dataRepository;
+      private IProject _project;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dataRepository = new DataRepository("id")
+         {
+            new DataColumn(),
+            new DataColumn()
+         };
+         _project = new MoBiProject();
+      }
+
+      protected override IChartDisplayPresenter CreateDisplayPresenter()
+      {
+         return A.Fake<IChartDisplayPresenter>();
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new ObservedDataRemovedEvent(new[] { _dataRepository }, _project));
+      }
+
+      [Observation]
+      public void the_display_is_not_refreshed()
+      {
+         A.CallTo(() => _chartDisplayPresenter.Refresh()).MustNotHaveHappened();
       }
    }
 

--- a/tests/MoBi.Tests/Presentation/Tasks/ObservedDataTasksSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/ObservedDataTasksSpecs.cs
@@ -235,7 +235,7 @@ namespace MoBi.Presentation.Tasks
       }
 
       [Observation]
-      public void should_add_data_repositroy_to_current_project()
+      public void should_add_data_repository_to_current_project()
       {
          _project.AllObservedData.Contains(_dataRepository).ShouldBeTrue();
       }
@@ -245,7 +245,7 @@ namespace MoBi.Presentation.Tasks
       {
          A.CallTo(() => _context.PublishEvent(A<ObservedDataAddedEvent>._)).MustHaveHappened();
          _event.ShouldNotBeNull();
-         _event.DataRepository.ShouldBeEqualTo(_dataRepository);
+         _event.DataRepositories.ShouldOnlyContain(_dataRepository);
       }
    }
 

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.17" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2.17" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.19" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2.19" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #2142

# Description
Now we can decline to react when the removed observed data is not in the chart.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):