### PR TITLE
Fixes #1560 Allow "Reset" for each changed value in the Expression Profile and Individual BBs

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.75" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.75" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.76" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.76" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.75" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.76" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,14 +16,14 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.75" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.75" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.76" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.76" />
       <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.75" />
-      <PackageReference Include="OSPSuite.Presentation" Version="13.0.75" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.75" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.75" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.75" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.76" />
+      <PackageReference Include="OSPSuite.Presentation" Version="13.0.76" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.76" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.76" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.76" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -23,16 +23,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.75" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.76" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.75" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.76" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/Commands/ChangeValueFormulaCommand.cs
+++ b/src/MoBi.Core/Commands/ChangeValueFormulaCommand.cs
@@ -19,9 +19,11 @@ namespace MoBi.Core.Commands
       protected IFormula _newFormula;
       protected IFormula _oldFormula;
       protected T _changedPathAndValueEntity;
+      private readonly bool _shouldResetInitialStateOnUndo;
+      private bool _shouldResetInitialState;
       protected ObjectPath Path { get; set; }
 
-      public ChangeValueFormulaCommand(IBuildingBlock<T> buildingBlock, T pathAndValueEntity, IFormula newFormula, IFormula oldFormula): base(buildingBlock)
+      public ChangeValueFormulaCommand(IBuildingBlock<T> buildingBlock, T pathAndValueEntity, IFormula newFormula, IFormula oldFormula) : base(buildingBlock)
       {
          _newFormula = newFormula;
          _oldFormula = oldFormula;
@@ -36,6 +38,7 @@ namespace MoBi.Core.Commands
          _oldFormulaId = GetFormulaId(_oldFormula);
          _newFormulaId = GetFormulaId(_newFormula);
 
+         _shouldResetInitialStateOnUndo = pathAndValueEntity is ParameterValueWithInitialState { HasInitialState: false };
       }
 
       protected string GetFormulaId(IFormula formula)
@@ -50,7 +53,7 @@ namespace MoBi.Core.Commands
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
       {
-         return new ChangeValueFormulaCommand<T>(_buildingBlock, _changedPathAndValueEntity, _oldFormula, _newFormula).AsInverseFor(this);
+         return new ChangeValueFormulaCommand<T>(_buildingBlock, _changedPathAndValueEntity, _oldFormula, _newFormula) { _shouldResetInitialState = _shouldResetInitialStateOnUndo }.AsInverseFor(this);
       }
 
       protected override void ClearReferences()
@@ -65,6 +68,24 @@ namespace MoBi.Core.Commands
       protected override void ExecuteWith(IMoBiContext context)
       {
          base.ExecuteWith(context);
+
+         if (_changedPathAndValueEntity is ParameterValueWithInitialState  parameterValue)
+         {
+            // We can set an initial state when the parameter does not already have one
+            if (_shouldResetInitialState)
+            {
+               parameterValue.InitialValue = null;
+               parameterValue.InitialFormulaId = null;
+               parameterValue.InitialUnit = null;
+            }
+            else if (!parameterValue.HasInitialState)
+            {
+               parameterValue.InitialValue = _changedPathAndValueEntity.Value;
+               parameterValue.InitialFormulaId = parameterValue.Formula?.Id;
+               parameterValue.InitialUnit = _changedPathAndValueEntity.DisplayUnit;
+            }
+         }
+
          _changedPathAndValueEntity.Formula = _newFormula;
          Path = _changedPathAndValueEntity.Path;
       }

--- a/src/MoBi.Core/Commands/ExpressionParameterValueOrUnitUpdateCommand.cs
+++ b/src/MoBi.Core/Commands/ExpressionParameterValueOrUnitUpdateCommand.cs
@@ -1,0 +1,22 @@
+﻿using MoBi.Core.Domain.Model;
+using OSPSuite.Core.Domain.Builder;
+
+namespace MoBi.Core.Commands;
+
+public class ExpressionParameterValueOrUnitUpdateCommand : PathAndValueEntityValueOrUnitChangedCommand<ExpressionParameter, ExpressionProfileBuildingBlock>
+{
+   public ExpressionParameterValueOrUnitUpdateCommand(ExpressionParameter builder, ExpressionParameterValueUpdate expressionParameterValueUpdate, ExpressionProfileBuildingBlock buildingBlock) : base(builder, expressionParameterValueUpdate.UpdatedValue, builder.DisplayUnit, buildingBlock)
+   {
+         
+   }
+
+   protected override void ExecuteWith(IMoBiContext context)
+   {
+      base.ExecuteWith(context);
+
+      // In this context we are not storing the initial state because we are setting the initial state as queried from PK-Sim
+      _builder.InitialValue = null;
+      _builder.InitialFormulaId = null;
+      _builder.InitialUnit = null;
+   }
+}

--- a/src/MoBi.Core/Commands/PathAndValueEntityValueOrUnitChangedCommand.cs
+++ b/src/MoBi.Core/Commands/PathAndValueEntityValueOrUnitChangedCommand.cs
@@ -15,12 +15,13 @@ namespace MoBi.Core.Commands
       where TBuilder : PathAndValueEntity, IObjectBase, IUsingFormula, IWithDisplayUnit
    {
       protected TBuilder _builder;
-      protected Unit _newDisplayUnit;
-      protected Unit _oldDisplayUnit;
+      protected readonly Unit _newDisplayUnit;
+      protected readonly Unit _oldDisplayUnit;
       protected double? _newBaseValue;
       protected double? _oldBaseValue;
       protected readonly ObjectPath _valuePath;
       private readonly DistributionType? _oldDistributionType;
+      private readonly bool _shouldResetInitialStateOnUndo;
 
       public PathAndValueEntityValueOrUnitChangedCommand(TBuilder builder, double? newBaseValue, Unit newDisplayUnit, TBuildingBlock buildingBlock) : base(buildingBlock)
       {
@@ -41,11 +42,13 @@ namespace MoBi.Core.Commands
             builder.ConvertToDisplayUnit(_oldBaseValue.GetValueOrDefault(double.NaN)),
             _oldDisplayUnit.Name,
             builder.Path.PathAsString, _buildingBlock.Name);
+
+         _shouldResetInitialStateOnUndo = builder is ParameterValueWithInitialState { HasInitialState: false };
       }
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
       {
-         return new PathAndValueEntityValueOrUnitChangedCommandWithDistribution(_builder, _oldBaseValue, _oldDisplayUnit, _buildingBlock, _oldDistributionType).AsInverseFor(this);
+         return new PathAndValueEntityValueOrUnitChangedCommandWithDistribution(_builder, _oldBaseValue, _oldDisplayUnit, _buildingBlock, _oldDistributionType, _shouldResetInitialStateOnUndo).AsInverseFor(this);
       }
 
       protected override void ClearReferences()
