### PR TITLE
2168 renaming of an expression profile does not rename the initial conditions

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.2..24" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2.24" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.2.0-OqGxQ" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2..24" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="12.2.20" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2.0-OqGxQ" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.24" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />

--- a/src/MoBi.Core/Commands/RenameExpressionProfileBuildingBlockCommand.cs
+++ b/src/MoBi.Core/Commands/RenameExpressionProfileBuildingBlockCommand.cs
@@ -54,4 +54,4 @@ namespace MoBi.Core.Commands
          });
       }
    }
-}
+}  

--- a/src/MoBi.Core/Commands/RenameExpressionProfileBuildingBlockCommand.cs
+++ b/src/MoBi.Core/Commands/RenameExpressionProfileBuildingBlockCommand.cs
@@ -45,6 +45,13 @@ namespace MoBi.Core.Commands
             objectPath.Replace(_oldMoleculeName, _expressionProfileBuildingBlock.MoleculeName);
             x.Path = objectPath;
          });
+
+         _expressionProfileBuildingBlock.InitialConditions.Each(x =>
+         {
+            var objectPath = x.Path;
+            objectPath.Replace(_oldMoleculeName, _expressionProfileBuildingBlock.MoleculeName);
+            x.Path = objectPath;
+         });
       }
    }
 }

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -32,13 +32,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.2.24" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -32,13 +32,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.2.0-OqGxQ" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -32,13 +32,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="12.2..24" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2.0-OqGxQ" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Assets" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Assets" Version="12.2..24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -24,9 +24,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -24,9 +24,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -24,9 +24,9 @@
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.24" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -23,11 +23,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.5" />
    </ItemGroup>
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -23,11 +23,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.24" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.5" />
    </ItemGroup>
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -23,11 +23,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.2" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.1" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
     <PackageReference Include="System.Resources.Extensions" Version="9.0.5" />
    </ItemGroup>
   <ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -71,7 +71,7 @@
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2..24" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2.24" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -65,13 +65,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.24" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2.0-OqGxQ" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2..24" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -65,13 +65,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.Presentation" Version="12.2.20" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="12.2.0-OqGxQ" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.1" GeneratePathProperty="true" />
 
   </ItemGroup>

--- a/tests/MoBi.Tests/Core/Commands/RenameExpressionProfileBuildingBlockCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/RenameExpressionProfileBuildingBlockCommandSpecs.cs
@@ -72,4 +72,49 @@ namespace MoBi.Core.Commands
          _buildingBlock.All<ExpressionParameter>(x => x.Path.Contains("NewMolecule")).ShouldBeTrue();
       }
    }
+
+   public class When_executing_the_rename_command_for_initial_conditions : concern_for_RenameExpressionProfileBuildingBlockCommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _buildingBlock.AddInitialCondition(new InitialCondition { Path = new ObjectPath("A", "OldMolecule", "IC1") });
+         _buildingBlock.AddInitialCondition(new InitialCondition { Path = new ObjectPath("A", "OldMolecule", "IC2") });
+      }
+
+      protected override void Because()
+      {
+         sut.Execute(_context);
+      }
+
+      [Observation]
+      public void the_initial_conditions_should_have_renamed_molecule()
+      {
+         _buildingBlock.Any<InitialCondition>(x => x.Path.Contains("OldMolecule")).ShouldBeFalse();
+         _buildingBlock.All<InitialCondition>(x => x.Path.Contains("NewMolecule")).ShouldBeTrue();
+      }
+   }
+
+   public class When_reversing_the_rename_command_for_initial_conditions : concern_for_RenameExpressionProfileBuildingBlockCommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _buildingBlock.AddInitialCondition(new InitialCondition { Path = new ObjectPath("A", "OldMolecule", "IC1") });
+         _buildingBlock.AddInitialCondition(new InitialCondition { Path = new ObjectPath("A", "OldMolecule", "IC2") });
+      }
+
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_context);
+      }
+
+      [Observation]
+      public void the_initial_conditions_should_revert_to_old_molecule()
+      {
+         _buildingBlock.Any<InitialCondition>(x => x.Path.Contains("NewMolecule")).ShouldBeFalse();
+         _buildingBlock.All<InitialCondition>(x => x.Path.Contains("OldMolecule")).ShouldBeTrue();
+      }
+   }
+
 }

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -43,10 +43,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2.24" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -43,10 +43,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2..24" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -43,10 +43,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2.0-OqGxQ" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.73" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.20" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2.20" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2.0-OqGxQ" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2.24" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2.24" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="12.2.0-OqGxQ" />
-    <PackageReference Include="OSPSuite.UI" Version="12.2.0-OqGxQ" />
+    <PackageReference Include="OSPSuite.Core" Version="12.2..24" />
+    <PackageReference Include="OSPSuite.UI" Version="12.2..24" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #2168 

TODO: reference the new CORE Package once [this PR](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/pull/2708) gets Merged.


# Description

Renaming an expression profile does not rename the initial conditions

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
<img width="587" height="528" alt="image" src="https://github.com/user-attachments/assets/8c415043-e1f9-48e2-8ea5-d064cec0c853" />


# Questions (if appropriate):