### PR TITLE
Fixes #2187 Automatic rename of like-named reactions

### DIFF
--- a/src/MoBi.Presentation/Tasks/CheckNameVisitor.cs
+++ b/src/MoBi.Presentation/Tasks/CheckNameVisitor.cs
@@ -210,7 +210,7 @@ namespace MoBi.Presentation.Tasks
       private void checkObjectBase<T>(T objectBase) where T : IObjectBase
       {
          if (objectBase.IsAnImplementationOf<IContainer>())
-            checkTagsInContainer((IContainer) objectBase);
+            checkTagsInContainer((IContainer)objectBase);
 
          if (_objectToRename.Equals(objectBase))
             return;
@@ -223,7 +223,7 @@ namespace MoBi.Presentation.Tasks
 
       private string renameDescription(IObjectBase objectBase, string oldName, string newName, string propertyName) =>
         AppConstants.Commands.EditDescription(_objectTypeResolver.TypeFor(objectBase), propertyName, oldName, newName, objectBase.Name);
-      
+
       private void checkTagsInContainer(IContainer container)
       {
          //Check Name Tags!
@@ -251,12 +251,12 @@ namespace MoBi.Presentation.Tasks
          checkObjectBase(transportBuilder);
          if (transportBuilder.MoleculeNames().Contains(_oldName))
          {
-            _changes.Add(transportBuilder, new ChangeMoleculeNameAtMoleculeDependentBuilderCommand(_newName, _oldName, transportBuilder, _buildingBlock) {ObjectType = objectType});
+            _changes.Add(transportBuilder, new ChangeMoleculeNameAtMoleculeDependentBuilderCommand(_newName, _oldName, transportBuilder, _buildingBlock) { ObjectType = objectType });
          }
 
          if (transportBuilder.MoleculeNamesToExclude().Contains(_oldName))
          {
-            _changes.Add(transportBuilder, new ChangeExcludeMoleculeNameAtMoleculeDependentBuilderCommand(_newName, _oldName, transportBuilder, _buildingBlock) {ObjectType = objectType});
+            _changes.Add(transportBuilder, new ChangeExcludeMoleculeNameAtMoleculeDependentBuilderCommand(_newName, _oldName, transportBuilder, _buildingBlock) { ObjectType = objectType });
          }
       }
 
@@ -273,7 +273,7 @@ namespace MoBi.Presentation.Tasks
             if (!string.Equals(tagCondition.Tag, _oldName))
                continue;
 
-            var commandParameters = new TagConditionCommandParameters<T> {TaggedObject = taggedObject, BuildingBlock = _buildingBlock, DescriptorCriteriaRetriever = descriptorCriteriaRetriever};
+            var commandParameters = new TagConditionCommandParameters<T> { TaggedObject = taggedObject, BuildingBlock = _buildingBlock, DescriptorCriteriaRetriever = descriptorCriteriaRetriever };
             _changes.Add(taggedObject, new EditTagCommand<T>(_newName, _oldName, commandParameters));
          }
       }
@@ -296,13 +296,10 @@ namespace MoBi.Presentation.Tasks
 
       private void renameReactionForMoleculeName(ReactionBuilder reaction)
       {
-         if (!(_objectToRename is MoleculeBuilder))
+         if (!(_objectToRename is MoleculeBuilder) || !reaction.Name.Contains(_oldName))
             return;
 
-         if (!containsWord(reaction.Name, _oldName))
-            return;
-
-         var newName = wordReplace(reaction.Name, _oldName, _newName);
+         var newName = reaction.Name.Replace(_oldName, _newName);
          _changes.Add(reaction, new RenameObjectBaseCommand(reaction, newName, _buildingBlock));
       }
 
