### PR TITLE
Fixes #2166 Simulation cannot be closed due to invalid output intervals

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1244,6 +1244,8 @@ namespace MoBi.Assets
          public static readonly string MergeBuildingBlocksCountError = "Building blocks to merge and target building blocks do not have the same length";
          public static readonly string MissingName = "Name missing";
          public static readonly string DeserializationFailed = "Deserialization failed";
+         public static readonly string TheStartTimeMustBeEarlierThanTheEndTimeOfTheInterval = "The start time must be earlier than the end time of the interval";
+
          public static string SourceBuildingBlockNotInProject(string entityType) => $"Building Block used to create {entityType} is not present in project";
          public static readonly string ShouldNeverHappen = "Should never happen";
          public static readonly string ErrorInFormula = "Error in Formula";

--- a/src/MoBi.Core/Events/Events.cs
+++ b/src/MoBi.Core/Events/Events.cs
@@ -12,11 +12,13 @@ namespace MoBi.Core.Events
 {
    public class SimulationRunFinishedEvent
    {
-      public IMoBiSimulation Simulation { get; set; }
+      public IMoBiSimulation Simulation { get; }
+      public bool Success { get; }
 
-      public SimulationRunFinishedEvent(IMoBiSimulation simulation)
+      public SimulationRunFinishedEvent(IMoBiSimulation simulation, bool success)
       {
          Simulation = simulation;
+         Success = success;
       }
    }
 

--- a/src/MoBi.Presentation/Presenter/EditOutputSchemaPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditOutputSchemaPresenter.cs
@@ -83,6 +83,8 @@ namespace MoBi.Presentation.Presenter
 
       public void SetParameterUnit(IParameterDTO parameterDTO, Unit newUnit, OutputIntervalDTO outputIntervalDTO)
       {
+         // The UI validation of interval start and end does not evaluate for unit changes.
+         // This is a programmatic validation of the proposed new unit
          if (!intervalIsValidInNewUnit(parameterDTO, newUnit, outputIntervalDTO))
          {
             displayIntervalErrorMessage();

--- a/src/MoBi.Presentation/Presenter/EditOutputSchemaPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditOutputSchemaPresenter.cs
@@ -1,4 +1,5 @@
-﻿using OSPSuite.Assets;
+﻿using MoBi.Assets;
+using OSPSuite.Assets;
 using OSPSuite.Utility.Collections;
 using OSPSuite.Utility.Extensions;
 using MoBi.Core.Domain.Model;
@@ -9,6 +10,7 @@ using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Events;
+using OSPSuite.Core.Services;
 using OSPSuite.Presentation.DTO;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Utility.Events;
@@ -19,7 +21,7 @@ namespace MoBi.Presentation.Presenter
    {
       void AddOutputInterval();
       void RemoveOutputInterval(OutputIntervalDTO outputIntervalDTO);
-      void SetParameterUnit(IParameterDTO parameterDTO, Unit newUnit);
+      void SetParameterUnit(IParameterDTO parameterDTO, Unit newUnit, OutputIntervalDTO outputIntervalDTO);
       void SetParameterValue(IParameterDTO parameterDTO, double valuevalueInDisplayUnit);
       bool ShowGroupCaption { set; }
       void Edit(IMoBiSimulation simulation);
@@ -32,17 +34,19 @@ namespace MoBi.Presentation.Presenter
       private readonly IOutputIntervalToOutputIntervalDTOMapper _intervalMapper;
       private readonly IQuantityTask _quantityTask;
       private readonly IOutputSchemaTask _outputSchemaTask;
+      private readonly IDialogCreator _dialogCreator;
       private ICache<OutputIntervalDTO, OutputInterval> _allIntervals;
       private SimulationSettings _simulationSettings;
       private IMoBiSimulation _simulation;
 
       public EditOutputSchemaPresenter(IEditOutputSchemaView view, IOutputIntervalToOutputIntervalDTOMapper intervalMapper,
-         IQuantityTask quantityTask, IOutputSchemaTask outputSchemaTask)
+         IQuantityTask quantityTask, IOutputSchemaTask outputSchemaTask, IDialogCreator dialogCreator)
          : base(view)
       {
          _intervalMapper = intervalMapper;
          _quantityTask = quantityTask;
          _outputSchemaTask = outputSchemaTask;
+         _dialogCreator = dialogCreator;
       }
 
       private void bindToView()
@@ -77,14 +81,60 @@ namespace MoBi.Presentation.Presenter
          bindToView();
       }
 
-      public void SetParameterUnit(IParameterDTO parameterDTO, Unit newUnit)
+      public void SetParameterUnit(IParameterDTO parameterDTO, Unit newUnit, OutputIntervalDTO outputIntervalDTO)
       {
+         if (!intervalIsValidInNewUnit(parameterDTO, newUnit, outputIntervalDTO))
+         {
+            displayIntervalErrorMessage();
+            return;
+         }
+
          var parameter = parameterDTO.Parameter;
          AddCommand(_simulation != null
             ? _quantityTask.SetQuantityDisplayUnit(parameter, newUnit, _simulation)
             : _quantityTask.SetQuantityDisplayUnit(parameter, newUnit, _simulationSettings));
       }
 
+      private bool intervalIsValidInNewUnit(IParameterDTO parameterDTO, Unit newUnit, OutputIntervalDTO outputIntervalDTO)
+      {
+         if (parameterDTO == outputIntervalDTO.StartTimeParameter && !checkStartTimeInNewUnit(newUnit, outputIntervalDTO))
+            return false;
+
+         if (parameterDTO == outputIntervalDTO.EndTimeParameter && !checkEndTimeInNewUnit(newUnit, outputIntervalDTO))
+            return false;
+
+         return true;
+      }
+
+      private void displayIntervalErrorMessage()
+      {
+         _dialogCreator.MessageBoxError(AppConstants.Exceptions.TheStartTimeMustBeEarlierThanTheEndTimeOfTheInterval);
+      }
+
+      private bool checkEndTimeInNewUnit(Unit newUnit, OutputIntervalDTO outputIntervalDTO)
+      {
+         var endValueInCurrentDisplayUnit = displayValueInCurrentDisplayUnit(outputIntervalDTO.EndTimeParameter);
+         var endTimeInBaseUnit = newValueInBaseUnit(endValueInCurrentDisplayUnit, newUnit);
+         return endTimeInBaseUnit > outputIntervalDTO.StartTimeParameter.Parameter.Value;
+      }
+
+      private bool checkStartTimeInNewUnit(Unit newUnit, OutputIntervalDTO outputIntervalDTO)
+      {
+         var startValueInCurrentDisplayUnit = displayValueInCurrentDisplayUnit(outputIntervalDTO.StartTimeParameter);
+         var startTimeInBaseUnit = newValueInBaseUnit(startValueInCurrentDisplayUnit, newUnit);
+         return startTimeInBaseUnit < outputIntervalDTO.EndTimeParameter.Parameter.Value;
+      }
+
+      private double newValueInBaseUnit(double valueInCurrentDisplayUnit, Unit newUnit)
+      {
+         return newUnit.UnitValueToBaseUnitValue(valueInCurrentDisplayUnit);
+      }
+
+      private double displayValueInCurrentDisplayUnit(IParameterDTO parameterDTO)
+      {
+         return parameterDTO.Parameter.ValueInDisplayUnit;
+      }
+      
       public void SetParameterValue(IParameterDTO parameterDTO, double valuevalueInDisplayUnit)
       {
          var parameter = parameterDTO.Parameter;

--- a/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
@@ -230,7 +230,7 @@ namespace MoBi.Presentation.Presenter
 
          _view.SetParametersTabEnabled(true);
 
-         if (!_view.ShowsResults)
+         if (!_view.ShowsResults && eventToHandle.Success)
             _view.ShowResultsTab();
 
          _chartTask.SetOriginText(_simulation.Name, _simulation.Chart);

--- a/src/MoBi.Presentation/Tasks/SimulationRunner.cs
+++ b/src/MoBi.Presentation/Tasks/SimulationRunner.cs
@@ -152,7 +152,7 @@ namespace MoBi.Presentation.Tasks
          _context.PublishEvent(new SimulationRunStartedEvent(simulation));
          _context.PublishEvent(new ProgressInitEvent(100, AppConstants.SimulationRun));
          _simModelManager = _simModelManagerFactory.Create();
-
+         var succeeded = false; 
          try
          {
             addEvents();
@@ -165,6 +165,7 @@ namespace MoBi.Presentation.Tasks
 
             if (simulationRunResults.Success)
             {
+               succeeded = true;
                var results = simulationRunResults.Results;
                results.Name = getNewRepositoryName();
                _displayUnitUpdater.UpdateDisplayUnitsIn(results);
@@ -185,7 +186,7 @@ namespace MoBi.Presentation.Tasks
             }
 
             removeEvents();
-            _context.PublishEvent(new SimulationRunFinishedEvent(simulation));
+            _context.PublishEvent(new SimulationRunFinishedEvent(simulation, succeeded));
          }
       }
 

--- a/src/MoBi.UI/Views/EditOutputSchemaView.cs
+++ b/src/MoBi.UI/Views/EditOutputSchemaView.cs
@@ -33,7 +33,7 @@ namespace MoBi.UI.Views
 
       public override void InitializeBinding()
       {
-         _gridViewBinder = new GridViewBinder<OutputIntervalDTO>(gridViewIntervals) { BindingMode = BindingMode.OneWay, ValidationMode = ValidationMode.LeavingRow };
+         _gridViewBinder = new GridViewBinder<OutputIntervalDTO>(gridViewIntervals) { BindingMode = BindingMode.OneWay };
 
          _gridViewBinder.Bind(dto => dto.StartTime)
             .WithFormat(x => x.StartTimeParameter.ParameterFormatter())
@@ -74,7 +74,7 @@ namespace MoBi.UI.Views
          this.DoWithinExceptionHandler(() =>
          {
             gridViewIntervals.CloseEditor();
-            _presenter.SetParameterUnit(parameterDTO, newUnit);
+            _presenter.SetParameterUnit(parameterDTO, newUnit, _gridViewBinder.FocusedElement);
          });
       }
 

--- a/tests/MoBi.Tests/Presentation/EditOutputSchemaPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditOutputSchemaPresenterSpecs.cs
@@ -1,0 +1,186 @@
+﻿using FakeItEasy;
+using MoBi.Assets;
+using MoBi.Core.Services;
+using MoBi.Helpers;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.UnitSystem;
+using OSPSuite.Core.Services;
+using OSPSuite.Presentation.DTO;
+
+namespace MoBi.Presentation
+{
+   internal class concern_for_EditOutputSchemaPresenter : ContextSpecification<EditOutputSchemaPresenter>
+   {
+      protected IDialogCreator _dialogCreator;
+      private IOutputSchemaTask _outputSchemaTask;
+      protected IQuantityTask _quantityTask;
+      private IOutputIntervalToOutputIntervalDTOMapper _intervalMapper;
+      private IEditOutputSchemaView _view;
+      protected SimulationSettings _simulationSettings;
+      protected OutputIntervalDTO _outputInterval;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         DimensionFactoryForSpecs.TimeDimension.AddUnit("minutes", 60, 0, isDefault: false);
+         DimensionFactoryForSpecs.TimeDimension.AddUnit("years", 31556952, 0, isDefault: false);
+      }
+
+      protected override void Context()
+      {
+         _dialogCreator = A.Fake<IDialogCreator>();
+         _outputSchemaTask = A.Fake<IOutputSchemaTask>();
+         _quantityTask = A.Fake<IQuantityTask>();
+         _intervalMapper = A.Fake<IOutputIntervalToOutputIntervalDTOMapper>();
+         _view = A.Fake<IEditOutputSchemaView>();
+         _simulationSettings = new SimulationSettings
+         {
+            OutputSchema = new OutputSchema()
+         };
+
+         sut = new EditOutputSchemaPresenter(_view, _intervalMapper, _quantityTask, _outputSchemaTask, _dialogCreator);
+
+         var timeDimension = DimensionFactoryForSpecs.TimeDimension;
+         var minutes = timeDimension.Unit("minutes");
+         _outputInterval = new OutputIntervalDTO
+         {
+            StartTimeParameter = new ParameterDTO(new Parameter().WithDimension(timeDimension).WithDisplayUnit(minutes)),
+            EndTimeParameter = new ParameterDTO(new Parameter().WithDimension(timeDimension).WithDisplayUnit(minutes)),
+            ResolutionParameter = new ParameterDTO(new Parameter().WithDimension(timeDimension)),
+         };
+
+         // start = 10 minutes, end = 20 minutes
+         _outputInterval.StartTimeParameter.Parameter.Value = _outputInterval.StartTimeParameter.Parameter.ConvertToBaseUnit(10, minutes);
+         _outputInterval.EndTimeParameter.Parameter.Value = _outputInterval.EndTimeParameter.Parameter.ConvertToBaseUnit(20, minutes);
+         
+         sut.InitializeWith(A.Fake<ICommandCollector>());
+         sut.Edit(_simulationSettings);
+      }
+
+      public override void GlobalCleanup()
+      {
+         base.GlobalCleanup();
+         DimensionFactoryForSpecs.TimeDimension.RemoveUnit("minutes");
+         DimensionFactoryForSpecs.TimeDimension.RemoveUnit("years");
+      }
+   }
+
+   internal class When_the_output_interval_start_time_becomes_later_than_the_end_time_through_setting_the_unit : concern_for_EditOutputSchemaPresenter
+   {
+      private Unit _newUnit;
+
+      protected override void Context()
+      {
+         base.Context();
+         _newUnit = DimensionFactoryForSpecs.TimeDimension.Unit("years");
+      }
+
+      protected override void Because()
+      {
+         sut.SetParameterUnit(_outputInterval.StartTimeParameter, _newUnit, _outputInterval);
+      }
+
+      [Observation]
+      public void the_dialog_should_show_the_error_message()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxError(AppConstants.Exceptions.TheStartTimeMustBeEarlierThanTheEndTimeOfTheInterval)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_quantity_task_is_not_used_to_change_the_unit()
+      {
+         A.CallTo(() => _quantityTask.SetQuantityDisplayUnit(_outputInterval.StartTimeParameter.Parameter, _newUnit, _simulationSettings)).MustNotHaveHappened();
+      }
+   }
+
+   internal class When_the_output_interval_end_time_becomes_less_than_start_time_through_setting_the_unit : concern_for_EditOutputSchemaPresenter
+   {
+      private Unit _newUnit;
+
+      protected override void Context()
+      {
+         base.Context();
+         _newUnit = DimensionFactoryForSpecs.TimeDimension.Unit("s");
+      }
+
+      protected override void Because()
+      {
+         sut.SetParameterUnit(_outputInterval.EndTimeParameter, _newUnit, _outputInterval);
+      }
+
+      [Observation]
+      public void the_dialog_should_show_the_error_message()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxError(AppConstants.Exceptions.TheStartTimeMustBeEarlierThanTheEndTimeOfTheInterval)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_quantity_task_is_not_used_to_change_the_unit()
+      {
+         A.CallTo(() => _quantityTask.SetQuantityDisplayUnit(_outputInterval.StartTimeParameter.Parameter, _newUnit, _simulationSettings)).MustNotHaveHappened();
+      }
+   }
+
+   internal class When_changing_the_start_time_unit : concern_for_EditOutputSchemaPresenter
+   {
+      private Unit _newUnit;
+
+      protected override void Context()
+      {
+         base.Context();
+         _newUnit = DimensionFactoryForSpecs.TimeDimension.Unit("s");
+      }
+
+      protected override void Because()
+      {
+         sut.SetParameterUnit(_outputInterval.StartTimeParameter, _newUnit, _outputInterval);
+      }
+
+      [Observation]
+      public void the_dialog_should_show_the_error_message()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxError(AppConstants.Exceptions.TheStartTimeMustBeEarlierThanTheEndTimeOfTheInterval)).MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void the_quantity_task_is_used_to_change_the_unit()
+      {
+         A.CallTo(() => _quantityTask.SetQuantityDisplayUnit(_outputInterval.StartTimeParameter.Parameter, _newUnit, _simulationSettings)).MustHaveHappened();
+      }
+   }
+
+   internal class When_changing_the_end_time_unit : concern_for_EditOutputSchemaPresenter
+   {
+      private Unit _newUnit;
+
+      protected override void Context()
+      {
+         base.Context();
+         _newUnit = DimensionFactoryForSpecs.TimeDimension.Unit("years");
+      }
+
+      protected override void Because()
+      {
+         sut.SetParameterUnit(_outputInterval.EndTimeParameter, _newUnit, _outputInterval);
+      }
+
+      [Observation]
+      public void the_dialog_should_show_the_error_message()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxError(AppConstants.Exceptions.TheStartTimeMustBeEarlierThanTheEndTimeOfTheInterval)).MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void the_quantity_task_is_used_to_change_the_unit()
+      {
+         A.CallTo(() => _quantityTask.SetQuantityDisplayUnit(_outputInterval.EndTimeParameter.Parameter, _newUnit, _simulationSettings)).MustHaveHappened();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/EditOutputSchemaPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditOutputSchemaPresenterSpecs.cs
@@ -124,7 +124,7 @@ namespace MoBi.Presentation
       [Observation]
       public void the_quantity_task_is_not_used_to_change_the_unit()
       {
-         A.CallTo(() => _quantityTask.SetQuantityDisplayUnit(_outputInterval.StartTimeParameter.Parameter, _newUnit, _simulationSettings)).MustNotHaveHappened();
+         A.CallTo(() => _quantityTask.SetQuantityDisplayUnit(_outputInterval.EndTimeParameter.Parameter, _newUnit, _simulationSettings)).MustNotHaveHappened();
       }
    }
 

--- a/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
@@ -21,7 +21,7 @@ using OSPSuite.Presentation.Views;
 
 namespace MoBi.Presentation
 {
-   public abstract class concern_for_EditSimulationPresenter : ContextSpecification<IEditSimulationPresenter>
+   public abstract class concern_for_EditSimulationPresenter : ContextSpecification<EditSimulationPresenter>
    {
       protected IEditSimulationView _view;
       protected ISimulationChartPresenter _chartPresenter;
@@ -152,7 +152,7 @@ namespace MoBi.Presentation
       {
          base.Context();
          _simulation = A.Fake<IMoBiSimulation>();
-         _simulationRunFinishedEvent = new SimulationRunFinishedEvent(_simulation);
+         _simulationRunFinishedEvent = new SimulationRunFinishedEvent(_simulation, true);
          sut.Edit(_simulation);
          A.CallTo(() => _view.ShowsResults).Returns(false);
       }
@@ -206,6 +206,35 @@ namespace MoBi.Presentation
    }
 
    public class
+      When_the_simulation_presenter_is_notified_that_a_simulation_run_is_finished_for_the_edited_simulation_but_failed :
+      concern_for_EditSimulationPresenter
+   {
+      private IMoBiSimulation _simulation;
+      private CurveChart _chart;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = A.Fake<IMoBiSimulation>();
+         sut.Edit(_simulation);
+         _chart = A.Fake<CurveChart>();
+         A.CallTo(() => _simulation.Chart).Returns(_chart);
+         A.CallTo(() => _view.ShowsResults).Returns(true);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new SimulationRunFinishedEvent(_simulation, false));
+      }
+
+      [Observation]
+      public void should_not_show_results_tab()
+      {
+         A.CallTo(() => _view.ShowResultsTab()).MustNotHaveHappened();
+      }
+   }
+
+   public class
       When_the_simulation_presenter_is_notified_that_a_simulation_run_is_finished_for_the_edited_simulation :
       concern_for_EditSimulationPresenter
    {
@@ -224,7 +253,7 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.Handle(new SimulationRunFinishedEvent(_simulation));
+         sut.Handle(new SimulationRunFinishedEvent(_simulation, true));
       }
 
       [Observation]
@@ -237,6 +266,12 @@ namespace MoBi.Presentation
       public void should_show_simulation_chart()
       {
          A.CallTo(() => _chartPresenter.Show(_chart, A<IReadOnlyList<DataRepository>>._, A<IReadOnlyList<DataRepository>>._, A<CurveChartTemplate>._)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_show_results_tab()
+      {
+         A.CallTo(() => _view.ShowResultsTab()).MustNotHaveHappened();
       }
    }
 


### PR DESCRIPTION
Fixes #2166

# Description
There's some rework of the validation and some additional validation done. Also, we do not show results tab on a simulation unless the simulation was completed successfully.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):