@@ -63,26 +66,44 @@ namespace MoBi.Core.Commands
       protected override void ExecuteWith(IMoBiContext context)
       {
          base.ExecuteWith(context);
+
+         // We can set an initial state when the parameter does not already have one, and it is not distributed
+         if (_builder is ParameterValueWithInitialState { HasInitialState: false, DistributionType: null } parameterValue)
+         {
+            parameterValue.InitialValue = _oldBaseValue;
+            parameterValue.InitialFormulaId = parameterValue.Formula?.Id;
+            parameterValue.InitialUnit = _oldDisplayUnit;
+         }
+
          _builder.Value = _newBaseValue;
          _builder.DisplayUnit = _newDisplayUnit;
          _builder.DistributionType = null;
       }
 
       // This command is used to restore a distribution when a distributed parameter is changed to non-distributed, and then the command is reversed.
-      // There is no general way to change between distribution types, so this class is private, so it can only be used with restore functionality
+      // There is no general way to change between distribution types, so this class is private, so it can only be used as an inverse command.
       private class PathAndValueEntityValueOrUnitChangedCommandWithDistribution : PathAndValueEntityValueOrUnitChangedCommand<TBuilder, TBuildingBlock>
       {
          private readonly DistributionType? _newDistributionType;
+         private readonly bool _shouldResetInitialState;
 
-         public PathAndValueEntityValueOrUnitChangedCommandWithDistribution(TBuilder builder, double? newBaseValue, Unit newDisplayUnit, TBuildingBlock buildingBlock, DistributionType? newDistributionType) : base(builder, newBaseValue, newDisplayUnit, buildingBlock)
+         public PathAndValueEntityValueOrUnitChangedCommandWithDistribution(TBuilder builder, double? newBaseValue, Unit newDisplayUnit, TBuildingBlock buildingBlock, DistributionType? newDistributionType, bool shouldResetInitialState) : base(builder, newBaseValue, newDisplayUnit, buildingBlock)
          {
             _newDistributionType = newDistributionType;
+            _shouldResetInitialState = shouldResetInitialState;
          }
 
          protected override void ExecuteWith(IMoBiContext context)
          {
             base.ExecuteWith(context);
             _builder.DistributionType = _newDistributionType;
+
+            if (!_shouldResetInitialState || _builder is not ParameterValueWithInitialState parameterValue)
+               return;
+
+            parameterValue.InitialValue = null;
+            parameterValue.InitialFormulaId = null;
+            parameterValue.InitialUnit = null;
          }
       }
    }

--- a/src/MoBi.Core/Commands/ResetInitialStateCommand.cs
+++ b/src/MoBi.Core/Commands/ResetInitialStateCommand.cs
@@ -1,0 +1,56 @@
+﻿using MoBi.Core.Domain.Model;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.UnitSystem;
+
+namespace MoBi.Core.Commands;
+
+public class ResetInitialStateCommand<TBuilder, TBuildingBlock> : PathAndValueEntityValueOrUnitChangedCommand<TBuilder, TBuildingBlock> where TBuilder : ParameterValueWithInitialState where TBuildingBlock : class, IBuildingBlock<TBuilder>
+{
+   private readonly double? _oldInitialValue;
+   private readonly Unit _oldInitialUnit;
+   private readonly string _oldInitialFormulaId;
+
+   private readonly double? _newInitialValue;
+   private readonly Unit _newInitialUnit;
+   private readonly string _newInitialFormulaId;
+   private readonly string _originalFormulaId;
+   private readonly string _newFormulaId;
+   private readonly string _oldFormulaId;
+
+   public ResetInitialStateCommand(TBuilder builder, TBuildingBlock buildingBlock) : this(builder, null, null, null, builder.InitialValue, builder.InitialFormulaId, builder.InitialUnit, builder.InitialValue, builder.InitialUnit, builder.InitialFormulaId, builder.Formula?.Id, buildingBlock)
+   {
+
+   }
+
+   // Only for use in restoring previous state after a reset
+   private ResetInitialStateCommand(TBuilder builder, double? newInitialValue, string newInitialFormulaId, Unit newInitialUnit, double? oldInitialValue, string oldInitialFormulaId, Unit oldInitialUnit, double? newValue, Unit newUnit, string newFormulaId, string oldFormulaId, TBuildingBlock buildingBlock) : base(builder, newValue, newUnit, buildingBlock)
+   {
+      _oldInitialValue = oldInitialValue;
+      _oldInitialUnit = oldInitialUnit;
+      _oldInitialFormulaId = oldInitialFormulaId;
+
+      _newInitialFormulaId = newInitialFormulaId;
+      _newInitialUnit = newInitialUnit;
+      _newInitialValue = newInitialValue;
+
+      _newFormulaId = newFormulaId;
+      _oldFormulaId = oldFormulaId;
+   }
+
+   protected override void ExecuteWith(IMoBiContext context)
+   {
+      base.ExecuteWith(context);
+
+      _builder.Formula = _buildingBlock.FormulaCache.Contains(_newFormulaId) ? _buildingBlock.FormulaCache[_newFormulaId] : null;
+
+      _builder.InitialValue = _newInitialValue;
+      _builder.InitialFormulaId = _newInitialFormulaId;
+      _builder.InitialUnit = _newInitialUnit;
+   }
+
+   protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
+   {
+      return new ResetInitialStateCommand<TBuilder, TBuildingBlock>(_builder, _oldInitialValue, _oldInitialFormulaId, _oldInitialUnit, _newInitialValue, _newInitialFormulaId, _newInitialUnit, _oldBaseValue, _oldDisplayUnit, _oldFormulaId, _newFormulaId, _buildingBlock);
+   }
+}