@@ -435,7 +432,7 @@ namespace MoBi.Presentation.Tasks
       public void Visit(TransporterMoleculeContainer transporterMoleculeContainer)
       {
          checkObjectBase(transporterMoleculeContainer);
-         if (!string.Equals(_oldName, transporterMoleculeContainer.TransportName)) 
+         if (!string.Equals(_oldName, transporterMoleculeContainer.TransportName))
             return;
 
          _changes.Add(transporterMoleculeContainer,

--- a/src/MoBi.Presentation/Tasks/CheckNameVisitor.cs
+++ b/src/MoBi.Presentation/Tasks/CheckNameVisitor.cs
@@ -296,7 +296,8 @@ namespace MoBi.Presentation.Tasks
 
       private void renameReactionForMoleculeName(ReactionBuilder reaction)
       {
-         if (!(_objectToRename is MoleculeBuilder) || !reaction.Name.Contains(_oldName))
+         // Only rename if the reaction name contains the old name but is not exactly equal to it. There is a preceding rename for that.
+         if (!(_objectToRename is MoleculeBuilder) || !reaction.Name.Contains(_oldName) || reaction.Name.Equals(_oldName))
             return;
 
          var newName = reaction.Name.Replace(_oldName, _newName);

--- a/src/MoBi.Presentation/Tasks/CheckNameVisitor.cs
+++ b/src/MoBi.Presentation/Tasks/CheckNameVisitor.cs
@@ -63,16 +63,16 @@ namespace MoBi.Presentation.Tasks
       private readonly string _transportNamePropertyName;
       private string _oldName;
       private readonly IParameterValuePathTask _parameterValuePathTask;
-      private readonly IInitialConditionPathTask _msvPathTask;
+      private readonly IInitialConditionPathTask _initialConditionPathTask;
       private readonly ICloneManager _cloneManager;
       private StringChanges _changes;
 
-      public CheckNameVisitor(IObjectTypeResolver objectTypeResolver, IAliasCreator aliasCreator, IParameterValuePathTask parameterValuePathTask, IInitialConditionPathTask msvPathTask, ICloneManager cloneManager)
+      public CheckNameVisitor(IObjectTypeResolver objectTypeResolver, IAliasCreator aliasCreator, IParameterValuePathTask parameterValuePathTask, IInitialConditionPathTask initialConditionPathTask, ICloneManager cloneManager)
       {
          _objectTypeResolver = objectTypeResolver;
          _aliasCreator = aliasCreator;
          _parameterValuePathTask = parameterValuePathTask;
-         _msvPathTask = msvPathTask;
+         _initialConditionPathTask = initialConditionPathTask;
          _cloneManager = cloneManager;
 
          Expression<Func<IObjectBase, string>> nameString = x => x.Name;
@@ -290,7 +290,17 @@ namespace MoBi.Presentation.Tasks
          checkReactionPartnerIn(reaction.Educts, reaction, educt: true);
          checkReactionPartnerIn(reaction.Products, reaction, educt: false);
          checkModifier(reaction);
+         renameReactionForMoleculeName(reaction);
          checkDescriptorCriteria(reaction, x => x.ContainerCriteria);
+      }
+
+      private void renameReactionForMoleculeName(ReactionBuilder reaction)
+      {
+         if (!(_objectToRename is MoleculeBuilder) || !reaction.Name.Contains(_oldName))
+            return;
+
+         var newName = reaction.Name.Replace(_oldName, _newName);
+         _changes.Add(reaction, new RenameObjectBaseCommand(reaction, newName, _buildingBlock));
       }
 
       private void checkModifier(ReactionBuilder reaction)
@@ -432,7 +442,7 @@ namespace MoBi.Presentation.Tasks
 
       public void Visit(InitialCondition initialCondition)
       {
-         checkPathAndValueEntity(initialCondition, _msvPathTask);
+         checkPathAndValueEntity(initialCondition, _initialConditionPathTask);
       }
 
       public void Visit(ParameterValue parameterValue)

--- a/src/MoBi.Presentation/Tasks/CheckNameVisitor.cs
+++ b/src/MoBi.Presentation/Tasks/CheckNameVisitor.cs
@@ -296,10 +296,13 @@ namespace MoBi.Presentation.Tasks
 
       private void renameReactionForMoleculeName(ReactionBuilder reaction)
       {
-         if (!(_objectToRename is MoleculeBuilder) || !reaction.Name.Contains(_oldName))
+         if (!(_objectToRename is MoleculeBuilder))
             return;
 
-         var newName = reaction.Name.Replace(_oldName, _newName);
+         if (!containsWord(reaction.Name, _oldName))
+            return;
+
+         var newName = wordReplace(reaction.Name, _oldName, _newName);
          _changes.Add(reaction, new RenameObjectBaseCommand(reaction, newName, _buildingBlock));
       }
 

--- a/tests/MoBi.Tests/Core/CheckNameVisitorSpecs.cs
+++ b/tests/MoBi.Tests/Core/CheckNameVisitorSpecs.cs
@@ -54,6 +54,44 @@ namespace MoBi.Core
       }
    }
 
+   internal class When_renaming_a_molecule_builder : concern_for_CheckNameVisitor
+   {
+      private MoleculeBuildingBlock _moleculeBuildingBlock;
+      private IReadOnlyList<IStringChange> _changes;
+      private ReactionBuilder _reaction;
+      private Module _module;
+
+      protected override void Context()
+      {
+         base.Context();
+         _moleculeBuildingBlock = new MoleculeBuildingBlock();
+         var builder = new MoleculeBuilder();
+         _moleculeBuildingBlock.Add(builder);
+         _changedObject = builder;
+         _changedObject.Name = _changedName;
+         _changedName = _changedObject.Name;
+         _newName = "new";
+         _reaction = new ReactionBuilder().WithName($"{_changedName}_reaction");
+
+         _module = new Module
+         {
+            _moleculeBuildingBlock,
+            new MoBiReactionBuildingBlock { _reaction }
+         };
+      }
+
+      protected override void Because()
+      {
+         _changes = sut.GetPossibleChangesFrom(_changedObject, _newName, _module.Reactions, _changedName);
+      }
+
+      [Observation]
+      public void a_rename_reaction_should_occur()
+      {
+         _changes.OfType<StringChange<ReactionBuilder>>().Count(x => x.EntityToEdit.Equals(_reaction) && x.ChangeCommand.IsAnImplementationOf<RenameObjectBaseCommand>()).ShouldBeEqualTo(1);
+      }
+   }
+
    internal class When_visiting_an_objectBase_with_changed_Name : concern_for_CheckNameVisitor
    {
       private IContainer _objectBase;
@@ -95,7 +133,7 @@ namespace MoBi.Core
          base.Context();
          _formula = new ExplicitFormula();
          _formula.Name = _changedName;
-         _path = new FormulaUsablePath(new[] {"A", "B", _changedName}) {Alias = _changedName};
+         _path = new FormulaUsablePath(new[] { "A", "B", _changedName }) { Alias = _changedName };
          A.CallTo(() => _aliasCreator.CreateAliasFrom(_changedName)).Returns(_changedName);
          A.CallTo(() => _aliasCreator.CreateAliasFrom(_newName)).Returns(_newName);
          _formula.AddObjectPath(_path);
@@ -150,16 +188,16 @@ namespace MoBi.Core
       {
          base.Context();
          _module = new Module();
-         _initialConditionsBuildingBlock = new InitialConditionsBuildingBlock {Name = _changedName};
+         _initialConditionsBuildingBlock = new InitialConditionsBuildingBlock { Name = _changedName };
          _initialCondition = new InitialCondition();
-         _path = new ObjectPath(new[] {"A", "B", _changedName});
+         _path = new ObjectPath(new[] { "A", "B", _changedName });
          _initialCondition.Path = _path;
          _initialConditionsBuildingBlock.Add(_initialCondition);
 
          _module.Add(_initialConditionsBuildingBlock);
 
          _initialCondition2 = new InitialCondition();
-         _path = new ObjectPath(new[] {"A", _changedName, "B"});
+         _path = new ObjectPath(new[] { "A", _changedName, "B" });
          _initialCondition2.Path = _path;
          _initialConditionsBuildingBlock.Add(_initialCondition2);
       }
@@ -216,11 +254,11 @@ namespace MoBi.Core
             Name = _changedName
          };
          _parameterValue = new ParameterValue();
-         _path = new ObjectPath(new[] {"A", "B", _changedName});
+         _path = new ObjectPath(new[] { "A", "B", _changedName });
          _parameterValue.Path = _path;
          _parameterValuesBuildingBlock.Add(_parameterValue);
          _parameterValue2 = new ParameterValue();
-         _path = new ObjectPath(new[] {"A", _changedName, "B"});
+         _path = new ObjectPath(new[] { "A", _changedName, "B" });
          _parameterValue2.Path = _path;
          _parameterValuesBuildingBlock.Add(_parameterValue2);
          _module.Add(_parameterValuesBuildingBlock);
@@ -277,9 +315,9 @@ namespace MoBi.Core
          _changedName = _changedObject.Name;
          _oldAlias = "Name_really_old";
          _theFormula = new ExplicitFormula(String.Format("k_{0}*{0}", _oldAlias));
-         _formulaUsablePathNotToChange = new FormulaUsablePath(new[] {ObjectPath.PARENT_CONTAINER, "BLA", String.Format("k_{0}", _oldAlias)}) {Alias = String.Format("k_{0}", _oldAlias)};
+         _formulaUsablePathNotToChange = new FormulaUsablePath(new[] { ObjectPath.PARENT_CONTAINER, "BLA", String.Format("k_{0}", _oldAlias) }) { Alias = String.Format("k_{0}", _oldAlias) };
          _theFormula.AddObjectPath(_formulaUsablePathNotToChange);
-         _formulaUsablePathToChange = new FormulaUsablePath(new[] {ObjectPath.PARENT_CONTAINER, _changedName}) {Alias = _oldAlias};
+         _formulaUsablePathToChange = new FormulaUsablePath(new[] { ObjectPath.PARENT_CONTAINER, _changedName }) { Alias = _oldAlias };
          _theFormula.AddObjectPath(_formulaUsablePathToChange);
          _theFormula.Name = "F1";
          A.CallTo(() => _aliasCreator.CreateAliasFrom(_changedName)).Returns(_oldAlias);
@@ -486,8 +524,8 @@ namespace MoBi.Core
          _simulationSettings.AddChartTemplate(_curveChartTemplate);
          _curveTemplate = new CurveTemplate
          {
-            xData = {Path = $"A|B|{_oldName}"},
-            yData = {Path = $"C|D|{_oldName}"},
+            xData = { Path = $"A|B|{_oldName}" },
+            yData = { Path = $"C|D|{_oldName}" },
          };
          _curveChartTemplate.Curves.Add(_curveTemplate);
 
@@ -528,8 +566,8 @@ namespace MoBi.Core
          _simulationSettings.AddChartTemplate(_curveChartTemplate);
          _curveChartTemplate.Curves.Add(new CurveTemplate
          {
-            xData = {Path = "A|B|D"},
-            yData = {Path = "C|D|E"}
+            xData = { Path = "A|B|D" },
+            yData = { Path = "C|D|E" }
          });
       }
 

