### PR TITLE
311 security dialogue missing when parameter identification is running fix

### DIFF
--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -254,16 +254,16 @@ namespace MoBi.Presentation.Tasks
          if (_parameterIdentificationRunner.IsRunning)
          {
             showRunningParameterIdentificationWarnings();
-            shouldClose = false;
+            return false;
          }
 
          if (_simulationRunner.IsAnySimulationRunning())
          {
             showRunningSimulationsWarnings();
-            shouldClose = false;
+            return false;
          }
 
-         if (_context.CurrentProject.HasChanged && shouldClose)
+         if (_context.CurrentProject.HasChanged)
             shouldClose = askForSaveProject();
 
          if (!shouldClose)

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -247,7 +247,6 @@ namespace MoBi.Presentation.Tasks
 
       public bool CloseProject()
       {
-         var shouldClose = true;
          if (_context.CurrentProject == null)
             return true;
 
@@ -263,10 +262,7 @@ namespace MoBi.Presentation.Tasks
             return false;
          }
 
-         if (_context.CurrentProject.HasChanged)
-            shouldClose = askForSaveProject();
-
-         if (!shouldClose)
+         if (_context.CurrentProject.HasChanged && !askForSaveProject())
             return false;
 
          _context.PublishEvent(new ProjectClosingEvent());

--- a/src/MoBi.Presentation/Tasks/ProjectTask.cs
+++ b/src/MoBi.Presentation/Tasks/ProjectTask.cs
@@ -263,7 +263,7 @@ namespace MoBi.Presentation.Tasks
             shouldClose = false;
          }
 
-         if (_context.CurrentProject.HasChanged)
+         if (_context.CurrentProject.HasChanged && shouldClose)
             shouldClose = askForSaveProject();
 
          if (!shouldClose)

--- a/tests/MoBi.Tests/Presentation/ProjectTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ProjectTaskSpecs.cs
@@ -719,4 +719,49 @@ namespace MoBi.Presentation
          _context.CurrentProject.ReactionDimensionMode.ShouldBeEqualTo(ReactionDimensionMode.AmountBased);
       }
    }
+
+   public class When_told_to_close_project_and_simulation_is_running : concern_for_ProjectTask
+   {
+      private bool _result;
+      private MoBiProject _project;
+
+      protected override void Context()
+      {
+         base.Context();
+         _project = A.Fake<MoBiProject>();
+         _project.HasChanged = true; // Would normally trigger save dialog
+         A.CallTo(() => _context.CurrentProject).Returns(_project);
+         A.CallTo(() => _simulationRunner.IsAnySimulationRunning()).Returns(true); // This sets shouldClose = false
+      }
+
+      protected override void Because()
+      {
+         _result = sut.CloseProject();
+      }
+
+      [Observation]
+      public void should_not_ask_for_save_dialog()
+      {
+         A.CallTo(
+            () => _dialogCreator.AskForFileToSave(
+               AppConstants.Dialog.AskForSaveProject,
+               AppConstants.Filter.MOBI_PROJECT_FILE_FILTER,
+               Constants.DirectoryKey.PROJECT,
+               A<string>._,
+               null)).MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void should_not_ask_for_message_box_yes_no_cancel()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxYesNoCancel(A<string>._, A<ViewResult>._))
+            .MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void should_return_false()
+      {
+         _result.ShouldBeFalse();
+      }
+   }
 }


### PR DESCRIPTION
Fixes #311 

# Description

When a Running Sim or PI is running, and the project has pending changes, then the user is able to close it even when running.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):