--- a/src/MoBi.Core/Commands/ResetInitialStateCommand.cs
+++ b/src/MoBi.Core/Commands/ResetInitialStateCommand.cs
@@ -14,7 +14,6 @@ public class ResetInitialStateCommand<TBuilder, TBuildingBlock> : PathAndValueEn
    private readonly double? _newInitialValue;
    private readonly Unit _newInitialUnit;
    private readonly string _newInitialFormulaId;
-   private readonly string _originalFormulaId;
    private readonly string _newFormulaId;
    private readonly string _oldFormulaId;
 

--- a/src/MoBi.Core/Commands/ResetInitialStateCommand.cs
+++ b/src/MoBi.Core/Commands/ResetInitialStateCommand.cs
@@ -41,7 +41,9 @@ public class ResetInitialStateCommand<TBuilder, TBuildingBlock> : PathAndValueEn
    {
       base.ExecuteWith(context);
 
-      _builder.Formula = _buildingBlock.FormulaCache.Contains(_newFormulaId) ? _buildingBlock.FormulaCache[_newFormulaId] : null;
+      _builder.Formula = !string.IsNullOrEmpty(_newFormulaId) && _buildingBlock.FormulaCache.Contains(_newFormulaId)
+         ? _buildingBlock.FormulaCache[_newFormulaId]
+         : null;
 
       _builder.InitialValue = _newInitialValue;
       _builder.InitialFormulaId = _newInitialFormulaId;

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,13 +31,13 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="8.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.75" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.76" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.75" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.76" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/DTO/ExpressionParameterDTO.cs
+++ b/src/MoBi.Presentation/DTO/ExpressionParameterDTO.cs
@@ -2,7 +2,7 @@
 
 namespace MoBi.Presentation.DTO
 {
-   public class ExpressionParameterDTO : PathAndValueEntityDTO<ExpressionParameter, ExpressionParameterDTO>
+   public class ExpressionParameterDTO : ParameterValueWithInitialStateDTO<ExpressionParameter, ExpressionParameterDTO>
    {
       public ExpressionParameterDTO(ExpressionParameter expressionParameter) : base(expressionParameter)
       {

--- a/src/MoBi.Presentation/DTO/IndividualParameterDTO.cs
+++ b/src/MoBi.Presentation/DTO/IndividualParameterDTO.cs
@@ -2,7 +2,7 @@
 
 namespace MoBi.Presentation.DTO
 {
-   public class IndividualParameterDTO : PathAndValueEntityDTO<IndividualParameter, IndividualParameterDTO>
+   public class IndividualParameterDTO : ParameterValueWithInitialStateDTO<IndividualParameter, IndividualParameterDTO>
    {
       public IndividualParameterDTO(IndividualParameter individualParameter) : base(individualParameter)
       {

--- a/src/MoBi.Presentation/DTO/ParameterValueWithInitialStateDTO.cs
+++ b/src/MoBi.Presentation/DTO/ParameterValueWithInitialStateDTO.cs
@@ -1,0 +1,12 @@
+﻿using OSPSuite.Core.Domain.Builder;
+
+namespace MoBi.Presentation.DTO;
+
+public class ParameterValueWithInitialStateDTO<TParameter, TParameterDTO> : PathAndValueEntityDTO<TParameter, TParameterDTO> where TParameterDTO : PathAndValueEntityDTO<TParameter> where TParameter : ParameterValueWithInitialState
+{
+   protected ParameterValueWithInitialStateDTO(TParameter pathAndValueEntity) : base(pathAndValueEntity)
+   {
+   }
+
+   public bool HasInitialState => PathWithValueObject.HasInitialState;
+}

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -23,9 +23,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.75" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.76" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/ExpressionProfileBuildingBlockPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ExpressionProfileBuildingBlockPresenter.cs
@@ -18,6 +18,7 @@ namespace MoBi.Presentation.Presenter
    {
       void Edit(ExpressionProfileBuildingBlock expressionProfileBuildingBlock);
       void LoadExpressionFromPKSimDatabaseQuery();
+      void ResetInitialState(ExpressionParameterDTO dto);
    }
 
    public class ExpressionProfileBuildingBlockPresenter :
@@ -53,6 +54,17 @@ namespace MoBi.Presentation.Presenter
       public void LoadExpressionFromPKSimDatabaseQuery()
       {
          AddCommand(_interactionTasksForExpressionProfile.UpdateExpressionProfileFromDatabase(_buildingBlock));
+      }
+
+      public void ResetInitialState(ExpressionParameterDTO dto)
+      {
+         AddCommand(_interactionTasksForExpressionProfile.ResetToInitialState(dto.PathWithValueObject, _buildingBlock));
+         refreshDTO(dto);
+      }
+
+      private void refreshDTO(ExpressionParameterDTO parameterDTO)
+      {
+         RefreshDTO(parameterDTO, parameterDTO.PathWithValueObject.Formula, parameterDTO.PathWithValueObject);
       }
 
       private void rebind()

--- a/src/MoBi.Presentation/Presenter/IndividualBuildingBlockPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/IndividualBuildingBlockPresenter.cs
@@ -17,6 +17,7 @@ namespace MoBi.Presentation.Presenter
       IPathAndValueBuildingBlockPresenter<IndividualParameterDTO>
    {
       void Edit(IndividualBuildingBlock individualBuildingBlock);
+      void ResetInitialState(IndividualParameterDTO dto);
    }
 
    public class IndividualBuildingBlockPresenter : 
@@ -26,7 +27,7 @@ namespace MoBi.Presentation.Presenter
    {
       private readonly IIndividualBuildingBlockToIndividualBuildingBlockDTOMapper _individualToDTOMapper;
       private IndividualBuildingBlockDTO _individualBuildingBlockDTO;
-      
+      private readonly IInteractionTasksForIndividualBuildingBlock _interactionTasksForIndividualBuildingBlock;
 
       public IndividualBuildingBlockPresenter(IIndividualBuildingBlockView view, 
          IIndividualBuildingBlockToIndividualBuildingBlockDTOMapper individualToDTOMapper,
@@ -36,6 +37,7 @@ namespace MoBi.Presentation.Presenter
          IIndividualDistributedPathAndValueEntityPresenter distributedPathAndValuePresenter) : base(view, interactionTask, formulaToValueFormulaDTOMapper, dimensionFactory, distributedPathAndValuePresenter)
       {
          _individualToDTOMapper = individualToDTOMapper;
+         _interactionTasksForIndividualBuildingBlock = interactionTask;
       }
 
       public override void Edit(IndividualBuildingBlock individualBuildingBlock)
@@ -43,6 +45,17 @@ namespace MoBi.Presentation.Presenter
          base.Edit(individualBuildingBlock);
          _individualBuildingBlockDTO = _individualToDTOMapper.MapFrom(individualBuildingBlock);
          _view.BindTo(_individualBuildingBlockDTO);
+      }
+
+      public void ResetInitialState(IndividualParameterDTO dto)
+      {
+         AddCommand(_interactionTasksForIndividualBuildingBlock.ResetToInitialState(dto.PathWithValueObject, _buildingBlock));
+         refreshDTO(dto);
+      }
+
+      private void refreshDTO(IndividualParameterDTO parameterDTO)
+      {
+         RefreshDTO(parameterDTO, parameterDTO.PathWithValueObject.Formula, parameterDTO.PathWithValueObject);
       }
 
       public bool HasAtLeastOneValue(int pathElementIndex) => _individualBuildingBlockDTO.Parameters.HasAtLeastOneValue(pathElementIndex);

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExpressionProfileBuildingBlock.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExpressionProfileBuildingBlock.cs
@@ -22,6 +22,7 @@ namespace MoBi.Presentation.Tasks.Interaction
       IInteractionTasksForProjectBuildingBlock
    {
       IMoBiCommand UpdateExpressionProfileFromDatabase(ExpressionProfileBuildingBlock buildingBlock);
+      IMoBiCommand ResetToInitialState(ExpressionParameter expressionParameter, ExpressionProfileBuildingBlock buildingBlock);
    }
 
    public class InteractionTasksForExpressionProfileBuildingBlock : InteractionTasksForProjectPathAndValueEntityBuildingBlocks<ExpressionProfileBuildingBlock, ExpressionParameter>, IInteractionTasksForExpressionProfileBuildingBlock
@@ -66,25 +67,26 @@ namespace MoBi.Presentation.Tasks.Interaction
             Description = AppConstants.Commands.UpdateRelativeExpressions
          };
 
-         macroCommand.AddRange(expressionProfileUpdate.Select(parameter => updateCommandFor(buildingBlock, parameter.Path, parameter.UpdatedValue)));
+         macroCommand.AddRange(expressionProfileUpdate.Select(parameter => updateCommandFor(buildingBlock, parameter)));
 
          return macroCommand.RunCommand(Context);
       }
 
-      public ExpressionProfileBuildingBlock LoadFromSnapshot(string snapshot)
-      {
-         // Cloning required to reset object ids
-         return _cloneManagerForBuildingBlock.Clone(_pkSimStarter.LoadExpressionProfileFromSnapshot(snapshot));
-      }
+      public IMoBiCommand ResetToInitialState(ExpressionParameter expressionParameter, ExpressionProfileBuildingBlock buildingBlock) => 
+         new ResetInitialStateCommand<ExpressionParameter, ExpressionProfileBuildingBlock>(expressionParameter, buildingBlock).RunCommand(Context);
 
-      private static ICommand updateCommandFor(ExpressionProfileBuildingBlock buildingBlock, ObjectPath path, double? value)
+      public ExpressionProfileBuildingBlock LoadFromSnapshot(string snapshot) =>
+         // Cloning required to reset object ids
+         _cloneManagerForBuildingBlock.Clone(_pkSimStarter.LoadExpressionProfileFromSnapshot(snapshot));
+
+      private static ICommand updateCommandFor(ExpressionProfileBuildingBlock buildingBlock, ExpressionParameterValueUpdate expressionParameterValueUpdate)
       {
-         var parameterToUpdate = buildingBlock[path];
+         var parameterToUpdate = buildingBlock[expressionParameterValueUpdate.Path];
 
          if (parameterToUpdate == null)
             return new MoBiEmptyCommand();
 
-         return new PathAndValueEntityValueOrUnitChangedCommand<ExpressionParameter, ExpressionProfileBuildingBlock>(parameterToUpdate, value, parameterToUpdate.DisplayUnit, buildingBlock);
+         return new ExpressionParameterValueOrUnitUpdateCommand(parameterToUpdate, expressionParameterValueUpdate, buildingBlock);
       }
 
       protected override string GetNewNameForClone(ExpressionProfileBuildingBlock buildingBlockToClone)
@@ -102,10 +104,8 @@ namespace MoBi.Presentation.Tasks.Interaction
          return _editTaskForExpressionProfileBuildingBlock.NewNameFromSuggestions(buildingBlockToClone.MoleculeName, buildingBlockToClone.Species, suggestedCategory, buildingBlockToClone.Type, forbiddenValues);
       }
 
-      public override IMoBiCommand GetRemoveCommand(ExpressionProfileBuildingBlock expressionProfileToRemove, MoBiProject parent, IBuildingBlock buildingBlock)
-      {
-         return new RemoveExpressionProfileBuildingBlockFromProjectCommand(expressionProfileToRemove);
-      }
+      public override IMoBiCommand GetRemoveCommand(ExpressionProfileBuildingBlock expressionProfileToRemove, MoBiProject parent, IBuildingBlock buildingBlock) => 
+         new RemoveExpressionProfileBuildingBlockFromProjectCommand(expressionProfileToRemove);
 
       public override bool CorrectName(ExpressionProfileBuildingBlock expressionProfile, MoBiProject project)
       {
@@ -123,14 +123,9 @@ namespace MoBi.Presentation.Tasks.Interaction
          return true;
       }
 
-      public override IMoBiCommand GetAddCommand(ExpressionProfileBuildingBlock expressionProfileToAdd, MoBiProject parent, IBuildingBlock buildingBlock)
-      {
-         return new AddExpressionProfileBuildingBlockToProjectCommand(expressionProfileToAdd);
-      }
+      public override IMoBiCommand GetAddCommand(ExpressionProfileBuildingBlock expressionProfileToAdd, MoBiProject parent, IBuildingBlock buildingBlock) => 
+         new AddExpressionProfileBuildingBlockToProjectCommand(expressionProfileToAdd);
 
-      protected override string SnapshotFrom(ExpressionProfileBuildingBlock buildingBlock)
-      {
-         return buildingBlock.Snapshot.FromBase64String();
-      }
+      protected override string SnapshotFrom(ExpressionProfileBuildingBlock buildingBlock) => buildingBlock.Snapshot.FromBase64String();
    }
 }

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForIndividualBuildingBlock.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForIndividualBuildingBlock.cs
@@ -1,6 +1,7 @@
 ﻿using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
+using MoBi.Core.Extensions;
 using MoBi.Core.Mappers;
 using MoBi.Core.Services;
 using MoBi.Presentation.Tasks.Edit;
@@ -15,6 +16,7 @@ namespace MoBi.Presentation.Tasks.Interaction
       IInteractionTasksForProjectPathAndValueEntityBuildingBlocks<IndividualBuildingBlock, IndividualParameter>,
       IInteractionTasksForProjectBuildingBlock
    {
+      IMoBiCommand ResetToInitialState(IndividualParameter individualParameter, IndividualBuildingBlock buildingBlock);
    }
 
    public class InteractionTasksForIndividualBuildingBlock : InteractionTasksForProjectPathAndValueEntityBuildingBlocks<IndividualBuildingBlock, IndividualParameter>, IInteractionTasksForIndividualBuildingBlock
@@ -46,20 +48,16 @@ namespace MoBi.Presentation.Tasks.Interaction
          return new RemoveIndividualBuildingBlockFromProjectCommand(individualBuildingBlockToRemove);
       }
 
-      public IndividualBuildingBlock LoadFromSnapshot(string snapshot)
-      {
+      public IndividualBuildingBlock LoadFromSnapshot(string snapshot) =>
          // Cloning required to reset object ids
-         return _cloneManagerForBuildingBlock.Clone(_pkSimStarter.LoadIndividualFromSnapshot(snapshot));
-      }
+         _cloneManagerForBuildingBlock.Clone(_pkSimStarter.LoadIndividualFromSnapshot(snapshot));
 
-      public override IMoBiCommand GetAddCommand(IndividualBuildingBlock individualBuildingBlockToAdd, MoBiProject parent, IBuildingBlock buildingBlock)
-      {
-         return new AddIndividualBuildingBlockToProjectCommand(individualBuildingBlockToAdd);
-      }
+      public IMoBiCommand ResetToInitialState(IndividualParameter individualParameter, IndividualBuildingBlock buildingBlock) => 
+         new ResetInitialStateCommand<IndividualParameter, IndividualBuildingBlock>(individualParameter, buildingBlock).RunCommand(Context);
 
-      protected override string SnapshotFrom(IndividualBuildingBlock buildingBlock)
-      {
-         return buildingBlock.Snapshot.FromBase64String();
-      }
+      public override IMoBiCommand GetAddCommand(IndividualBuildingBlock individualBuildingBlockToAdd, MoBiProject parent, IBuildingBlock buildingBlock) => 
+         new AddIndividualBuildingBlockToProjectCommand(individualBuildingBlockToAdd);
+
+      protected override string SnapshotFrom(IndividualBuildingBlock buildingBlock) => buildingBlock.Snapshot.FromBase64String();
    }
 }

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.75" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.76" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.5" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.75" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.76" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/Views/ExpressionProfileBuildingBlockView.cs
+++ b/src/MoBi.UI/Views/ExpressionProfileBuildingBlockView.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 using DevExpress.XtraEditors;
 using DevExpress.XtraEditors.Controls;
 using DevExpress.XtraEditors.Repository;
