### PR TITLE
Fixes #2116 Adding a physical container to a spatial structure does not register the MoleculeProperties container

### DIFF
--- a/src/MoBi.Core/Commands/AddObjectBaseCommand.cs
+++ b/src/MoBi.Core/Commands/AddObjectBaseCommand.cs
@@ -1,5 +1,6 @@
 ﻿using MoBi.Assets;
 using MoBi.Core.Domain.Model;
+using MoBi.Core.Domain.Services;
 using MoBi.Core.Events;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
@@ -10,40 +11,42 @@ namespace MoBi.Core.Commands
       where TChild : class, IObjectBase
       where TParent : class, IObjectBase
    {
-      public string ChildId { get; set; }
+      private string childId { get; }
       public bool Silent { get; set; }
 
       protected AddObjectBaseCommand(TParent parent, TChild itemToAdd, IBuildingBlock buildingBlock)
          : base(parent, itemToAdd, buildingBlock)
       {
          Silent = false;
-         ChildId = itemToAdd.Id;
+         childId = itemToAdd.Id;
       }
 
       protected override void ClearReferences()
       {
          base.ClearReferences();
-         _itemToAdd = default(TChild);
-         _parent = default(TParent);
+         _itemToAdd = null;
+         _parent = null;
       }
 
       protected override void ExecuteWith(IMoBiContext context)
       {
          base.ExecuteWith(context);
          Description = AppConstants.Commands.AddToDescription(ObjectType, _itemToAdd.Name, _parent.Name, context.TypeFor(_buildingBlock), _buildingBlock.Name);
-         context.Register(_itemToAdd);
+         register(_itemToAdd, context);
          AddTo(_itemToAdd, _parent, context);
 
          if (!Silent)
             context.PublishEvent(new AddedEvent<TChild>(_itemToAdd, _parent));
       }
 
+      private void register(TChild itemToAdd, IMoBiContext context) => context.Resolve<IRegisterTask>().RegisterAllIn(itemToAdd);
+
       protected abstract void AddTo(TChild child, TParent parent, IMoBiContext context);
 
       public override void RestoreExecutionData(IMoBiContext context)
       {
          base.RestoreExecutionData(context);
-         _itemToAdd = context.Get<TChild>(ChildId);
+         _itemToAdd = context.Get<TChild>(childId);
       }
    }
 }

--- a/src/MoBi.Core/Commands/RemoveObjectBaseCommand.cs
+++ b/src/MoBi.Core/Commands/RemoveObjectBaseCommand.cs
@@ -1,5 +1,6 @@
 ﻿using MoBi.Assets;
 using MoBi.Core.Domain.Model;
+using MoBi.Core.Domain.Services;
 using MoBi.Core.Events;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
@@ -20,16 +21,18 @@ namespace MoBi.Core.Commands
          base.ExecuteWith(context);
          Description = AppConstants.Commands.RemoveFromDescription(ObjectType, _itemToRemove.Name, _parent.Name, context.TypeFor(_buildingBlock), _buildingBlock.Name);
          RemoveFrom(_itemToRemove, _parent, context);
-         context.Unregister(_itemToRemove);
+         unRegister(_itemToRemove, context);
          context.PublishEvent(new RemovedEvent(_itemToRemove, _parent));
       }
