### PR TITLE
Fixes #234 Exception when trying to paste a parameter into the parameter tree of a simulation

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1685,6 +1685,7 @@ namespace MoBi.Assets
          public static readonly string ConvertToConstantValue = "Convert to constant value";
          public static readonly string GoToSource = "Go to Source";
          public static readonly string AddOutputSelection = "Add Output";
+         public static readonly string AddingParametersToASimulationIsNotSupported = "Adding parameters to a simulation is not supported";
          public static string SelectTheBuildingBlockWhereEntitiesWillBeAddedOrUpdated(string typeBeingAdded) => $"Select the building block where {typeBeingAdded} will be added or updated";
          public static readonly string SelectBuildingBlock = "Select Building Block";
          public static readonly string MakeDefault = "Make defaults";

--- a/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
@@ -65,7 +65,7 @@ namespace MoBi.Presentation.Presenter
       void ShowIndividualSelection();
       void UpdatePreview();
       void EnableSimulationTracking(TrackableSimulation trackableSimulation);
-      
+
       bool HasModules();
       bool HasBuildingBlocks();
       void NavigateToParameter(ParameterDTO parameterDTO);
@@ -136,7 +136,7 @@ namespace MoBi.Presentation.Presenter
          _noIndividualSelected = new IndividualBuildingBlock().WithName(AppConstants.Captions.None);
          SelectedIndividual = _noIndividualSelected;
          _view.ShowIndividualSelection(false);
-         AllIndividuals = new List<IndividualBuildingBlock> {_noIndividualSelected}.Concat(_interactionTaskContext.Context.CurrentProject.IndividualsCollection).ToList();
+         AllIndividuals = new List<IndividualBuildingBlock> { _noIndividualSelected }.Concat(_interactionTaskContext.Context.CurrentProject.IndividualsCollection).ToList();
       }
 
       public IReadOnlyList<IndividualBuildingBlock> AllIndividuals { get; }
@@ -181,7 +181,7 @@ namespace MoBi.Presentation.Presenter
 
       public void CopyPathForParameter(ParameterDTO parameter)
       {
-         if(!parameter.IsIndividualPreview)
+         if (!parameter.IsIndividualPreview)
             _view.CopyToClipBoard(_entityPathResolver.PathFor(parameter.Parameter));
          else
             _view.CopyToClipBoard(_individualParameterCache[parameter].Path.PathAsString);
@@ -314,6 +314,12 @@ namespace MoBi.Presentation.Presenter
 
       public void PasteFromClipBoard()
       {
+         if (_container.RootContainer.ContainerType == ContainerType.Simulation)
+         {
+            _interactionTaskContext.DialogCreator.MessageBoxInfo(AppConstants.Captions.AddingParametersToASimulationIsNotSupported);
+            return;
+         }
+         
          _ignoreAddEvents = true;
          try
          {
@@ -442,7 +448,7 @@ namespace MoBi.Presentation.Presenter
 
          if (parameter.IsAnImplementationOf<IDistributedParameter>())
          {
-            _editDistributedParameterPresenter.Edit((IDistributedParameter) parameter);
+            _editDistributedParameterPresenter.Edit((IDistributedParameter)parameter);
             _view.SetEditParameterView(_editDistributedParameterPresenter.View);
          }
          else

--- a/src/MoBi.UI/Views/EditParametersInContainerView.cs
+++ b/src/MoBi.UI/Views/EditParametersInContainerView.cs
@@ -77,7 +77,7 @@ namespace MoBi.UI.Views
          toolTipController.Initialize();
          _unitControl = new UxComboBoxUnit<ParameterDTO>(gridControl);
          gridView.HiddenEditor += (o, e) => hideEditor();
-         gridControl.KeyDown += gridViewKeyDown;
+         gridControl.KeyDown += (o, e) => OnEvent(() => gridViewKeyDown(o,e));
          gridControl.ToolTipController = toolTipController;
          //specific grid settings for parameter
          gridView.ShowRowIndicator = true;

--- a/tests/MoBi.Tests/Presentation/EditParametersInContainerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditParametersInContainerPresenterSpecs.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 using FakeItEasy;
+using MoBi.Assets;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Services;
 using MoBi.Presentation.DTO;
@@ -20,6 +20,8 @@ using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.DTO;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace MoBi.Presentation
 {
@@ -112,6 +114,43 @@ namespace MoBi.Presentation
       {
          // This test ensures that the edit is called twice 
          A.CallTo(() => _selectReferencePresenterFactory.ReferenceAtParameterFor(_container)).MustHaveHappenedANumberOfTimesMatching(x => x == 4);
+      }
+
+      [Observation]
+      public void the_clipboard_manager_is_used()
+      {
+         A.CallTo(() => _clipboardManager.PasteFromClipBoard(A<Action<IParameter>>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_pasting_from_clipboard_to_a_container_in_a_simulation : concern_for_EditParametersInContainerPresenter
+   {
+      private IContainer _container;
+
+      protected override void Context()
+      {
+         base.Context();
+         _container = new Container();
+         var simulationContainer = new Container().WithContainerType(ContainerType.Simulation);
+         simulationContainer.Add(_container);
+         sut.Edit(_container);
+      }
+
+      protected override void Because()
+      {
+         sut.PasteFromClipBoard();
+      }
+
+      [Observation]
+      public void the_dialog_informs_user_that_the_parameter_cannot_be_added()
+      {
+         A.CallTo(() => _interactionTaskContext.DialogCreator.MessageBoxInfo(AppConstants.Captions.AddingParametersToASimulationIsNotSupported)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_clipboard_manager_is_not_used()
+      {
+         A.CallTo(() => _clipboardManager.PasteFromClipBoard(A<Action<IParameter>>._)).MustNotHaveHappened();
       }
    }
 


### PR DESCRIPTION
Fixes #234

# Description
Prevent process termination on exception and inform the user they cannot paste into a simulation

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):