--- a/tests/MoBi.Tests/Core/CheckNameVisitorSpecs.cs
+++ b/tests/MoBi.Tests/Core/CheckNameVisitorSpecs.cs
@@ -54,7 +54,7 @@ namespace MoBi.Core
       }
    }
 
-   internal class When_renaming_a_molecule_builder : concern_for_CheckNameVisitor
+   internal class When_renaming_a_molecule_builder_and_reaction_has_the_name_within : concern_for_CheckNameVisitor
    {
       private MoleculeBuildingBlock _moleculeBuildingBlock;
       private IReadOnlyList<IStringChange> _changes;
@@ -72,6 +72,82 @@ namespace MoBi.Core
          _changedName = _changedObject.Name;
          _newName = "new";
          _reaction = new ReactionBuilder().WithName($"{_changedName}_reaction");
+
+         _module = new Module
+         {
+            _moleculeBuildingBlock,
+            new MoBiReactionBuildingBlock { _reaction }
+         };
+      }
+
+      protected override void Because()
+      {
+         _changes = sut.GetPossibleChangesFrom(_changedObject, _newName, _module.Reactions, _changedName);
+      }
+
+      [Observation]
+      public void a_rename_reaction_should_occur()
+      {
+         _changes.OfType<StringChange<ReactionBuilder>>().Count(x => x.EntityToEdit.Equals(_reaction) && x.ChangeCommand.IsAnImplementationOf<RenameObjectBaseCommand>()).ShouldBeEqualTo(1);
+      }
+   }
+
+   internal class When_renaming_a_molecule_builder_and_reaction_has_the_same_name_more_than_once : concern_for_CheckNameVisitor
+   {
+      private MoleculeBuildingBlock _moleculeBuildingBlock;
+      private IReadOnlyList<IStringChange> _changes;
+      private ReactionBuilder _reaction;
+      private Module _module;
+
+      protected override void Context()
+      {
+         base.Context();
+         _moleculeBuildingBlock = new MoleculeBuildingBlock();
+         var builder = new MoleculeBuilder();
+         _moleculeBuildingBlock.Add(builder);
+         _changedObject = builder;
+         _changedObject.Name = _changedName;
+         _changedName = _changedObject.Name;
+         _newName = "new";
+         _reaction = new ReactionBuilder().WithName($"{_changedName}{_changedName}");
+
+         _module = new Module
+         {
+            _moleculeBuildingBlock,
+            new MoBiReactionBuildingBlock { _reaction }
+         };
+      }
+
+      protected override void Because()
+      {
+         _changes = sut.GetPossibleChangesFrom(_changedObject, _newName, _module.Reactions, _changedName);
+      }
+
+      [Observation]
+      public void a_rename_reaction_should_occur()
+      {
+         _changes.OfType<StringChange<ReactionBuilder>>().Count(x => x.EntityToEdit.Equals(_reaction) && x.ChangeCommand.IsAnImplementationOf<RenameObjectBaseCommand>()).ShouldBeEqualTo(1);
+      }
+   }
+
+   internal class When_renaming_a_molecule_builder_and_reaction_has_the_same_name : concern_for_CheckNameVisitor
+   {
+      private MoleculeBuildingBlock _moleculeBuildingBlock;
+      private IReadOnlyList<IStringChange> _changes;
+      private ReactionBuilder _reaction;
+      private Module _module;
+
+      protected override void Context()
+      {
+         base.Context();
+         _moleculeBuildingBlock = new MoleculeBuildingBlock();
+         var builder = new MoleculeBuilder();
+         _moleculeBuildingBlock.Add(builder);
+         _changedObject = builder;
+         _changedObject.Name = _changedName;
+         _changedName = _changedObject.Name;
+         _newName = "new";
+         _reaction = new ReactionBuilder().WithName($"{_changedName}");
 
          _module = new Module
          {


### PR DESCRIPTION
Fixes #2187

# Description
Reactions that contain exactly the name of a renamed molecule will have the old molecule name replaced with the new molecule name.

We are not using regex to test the string because this will not handle cases where the word is camel cased, or surrounded with `_`.

The best option is to propose the change and the user can confirm or exclude it.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):