+
+      private void unRegister(TChild itemToRemove, IMoBiContext context) => context.Resolve<IUnregisterTask>().UnregisterAllIn(itemToRemove);
 
       protected abstract void RemoveFrom(TChild childToRemove, TParent parent, IMoBiContext context);
 
       protected override void ClearReferences()
       {
          base.ClearReferences();
-         _parent = default(TParent);
+         _parent = null;
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
@@ -208,15 +208,16 @@ namespace MoBi.Presentation.Presenter
       public override void Edit(IContainer container, IReadOnlyList<IObjectBase> existingObjectsInParent)
       {
          _container = container;
-         //an unnamed container means it is being created now, since the name is mandatory over the creation.
-         _isNewEntity = string.IsNullOrEmpty(_container.Name);
+         // containers that have already been registered are not considered new and must use commands
+         // for adding and removing subcontainers
+         _isNewEntity = _context.Get(container.Id) == null;
          base.Edit(container, existingObjectsInParent);
          _containerDTO = _containerMapper.MapFrom(_container, _trackableSimulation);
          _containerDTO.AddUsedNames(_editTasks.GetForbiddenNamesWithoutSelf(container, existingObjectsInParent));
          _view.BindTo(_containerDTO);
          _tagsPresenter.Edit(container);
          _view.ContainerPropertiesEditable = !container.IsMoleculeProperties();
-         _view.NameEditable = _isNewEntity;
+         _view.NameEditable = string.IsNullOrEmpty(_container.Name);
       }
 
       public override object Subject => _container;

--- a/tests/MoBi.Tests/Core/Commands/AddContainerToSpatialStructureCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/AddContainerToSpatialStructureCommandSpecs.cs
@@ -1,0 +1,86 @@
+﻿using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Domain.Model.Diagram;
+using MoBi.Core.Domain.Services;
+using MoBi.Core.Extensions;
+using MoBi.Helpers;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+
+namespace MoBi.Core.Commands
+{
+   internal class concern_for_AddContainerToSpatialStructureCommand : ContextSpecification<AddContainerToSpatialStructureCommand>
+   {
+      protected IContainer _parent;
+      protected IContainer _containerToAdd;
+      protected MoBiSpatialStructure _spatialStructure;
+      protected readonly string _parentId = "parent";
+      private ISpatialStructureDiagramManager _spatialStructureDiagramManager;
+      protected IMoBiContext _context;
+      private ObjectPathFactory _objectPathFactory;
+      protected IRegisterTask _registerTask;
+
+      protected override void Context()
+      {
+         _objectPathFactory = new ObjectPathFactoryForSpecs();
+         _spatialStructureDiagramManager = A.Fake<ISpatialStructureDiagramManager>();
+         _spatialStructure = new MoBiSpatialStructure { DiagramManager = _spatialStructureDiagramManager }.WithName("SpSt");
+         _spatialStructure.NeighborhoodsContainer = new Container().WithName(Constants.NEIGHBORHOODS);
+         _parent = new Container().WithName("Top").WithMode(ContainerMode.Logical).WithId(_parentId);
+         _containerToAdd = new Container().WithName("A").WithMode(ContainerMode.Physical);
+         _spatialStructure.AddTopContainer(_parent);
+
+         _context = A.Fake<IMoBiContext>();
+         _registerTask = A.Fake<IRegisterTask>();
+
+         A.CallTo(() => _context.ObjectPathFactory).Returns(_objectPathFactory);
+         A.CallTo(() => _context.Resolve<IRegisterTask>()).Returns(_registerTask);
+
+         sut = new AddContainerToSpatialStructureCommand(_parent, _containerToAdd, _spatialStructure);
+      }
+   }
+
+   internal class When_adding_the_container_to_the_spatial_structure : concern_for_AddContainerToSpatialStructureCommand
+   {
+      protected override void Because()
+      {
+         sut.RunCommand(_context);
+      }
+
+      [Observation]
+      public void the_container_should_be_registered_using_the_task()
+      {
+         A.CallTo(() => _registerTask.RegisterAllIn(_containerToAdd)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_container_is_added_to_the_spatial_structure()
+      {
+         _parent.ShouldContain(_containerToAdd);
+      }
+   }
+
+   internal class When_revert_an_add_container_to_spatial_structure_command : concern_for_AddContainerToSpatialStructureCommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _context = A.Fake<IMoBiContext>();
+         A.CallTo(() => _context.Get<MoBiSpatialStructure>(A<string>._)).Returns(_spatialStructure);
+         A.CallTo(() => _context.Get<IContainer>(_parentId)).Returns(_parent);
+         A.CallTo(() => _context.Get<IContainer>(_containerToAdd.Id)).Returns(_containerToAdd);
+      }
+
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_context);
+      }
+
+      [Observation]
+      public void should_remove_the_container()
+      {
+         _parent.Children.ShouldNotContain(_containerToAdd);
+      }
+   }
+}

--- a/tests/MoBi.Tests/Core/Commands/RemoveContainerFromSpatialStructureCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/RemoveContainerFromSpatialStructureCommandSpecs.cs
@@ -1,6 +1,8 @@
 ﻿using FakeItEasy;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Model.Diagram;