+using DevExpress.XtraGrid.Views.Base;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Formatters;
 using MoBi.Presentation.Presenter;
@@ -36,6 +38,7 @@ namespace MoBi.UI.Views
       private readonly PopupContainerControl _popupControl = new PopupContainerControl();
       private readonly RepositoryItemPopupContainerEdit _repositoryItemPopupContainerEdit = new RepositoryItemPopupContainerEdit();
       private IGridViewBoundColumn<ExpressionParameterDTO, double?> _valueColumn;
+      private RepositoryItemButtonEdit _isFixedParameterEditRepository;
 
       public ExpressionProfileBuildingBlockView(ValueOriginBinder<ExpressionParameterDTO> valueOriginBinder)
       {
@@ -61,6 +64,21 @@ namespace MoBi.UI.Views
          initializeBinders();
          initializeValueOriginBinding();
          gridView.ShowColumnChooser = true;
+         createResetButtonItem();
+
+         _isFixedParameterEditRepository.ButtonClick += (_, _) => OnEvent(() => onResetValue(_gridViewBinder.FocusedElement));
+      }
+
+      private void onResetValue(ExpressionParameterDTO dto)
+      {
+         _presenter.ResetInitialState(dto);
+         gridView.CloseEditor();
+      }
+
+      private void createResetButtonItem()
+      {
+         _isFixedParameterEditRepository = new UxRepositoryItemButtonImage(ApplicationIcons.Reset, Assets.ToolTips.ResetParameterToolTip) { TextEditStyle = TextEditStyles.Standard };
+         _isFixedParameterEditRepository.Buttons[0].IsLeft = true;
       }
 
       private void initializeValueOriginBinding()
