### PR TITLE
#2207 value 0 when adding initial conditions

### DIFF
--- a/src/MoBi.Presentation/Presenter/ExtendablePathAndValueBuildingBlockPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ExtendablePathAndValueBuildingBlockPresenter.cs
@@ -34,9 +34,9 @@ namespace MoBi.Presentation.Presenter
    {
       protected readonly IPathAndValueEntityToPathAndValueEntityDTOMapper<TPathAndValueEntity, TStartValueDTO> _valueMapper;
 
-      private readonly IInteractionTasksForExtendablePathAndValueEntity<TBuildingBlock, TPathAndValueEntity> _interactionTasksForExtendablePathAndValueEntity;
+      protected readonly IInteractionTasksForExtendablePathAndValueEntity<TBuildingBlock, TPathAndValueEntity> _interactionTasksForExtendablePathAndValueEntity;
       protected BindingList<TStartValueDTO> _startValueDTOs;
-      private readonly IEmptyStartValueCreator<TPathAndValueEntity> _emptyStartValueCreator;
+      protected readonly IEmptyStartValueCreator<TPathAndValueEntity> _emptyStartValueCreator;
       protected readonly IMoBiContext _context;
       private bool _handleChangedEvents;
       private TPathAndValueEntity _focusedStartValue;
@@ -134,7 +134,7 @@ namespace MoBi.Presentation.Presenter
 
       protected abstract IReadOnlyList<TStartValueDTO> ValueDTOsFor(TBuildingBlock buildingBlock);
 
-      private void bindToView()
+      protected void bindToView()
       {
          _view.BindTo(_startValueDTOs);
       }
@@ -218,7 +218,7 @@ namespace MoBi.Presentation.Presenter
          _handleChangedEvents = false;
       }
 
-      public TStartValueDTO AddNewEmptyPathAndValueEntity()
+      public virtual TStartValueDTO AddNewEmptyPathAndValueEntity()
       {
          var newParameterValue = _emptyStartValueCreator.CreateEmptyStartValue(_interactionTasksForExtendablePathAndValueEntity.GetDefaultDimension());
          var newRecord = _valueMapper.MapFrom(newParameterValue, _buildingBlock);

--- a/src/MoBi.Presentation/Presenter/InitialConditionsPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/InitialConditionsPresenter.cs
@@ -13,7 +13,6 @@ namespace MoBi.Presentation.Presenter
 {
    public interface IInitialConditionsPresenter : IBuildingBlockWithInitialConditionsPresenter<InitialConditionsBuildingBlock>
    {
-
    }
 
    public class InitialConditionsPresenter : BuildingBlockWithInitialConditionsPresenter<
@@ -43,5 +42,16 @@ namespace MoBi.Presentation.Presenter
       protected override void SelectEntity(InitialConditionDTO dto) => _view.Select(dto);
 
       protected override InitialConditionDTO DTOForBuilder(InitialCondition builder) => _startValueDTOs.FirstOrDefault(x => Equals(x.PathWithValueObject, builder));
+
+      public override InitialConditionDTO AddNewEmptyPathAndValueEntity()
+      {
+         var newParameterValue = _emptyStartValueCreator.CreateEmptyStartValue(_interactionTasksForExtendablePathAndValueEntity.GetDefaultDimension());
+         newParameterValue.Value = 0;
+         var newRecord = _valueMapper.MapFrom(newParameterValue, _buildingBlock);
+         _startValueDTOs.Insert(0, newRecord);
+         bindToView();
+
+         return newRecord;
+      }
    }
 }

--- a/tests/MoBi.Tests/IntegrationTests/ContextForIntegration.cs
+++ b/tests/MoBi.Tests/IntegrationTests/ContextForIntegration.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Threading;
-using Castle.Facilities.TypedFactory;
+﻿using Castle.Facilities.TypedFactory;
 using FakeItEasy;
 using MoBi.Assets;
 using MoBi.Core;
@@ -14,6 +11,7 @@ using MoBi.Core.Services;
 using MoBi.Engine;
 using MoBi.Helpers;
 using MoBi.Presentation;
+using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Serialization;
 using MoBi.Presentation.Settings;
@@ -37,6 +35,9 @@ using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Exceptions;
 using OSPSuite.Utility.Extensions;
 using OSPSuite.Utility.FileLocker;
+using System;
+using System.IO;
+using System.Threading;
 using CoreRegister = OSPSuite.Core.CoreRegister;
 using IContainer = OSPSuite.Utility.Container.IContainer;
 

--- a/tests/MoBi.Tests/Presentation/InitialConditionsPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/InitialConditionsPresenterSpecs.cs
@@ -1,6 +1,7 @@
-﻿using FakeItEasy;
+﻿using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
 using MoBi.Assets;
-using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
 using MoBi.Core.Mappers;
@@ -18,8 +19,6 @@ using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Domain.UnitSystem;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace MoBi.Presentation
 {
@@ -53,8 +52,8 @@ namespace MoBi.Presentation
          _buildingBlockMapper = new InitialConditionsBuildingBlockToInitialConditionsBuildingBlockDTOMapper(_dtoMapper, _mapper);
 
          sut = new InitialConditionsPresenter(
-               _view, _dtoMapper, _initialConditionTask,
-               _initialConditionsCreator, _context, _formulaToValueFormulaDTOMapper, _dimensionFactory, _distributedParameterPresenter, _buildingBlockMapper);
+            _view, _dtoMapper, _initialConditionTask,
+            _initialConditionsCreator, _context, _formulaToValueFormulaDTOMapper, _dimensionFactory, _distributedParameterPresenter, _buildingBlockMapper);
          _initialConditionsBuildingBlock = new InitialConditionsBuildingBlock();
 
          sut.InitializeWith(_commandCollector);
@@ -89,10 +88,18 @@ namespace MoBi.Presentation
    public class When_adding_a_new_empty_start_value : concern_for_InitialConditionsPresenter
    {
       private IDimension _defaultDimension;
+      private InitialConditionDTO _initialConditionDTO;
 
       protected override void Context()
       {
          base.Context();
+         //for this test, the real mapper is required, otherwise if I fake it, the test becomes meaningless
+         var realMapper = new InitialConditionToInitialConditionDTOMapper(new FormulaToValueFormulaDTOMapper());
+         A.CallTo(() => _dtoMapper.MapFrom(
+               A<InitialCondition>._,
+               A<IBuildingBlock<InitialCondition>>._))
+            .ReturnsLazily((InitialCondition ic, IBuildingBlock<InitialCondition> bb) =>
+               realMapper.MapFrom(ic, bb));
          sut.Edit(_initialConditionsBuildingBlock);
          _defaultDimension = A.Fake<IDimension>();
          A.CallTo(() => _initialConditionTask.GetDefaultDimension()).Returns(_defaultDimension);
@@ -100,13 +107,19 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.AddNewEmptyPathAndValueEntity();
+         _initialConditionDTO = sut.AddNewEmptyPathAndValueEntity();
       }
 
       [Observation]
       public void the_start_value_creator_should_create_the_empty_start_value()
       {
          A.CallTo(() => _initialConditionsCreator.CreateEmptyStartValue(_initialConditionTask.GetDefaultDimension())).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_value_after_creation_should_be_zero()
+      {
+         _initialConditionDTO.Value.ShouldBeEqualTo(0);
       }
    }
 


### PR DESCRIPTION
Fixes Open-Systems-Pharmacology/OSPSuite.Core#2743

# Description

When adding a new initial condition, the value should be 0.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [ ] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):