+using MoBi.Core.Domain.Services;
+using MoBi.Core.Extensions;
 using MoBi.Helpers;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
@@ -16,16 +18,17 @@ namespace MoBi.Core.Commands
       protected MoBiSpatialStructure _spatialStructure;
       protected IContainer _otherContainer;
       protected NeighborhoodBuilder _neighborhood;
-      protected string _parentId = "parent";
+      protected readonly string _parentId = "parent";
       private ISpatialStructureDiagramManager _spatialStructureDiagramManager;
       protected IMoBiContext _context;
       private ObjectPathFactory _objectPathFactory;
+      protected IUnregisterTask _unregisterTask;
 
       protected override void Context()
       {
          _objectPathFactory = new ObjectPathFactoryForSpecs();
          _spatialStructureDiagramManager = A.Fake<ISpatialStructureDiagramManager>();
-         _spatialStructure = new MoBiSpatialStructure {DiagramManager = _spatialStructureDiagramManager}.WithName("SpSt");
+         _spatialStructure = new MoBiSpatialStructure { DiagramManager = _spatialStructureDiagramManager }.WithName("SpSt");
          _spatialStructure.NeighborhoodsContainer = new Container().WithName(Constants.NEIGHBORHOODS);
          _parent = new Container().WithName("Top").WithMode(ContainerMode.Logical).WithId(_parentId);
          _containerToRemove = new Container().WithName("A").WithMode(ContainerMode.Physical).WithParentContainer(_parent);
@@ -39,8 +42,32 @@ namespace MoBi.Core.Commands
          };
          _spatialStructure.AddNeighborhood(_neighborhood);
          _context = A.Fake<IMoBiContext>();
+         _unregisterTask = A.Fake<IUnregisterTask>();
+
          A.CallTo(() => _context.ObjectPathFactory).Returns(_objectPathFactory);
+         A.CallTo(() => _context.Resolve<IUnregisterTask>()).Returns(_unregisterTask);
+
          sut = new RemoveContainerFromSpatialStructureCommand(_parent, _containerToRemove, _spatialStructure);
+      }
+   }
+
+   internal class When_removing_a_container_from_a_spatial_structure : concern_for_RemoveContainerFromSpatialStructureCommand
+   {
+      protected override void Because()
+      {
+         sut.RunCommand(_context);
+      }
+
+      [Observation]
+      public void the_container_should_be_unregistered()
+      {
+         A.CallTo(() => _unregisterTask.UnregisterAllIn(_containerToRemove)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_remove_the_container()
+      {
+         _parent.Children.ShouldNotContain(_containerToRemove);
       }
    }
 

--- a/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
@@ -268,7 +268,7 @@ namespace MoBi.Presentation
          };
          _spatialStructure.AddTopContainer(_muscle);
          _muscle.Mode = ContainerMode.Logical;
-
+         A.CallTo(() => _context.Get(_muscle.Id)).Returns(null);
          sut.Edit(_muscle);
          sut.BuildingBlock = _spatialStructure;
       }
@@ -277,7 +277,7 @@ namespace MoBi.Presentation
       {
          sut.ConfirmAndSetContainerMode(ContainerMode.Physical);
       }
-
+      
       [Observation]
       public void should_change_mode()
       {
@@ -311,6 +311,7 @@ namespace MoBi.Presentation
             .WithName(Constants.MOLECULE_PROPERTIES)
             .WithMode(ContainerMode.Logical);
          _muscle.Add(moleculeProperties);
+         A.CallTo(() => _context.Get(_muscle.Id)).Returns(null);
          sut.Edit(_muscle);
          sut.BuildingBlock = _spatialStructure;
       }

--- a/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
@@ -277,7 +277,7 @@ namespace MoBi.Presentation
       {
          sut.ConfirmAndSetContainerMode(ContainerMode.Physical);
       }
-      
+
       [Observation]
       public void should_change_mode()
       {


### PR DESCRIPTION
Fixes #2116 

# Description
The sub containers were not registered when a new container is added to a spatial structure with "MoleculeProperties" already added.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):