@@ -124,6 +142,7 @@ namespace MoBi.UI.Views
             .WithOnValueUpdating(onExpressionParameterValueSet)
             .WithFormat(dto => dto.ExpressionParameterFormatter())
             .WithRepository(valueRepositoryFor)
+            .WithShowButton(ShowButtonModeEnum.ShowAlways)
             .WithEditorConfiguration(configureRepository);
 
          _unitControl.ParameterUnitSet += setParameterUnit;
@@ -222,6 +241,9 @@ namespace MoBi.UI.Views
       {
          if (parameterDTO.IsDistributed)
             return _repositoryItemPopupContainerEdit;
+
+         if(parameterDTO.HasInitialState)
+            return _isFixedParameterEditRepository;
 
          return _valueColumn.DefaultRepository();
       }

--- a/src/MoBi.UI/Views/ExpressionProfileBuildingBlockView.cs
+++ b/src/MoBi.UI/Views/ExpressionProfileBuildingBlockView.cs
@@ -242,7 +242,7 @@ namespace MoBi.UI.Views
          if (parameterDTO.IsDistributed)
             return _repositoryItemPopupContainerEdit;
 
-         if(parameterDTO.HasInitialState)
+         if (parameterDTO.HasInitialState)
             return _isFixedParameterEditRepository;
 
          return _valueColumn.DefaultRepository();

--- a/src/MoBi.UI/Views/ExpressionProfileBuildingBlockView.cs
+++ b/src/MoBi.UI/Views/ExpressionProfileBuildingBlockView.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Threading.Tasks;
 using DevExpress.XtraEditors;
 using DevExpress.XtraEditors.Controls;
 using DevExpress.XtraEditors.Repository;

--- a/src/MoBi.UI/Views/IndividualBuildingBlockView.cs
+++ b/src/MoBi.UI/Views/IndividualBuildingBlockView.cs
@@ -94,7 +94,6 @@ namespace MoBi.UI.Views
          _isFixedParameterEditRepository.Buttons[0].IsLeft = true;
       }
 
-
       private void initializeValueOriginBinding()
       {
          _valueOriginBinder.InitializeBinding(_gridViewBinder, (o, e) => OnEvent(() => _presenter.SetValueOrigin(o, e)));

--- a/src/MoBi.UI/Views/IndividualBuildingBlockView.cs
+++ b/src/MoBi.UI/Views/IndividualBuildingBlockView.cs
@@ -7,6 +7,7 @@ using System.Windows.Forms;
 using DevExpress.XtraEditors;
 using DevExpress.XtraEditors.Controls;
 using DevExpress.XtraEditors.Repository;
+using DevExpress.XtraGrid.Views.Base;
 using DevExpress.XtraLayout;
 using DevExpress.XtraLayout.Utils;
 using MoBi.Presentation.DTO;
@@ -43,6 +44,7 @@ namespace MoBi.UI.Views
       private readonly PopupContainerControl _popupControl = new PopupContainerControl();
       private readonly RepositoryItemPopupContainerEdit _repositoryItemPopupContainerEdit = new RepositoryItemPopupContainerEdit();
       private LayoutControlGroup _flowGroup;
+      private RepositoryItemButtonEdit _isFixedParameterEditRepository;
 
       public IndividualBuildingBlockView(ValueOriginBinder<IndividualParameterDTO> valueOriginBinder)
       {
@@ -75,7 +77,23 @@ namespace MoBi.UI.Views
          base.InitializeBinding();
          initializeGridViewBinders();
          initializeValueOriginBinding();
+         createResetButtonItem();
+
+         _isFixedParameterEditRepository.ButtonClick += (_, _) => OnEvent(() => onResetValue(_gridViewBinder.FocusedElement));
       }
+
+      private void onResetValue(IndividualParameterDTO dto)
+      {
+         _presenter.ResetInitialState(dto);
+         gridView.CloseEditor();
+      }
+
+      private void createResetButtonItem()
+      {
+         _isFixedParameterEditRepository = new UxRepositoryItemButtonImage(ApplicationIcons.Reset, Assets.ToolTips.ResetParameterToolTip) { TextEditStyle = TextEditStyles.Standard };
+         _isFixedParameterEditRepository.Buttons[0].IsLeft = true;
+      }
+
 
       private void initializeValueOriginBinding()
       {
@@ -112,6 +130,7 @@ namespace MoBi.UI.Views
             .WithOnValueUpdating(onExpressionParameterValueSet)
             .WithFormat(dto => dto.IndividualParameterFormatter())
             .WithRepository(valueRepositoryFor)
+            .WithShowButton(ShowButtonModeEnum.ShowAlways)
             .WithEditorConfiguration(configureRepository);
 
          _unitControl.ParameterUnitSet += setParameterUnit;
@@ -129,6 +148,9 @@ namespace MoBi.UI.Views
       {
          if (parameterDTO.IsDistributed)
             return _repositoryItemPopupContainerEdit;
+
+         if (parameterDTO.HasInitialState)
+            return _isFixedParameterEditRepository;
 
          return _valueColumn.DefaultRepository();
       }

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -67,13 +67,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.75" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.76" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.75" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.75" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.76" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/Core/Commands/ChangeStartValueFormulaCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/ChangeStartValueFormulaCommandSpecs.cs
@@ -8,7 +8,7 @@ using OSPSuite.Core.Domain.Formulas;
 
 namespace MoBi.Core.Commands
 {
-   public abstract class concern_for_ChangeValueFormulaCommand<TCommand, TBuildingBlock, T> : ContextSpecification<TCommand> where T : PathAndValueEntity, IObjectBase, IUsingFormula where TCommand : ChangeValueFormulaCommand<T> where TBuildingBlock : IBuildingBlock<T>, new()
+   public abstract class concern_for_ChangeValueFormulaCommand<TCommand, TBuildingBlock, T> : ContextSpecification<TCommand> where T : PathAndValueEntity, IObjectBase, IUsingFormula, new() where TCommand : ChangeValueFormulaCommand<T> where TBuildingBlock : IBuildingBlock<T>, new()
    {
       protected IFormula _newFormula;
       protected IFormula _oldFormula;
@@ -19,10 +19,11 @@ namespace MoBi.Core.Commands
 
       protected override void Context()
       {
-         _changedBuilder = A.Fake<T>();
+         _changedBuilder = new T();
          _newFormula = new ExplicitFormula { Id = "newFormulaId" };
          _oldFormula = new ExplicitFormula { Id = "oldFormulaId" };
          _buildingBlock = GetBuildingBlock();
+         _changedBuilder.Formula = _oldFormula;
          sut = GetCommand();
 
          _context = A.Fake<IMoBiContext>();
@@ -52,10 +53,16 @@ namespace MoBi.Core.Commands
       {
          return new ChangeValueFormulaCommand<ExpressionParameter>(_buildingBlock, _changedBuilder, _newFormula, _oldFormula);
       }
+
+      [Observation]
+      public void the_initial_state_is_reset()
+      {
+         _changedBuilder.InitialFormulaId.ShouldBeNull();
+      }
    }
 
    abstract class When_inverting_a_formula_change_command<TCommand, TBuildingBlock, TBuilder> : concern_for_ChangeValueFormulaCommand<TCommand, TBuildingBlock, TBuilder> 
-      where TCommand : ChangeValueFormulaCommand<TBuilder> where TBuildingBlock : IBuildingBlock<TBuilder>, new() where TBuilder : PathAndValueEntity, IUsingFormula
+      where TCommand : ChangeValueFormulaCommand<TBuilder> where TBuildingBlock : IBuildingBlock<TBuilder>, new() where TBuilder : PathAndValueEntity, IUsingFormula, new()
    {
       protected override void Because()
       {
@@ -76,6 +83,12 @@ namespace MoBi.Core.Commands
       {
          return new ChangeValueFormulaCommand<ExpressionParameter>(_buildingBlock, _changedBuilder, _newFormula, _oldFormula);
       }
+
+      [Observation]
+      public void the_initial_state_is_captured()
+      {
+         _changedBuilder.InitialFormulaId.ShouldNotBeNull();
+      }
    }
 
    class executing_change_start_value_formula_command : executing_change_formula_command<ChangeValueFormulaCommand<InitialCondition>, InitialConditionsBuildingBlock, InitialCondition>
@@ -87,7 +100,7 @@ namespace MoBi.Core.Commands
    }
 
    abstract class executing_change_formula_command<TCommand, TBuildingBlock, TBuilder> : concern_for_ChangeValueFormulaCommand<TCommand, TBuildingBlock, TBuilder>
-      where TCommand : ChangeValueFormulaCommand<TBuilder> where TBuildingBlock : IBuildingBlock<TBuilder>, new() where TBuilder : PathAndValueEntity, IUsingFormula
+      where TCommand : ChangeValueFormulaCommand<TBuilder> where TBuildingBlock : IBuildingBlock<TBuilder>, new() where TBuilder : PathAndValueEntity, IUsingFormula, new()
    {
       private const string _newFormulaId = "new";
    

--- a/tests/MoBi.Tests/Core/Commands/ExpressionValueChangedCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/ExpressionValueChangedCommandSpecs.cs
@@ -4,6 +4,8 @@ using MoBi.Core.Extensions;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Core.Domain.UnitSystem;
 
 namespace MoBi.Core.Commands
 {
@@ -14,12 +16,14 @@ namespace MoBi.Core.Commands
       protected ExpressionParameter _expressionParameter;
       protected double? _oldValue;
       protected IMoBiContext _context;
+      protected IFormula _oldFormula;
 
       protected override void Context()
       {
          _newValue = 3.0;
-         _oldValue = null;
-         _expressionParameter = new ExpressionParameter { Value = _oldValue };
+         _oldValue = 2.0;
+         _oldFormula = new ExplicitFormula {Id = "formulaId"};
+         _expressionParameter = new ExpressionParameter { Value = _oldValue, Formula = _oldFormula, DisplayUnit = new Unit("unit", 1, 0)};
          _context = A.Fake<IMoBiContext>();
          _buildingBlock = new ExpressionProfileBuildingBlock
          {
@@ -43,6 +47,14 @@ namespace MoBi.Core.Commands
       {
          _expressionParameter.Value.ShouldBeEqualTo(_newValue);
       }
+
+      [Observation]
+      public void the_initial_state_should_be_set()
+      {
+         _expressionParameter.InitialValue.ShouldBeEqualTo(_oldValue);
+         _expressionParameter.InitialFormulaId.ShouldBeEqualTo(_oldFormula.Id);
+         _expressionParameter.InitialUnit.ShouldNotBeNull();
+      }
    }
 
    public class When_the_command_has_been_reversed : concern_for_ExpressionValueChangedCommand
@@ -64,6 +76,15 @@ namespace MoBi.Core.Commands
       public void the_expression_parameter_value_should_be_updated()
       {
          _expressionParameter.Value.ShouldBeEqualTo(_oldValue);
+      }
+
+      [Observation]
+      public void the_initial_state_should_be_reset()
+      {
+         _expressionParameter.InitialValue.ShouldBeNull();
+         _expressionParameter.InitialFormulaId.ShouldBeNull();
+         _expressionParameter.InitialUnit.ShouldBeNull();
+         _expressionParameter.HasInitialState.ShouldBeFalse();
       }
    }
 }

--- a/tests/MoBi.Tests/Core/Commands/ResetInitialStateCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/ResetInitialStateCommandSpecs.cs
@@ -1,0 +1,171 @@
+﻿using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Extensions;
+using MoBi.HelpersForTests;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Formulas;
+
+namespace MoBi.Core.Commands;
+
+internal class concern_for_ResetInitialStateCommand<TParameter, TBuildingBlock> : ContextSpecification<ResetInitialStateCommand<TParameter, TBuildingBlock>> where TParameter : ParameterValueWithInitialState, new() where TBuildingBlock : class, IBuildingBlock<TParameter>, new()
+{
+   protected TBuildingBlock _buildingBlock;
+   protected TParameter _builder;
+
+   protected override void Context()
+   {
+      _builder = new TParameter
+      {
+         Formula = null,
+         Dimension = DimensionFactoryForSpecs.MassDimension,
+         DisplayUnit = DimensionFactoryForSpecs.MassDimension.UnitAt(2),
+         Path = new ObjectPath("path"),
+         Value = 10
+      };
+      _buildingBlock = new TBuildingBlock().WithId("buildingBlockId");
+
+      _buildingBlock.AddFormula(new ExplicitFormula().WithId("formulaID"));
+
+      _builder.InitialValue = 4;
+      _builder.InitialFormulaId = "formulaID";
+      _builder.InitialUnit = DimensionFactoryForSpecs.MassDimension.DefaultUnit;
+
+      _buildingBlock.Add(_builder);
+      sut = new ResetInitialStateCommand<TParameter, TBuildingBlock>(_builder, _buildingBlock);
+   }
+}
+
+internal class When_reversing_the_reset_initial_state_command_for_expression : When_reversing_the_reset_initial_state_command<ExpressionParameter, ExpressionProfileBuildingBlock>
+{
+
+}
+
+internal class When_reversing_the_reset_initial_state_command_for_individual : When_reversing_the_reset_initial_state_command<IndividualParameter, IndividualBuildingBlock>
+{
+
+}
+
+internal class When_reversing_the_reset_initial_state_command<TParameter, TBuildingBlock> : concern_for_ResetInitialStateCommand<TParameter, TBuildingBlock> where TParameter : ParameterValueWithInitialState, new() where TBuildingBlock : class, IBuildingBlock<TParameter>, new()
+{
+   private IMoBiContext _context;
+
+   protected override void Context()
+   {
+      base.Context();
+      _context = A.Fake<IMoBiContext>();
+
+      A.CallTo(() => _context.Get<TBuildingBlock>(_buildingBlock.Id)).Returns(_buildingBlock);
+   }
+
+   protected override void Because()
+   {
+      sut.ExecuteAndInvokeInverse(_context);
+   }
+
+   [Observation]
+   public void the_value_should_be_restored_to_original()
+   {
+      _builder.Value.ShouldBeEqualTo(10);
+   }
+
+   [Observation]
+   public void the_unit_should_be_restored_to_original()
+   {
+      _builder.DisplayUnit.ShouldBeEqualTo(DimensionFactoryForSpecs.MassDimension.UnitAt(2));
+   }
+
+   [Observation]
+   public void the_formula_should_be_restored_to_null()
+   {
+      _builder.Formula.ShouldBeNull();
+   }
+
+   [Observation]
+   public void the_initial_value_should_be_restored()
+   {
+      _builder.InitialValue.ShouldBeEqualTo(4);
+   }
+
+   [Observation]
+   public void the_initial_unit_should_be_restored()
+   {
+      _builder.InitialUnit.ShouldBeEqualTo(DimensionFactoryForSpecs.MassDimension.DefaultUnit);
+   }
+
+   [Observation]
+   public void the_initial_formula_id_should_be_restored()
+   {
+      _builder.InitialFormulaId.ShouldBeEqualTo("formulaID");
+   }
+}
+
+internal class When_resetting_the_initial_state_for_expression : When_resetting_the_initial_state<ExpressionParameter, ExpressionProfileBuildingBlock>
+{
+
+}
+
+internal class When_resetting_the_initial_state_for_individual : When_resetting_the_initial_state<IndividualParameter, IndividualBuildingBlock>
+{
+
+}
+
+internal class When_resetting_the_initial_state<TParameter, TBuildingBlock> : concern_for_ResetInitialStateCommand<TParameter, TBuildingBlock> where TParameter : ParameterValueWithInitialState, new() where TBuildingBlock : class, IBuildingBlock<TParameter>, new()
+{
+   protected override void Context()
+   {
+      base.Context();
+      _builder.Value = 10;
+      _builder.Formula = null;
+      _builder.DisplayUnit = DimensionFactoryForSpecs.MassDimension.UnitAt(2);
+   }
+
+   protected override void Because()
+   {
+      sut.RunCommand(A.Fake<IMoBiContext>());
+   }
+
+   [Observation]
+   public void the_unit_should_be_reset()
+   {
+      _builder.DisplayUnit.ShouldBeEqualTo(DimensionFactoryForSpecs.MassDimension.DefaultUnit);
+   }
+
+   [Observation]
+   public void the_value_should_be_reset()
+   {
+      _builder.Value.ShouldBeEqualTo(4);
+   }
+
+   [Observation]
+   public void the_formula_should_be_reset()
+   {
+      _builder.Formula.Id.ShouldBeEqualTo("formulaID");
+   }
+
+   [Observation]
+   public void the_initial_value_should_be_cleared()
+   {
+      _builder.InitialValue.ShouldBeNull();
+   }
+
+   [Observation]
+   public void the_initial_unit_should_be_cleared()
+   {
+      _builder.InitialUnit.ShouldBeNull();
+   }
+
+   [Observation]
+   public void the_initial_formula_id_should_be_cleared()
+   {
+      _builder.InitialFormulaId.ShouldBeNull();
+   }
+
+   [Observation]
+   public void the_formula_should_remain_unchanged()
+   {
+      _builder.Formula.Id.ShouldBeEqualTo("formulaID");
+   }
+}

--- a/tests/MoBi.Tests/Core/Commands/ResetInitialStateCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/ResetInitialStateCommandSpecs.cs
@@ -162,10 +162,4 @@ internal class When_resetting_the_initial_state<TParameter, TBuildingBlock> : co
    {
       _builder.InitialFormulaId.ShouldBeNull();
    }
-
-   [Observation]
-   public void the_formula_should_remain_unchanged()
-   {
-      _builder.Formula.Id.ShouldBeEqualTo("formulaID");
-   }
 }

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.75" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.76" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForExpressionProfileBuildingBlockSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForExpressionProfileBuildingBlockSpecs.cs
@@ -155,6 +155,12 @@ namespace MoBi.Presentation.Tasks
          {
             A.CallTo(() => _pkSimStarter.UpdateExpressionProfileFromDatabase(_buildingBlock)).MustHaveHappened();
          }
+
+         [Observation]
+         public void the_initial_state_should_not_be_set()
+         {
+            _expressionParameter.HasInitialState.ShouldBeFalse();
+         }
       }
 
       public class When_cloning_an_expression_profile : concern_for_InteractionTasksForExpressionProfileBuildingBlock
@@ -261,7 +267,6 @@ namespace MoBi.Presentation.Tasks
             _clonedBuildingBlock.Add(_clonedParameter);
             A.CallTo(() => _interactionTaskContext.Context.Resolve<IEditFormulaInPathAndValuesPresenter>()).Returns(_editFormulaPresenter);
             A.CallTo(() => _cloneManager.Clone(_buildingBlock)).Returns(_clonedBuildingBlock);
-
          }
 
          protected override void Because()

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.75" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.75" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.76" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.76" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #1560

# Description
Implementing the initial state capture and reset for Individual and Expression parameters

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
<img width="881" height="455" alt="image" src="https://github.com/user-attachments/assets/5dbf04b8-0954-43a5-8218-31127ee13c0c" />

# Questions (if appropriate):