### PR TITLE
Fixes #2186 Rename reaction on load should update formula paths

### DIFF
--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -266,16 +266,8 @@ namespace MoBi.Presentation.Tasks.Interaction
          if (string.Equals(oldName, newName))
             return;
 
-         switch (objectBase)
-         {
-            case IUsingFormula usingFormula:
-               if(usingFormula.Formula != null)
-                  correctFormulaPathsForRename(oldName, newName, usingFormula.Formula);
-               break;
-            case IFormula formula:
-               formula.ObjectPaths.Each(x => x.Replace(oldName, newName));
-               break;
-         }
+         if (objectBase is IUsingFormula usingFormula) 
+            usingFormula.Formula?.ObjectPaths.Each(x => x.Replace(oldName, newName));
 
          if (!(objectBase is IContainer container))
             return;

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -266,22 +266,24 @@ namespace MoBi.Presentation.Tasks.Interaction
          if (string.Equals(oldName, newName))
             return;
 
-         if (objectBase is IUsingFormula usingFormula) 
-            usingFormula.Formula?.ObjectPaths.Each(x => x.Replace(oldName, newName));
+         var objects = objectsToCorrect(objectBase);
 
-         if (!(objectBase is IContainer container))
-            return;
+         objects.Each(x =>
+         {
+            if (x is IUsingFormula usingFormula)
+               usingFormula.Formula?.ObjectPaths.Each(path => path.Replace(oldName, newName));
+         });
+      }
 
+      private static List<IObjectBase> objectsToCorrect(IObjectBase objectBase)
+      {
          var children = new List<IObjectBase>();
 
-         // Correct child parameters of the container
-         children.AddRange(container.GetAllChildren<IParameter>());
-
-         // Recurse containers to check their parameters
-         children.AddRange(container.GetAllChildren<IContainer>());
-
-         // Distinct to remove duplicates (e.g., parameters that are also containers)
-         children.Distinct().Each(x => correctFormulaPathsForRename(oldName, newName, x));
+         if (objectBase is IContainer container)
+            children.AddRange(container.GetAllChildrenAndSelf<IEntity>());
+         else
+            children.Add(objectBase);
+         return children;
       }
 
       /// <summary>
@@ -296,23 +298,23 @@ namespace MoBi.Presentation.Tasks.Interaction
          if (string.Equals(oldName, newName))
             return;
 
-         if (objectBase is IEntity entity)
-            entity.Tags.Replace(oldName, newName);
+         var objects = objectsToCorrect(objectBase);
 
-         if (!(objectBase is IContainer container))
-            return;
-
-         // Recurse containers to check their tags and their children tags
-         container.GetAllChildren<IEntity>().Each(x => correctTagsForRename(oldName, newName, x));
-         switch (container)
+         objects.Each(x =>
          {
-            case TransportBuilder transportBuilder:
-               correctTransportBuilderTags(oldName, newName, transportBuilder);
-               break;
-            case ApplicationBuilder applicationBuilder:
-               correctApplicationBuilderMolecules(oldName, newName, applicationBuilder);
-               break;
-         }
+            if (x is IEntity entity)
+               entity.Tags.Replace(oldName, newName);
+
+            switch (x)
+            {
+               case TransportBuilder transportBuilder:
+                  correctTransportBuilderTags(oldName, newName, transportBuilder);
+                  break;
+               case ApplicationBuilder applicationBuilder:
+                  correctApplicationBuilderMolecules(oldName, newName, applicationBuilder);
+                  break;
+            }
+         });
       }
 
       private void correctApplicationBuilderMolecules(string oldName, string newName, ApplicationBuilder applicationBuilder)

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -255,7 +255,7 @@ namespace MoBi.Presentation.Tasks.Interaction
       }
 
       /// <summary>
-      /// Corrects formula paths in all subcontainers when an object is renamed before it is added to the project.
+      /// Corrects formula paths in all sub-containers when an object is renamed before it is added to the project.
       /// Commands are not used here since the object is not yet part of the project
       /// </summary>
       /// <param name="oldName">The original object name</param>
@@ -287,7 +287,7 @@ namespace MoBi.Presentation.Tasks.Interaction
       }
 
       /// <summary>
-      /// Updates in all subcontainers name tags from the specified old name to the new name before it is added to the project
+      /// Updates name tags in all sub-containers from the specified old name to the new name before it is added to the project
       /// Commands are not used here since the object is not yet part of the project
       /// </summary>
       /// <param name="oldName">The tag name to be replaced</param>

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -255,7 +255,7 @@ namespace MoBi.Presentation.Tasks.Interaction
       }
 
       /// <summary>
-      /// Recursively corrects formula paths when an object is renamed before it is added to the project.
+      /// Corrects formula paths in all subcontainers when an object is renamed before it is added to the project.
       /// Commands are not used here since the object is not yet part of the project
       /// </summary>
       /// <param name="oldName">The original object name</param>
@@ -287,7 +287,7 @@ namespace MoBi.Presentation.Tasks.Interaction
       }
 
       /// <summary>
-      /// Recursively updates name tags from the specified old name to the new name before it is added to the project
+      /// Updates in all subcontainers name tags from the specified old name to the new name before it is added to the project
       /// Commands are not used here since the object is not yet part of the project
       /// </summary>
       /// <param name="oldName">The tag name to be replaced</param>

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -269,7 +269,8 @@ namespace MoBi.Presentation.Tasks.Interaction
          switch (objectBase)
          {
             case IUsingFormula usingFormula:
-               correctFormulaPathsForRename(oldName, newName, usingFormula.Formula);
+               if(usingFormula.Formula != null)
+                  correctFormulaPathsForRename(oldName, newName, usingFormula.Formula);
                break;
             case IFormula formula:
                formula.ObjectPaths.Each(x => x.Replace(oldName, newName));
@@ -279,11 +280,16 @@ namespace MoBi.Presentation.Tasks.Interaction
          if (!(objectBase is IContainer container))
             return;
 
+         var children = new List<IObjectBase>();
+
          // Correct child parameters of the container
-         container.GetAllChildren<IParameter>().Each(x => correctFormulaPathsForRename(oldName, newName, x));
+         children.AddRange(container.GetAllChildren<IParameter>());
 
          // Recurse containers to check their parameters
-         container.GetAllChildren<IContainer>().Each(x => correctFormulaPathsForRename(oldName, newName, x));
+         children.AddRange(container.GetAllChildren<IContainer>());
+
+         // Distinct to remove duplicates (e.g., parameters that are also containers)
+         children.Distinct().Each(x => correctFormulaPathsForRename(oldName, newName, x));
       }
 
       /// <summary>

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTaskFor.cs
@@ -9,6 +9,7 @@ using MoBi.Presentation.Tasks.Edit;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Services;
 using OSPSuite.Utility.Extensions;
 using IBuildingBlockRepository = MoBi.Core.Domain.Repository.IBuildingBlockRepository;
@@ -233,6 +234,7 @@ namespace MoBi.Presentation.Tasks.Interaction
             return new MoBiEmptyCommand();
 
          correctTagsForRename(oldName, childToAdd.Name, childToAdd);
+         correctFormulaPathsForRename(oldName, childToAdd.Name, childToAdd);
 
          var macroCommand = new MoBiMacroCommand
          {
@@ -252,6 +254,45 @@ namespace MoBi.Presentation.Tasks.Interaction
          return macroCommand;
       }
 
+      /// <summary>
+      /// Recursively corrects formula paths when an object is renamed before it is added to the project.
+      /// Commands are not used here since the object is not yet part of the project
+      /// </summary>
+      /// <param name="oldName">The original object name</param>
+      /// <param name="newName">The new object name</param>
+      /// <param name="objectBase">The object to recurse</param>
+      private void correctFormulaPathsForRename(string oldName, string newName, IObjectBase objectBase)
+      {
+         if (string.Equals(oldName, newName))
+            return;
+
+         switch (objectBase)
+         {
+            case IUsingFormula usingFormula:
+               correctFormulaPathsForRename(oldName, newName, usingFormula.Formula);
+               break;
+            case IFormula formula:
+               formula.ObjectPaths.Each(x => x.Replace(oldName, newName));
+               break;
+         }
+
+         if (!(objectBase is IContainer container))
+            return;
+
+         // Correct child parameters of the container
+         container.GetAllChildren<IParameter>().Each(x => correctFormulaPathsForRename(oldName, newName, x));
+
+         // Recurse containers to check their parameters
+         container.GetAllChildren<IContainer>().Each(x => correctFormulaPathsForRename(oldName, newName, x));
+      }
+
+      /// <summary>
+      /// Recursively updates name tags from the specified old name to the new name before it is added to the project
+      /// Commands are not used here since the object is not yet part of the project
+      /// </summary>
+      /// <param name="oldName">The tag name to be replaced</param>
+      /// <param name="newName">The new tag name to use as a replacement</param>
+      /// <param name="objectBase">The root object in which to perform the tag renaming</param>
       private void correctTagsForRename(string oldName, string newName, IObjectBase objectBase)
       {
          if (string.Equals(oldName, newName))
@@ -259,8 +300,8 @@ namespace MoBi.Presentation.Tasks.Interaction
 
          if (objectBase is IEntity entity)
             entity.Tags.Replace(oldName, newName);
-         
-         if (!(objectBase is IContainer container)) 
+
+         if (!(objectBase is IContainer container))
             return;
 
          // Recurse containers to check their tags and their children tags

--- a/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForReactionBuilderSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForReactionBuilderSpecs.cs
@@ -67,9 +67,12 @@ namespace MoBi.Presentation.Tasks
          _parameter.Formula.AddObjectPath(new FormulaUsablePath("oldName"));
          _reactionBuilder.AddParameter(_parameter);
 
+         // add a parameter without a formula
+         _reactionBuilder.AddParameter(new Parameter().WithName("no_formula"));
+
          _itemsToAdd = new List<ReactionBuilder>
          {
-            _reactionBuilder
+            _reactionBuilder,
          };
 
          A.CallTo(() => _interactionTaskContext.InteractionTask.CorrectName(_reactionBuilder, A<IEnumerable<string>>._)).Invokes(x => x.Arguments.Get<ReactionBuilder>(0).Name = "newName").Returns(true);

--- a/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForReactionBuilderSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InteractionTasksForReactionBuilderSpecs.cs
@@ -1,17 +1,20 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using OSPSuite.BDDHelper;
 using FakeItEasy;
 using MoBi.Core.Domain.Model;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks.Edit;
 using MoBi.Presentation.Tasks.Interaction;
 using MoBi.UI.Diagram.DiagramManagers;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Presentation.Diagram.Elements;
 using OSPSuite.UI.Diagram.Elements;
+using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Presentation.Tasks
 {
@@ -34,6 +37,63 @@ namespace MoBi.Presentation.Tasks
          _multipleStringSelectionPresenter = A.Fake<IMultipleStringSelectionPresenter>();
          A.CallTo(() => _interactionTaskContext.ApplicationController).Returns(_moBiApplicationController);
          A.CallTo(() => _moBiApplicationController.Start<IMultipleStringSelectionPresenter>()).Returns(_multipleStringSelectionPresenter);
+      }
+   }
+
+   public class When_loading_a_reaction_that_is_renamed_and_parameter_formulas_reference_the_name : concern_for_InteractionTasksForReactionBuilder
+   {
+      private MoBiReactionBuildingBlock _buildingBlock;
+      private IReadOnlyCollection<ReactionBuilder> _itemsToAdd;
+      private Parameter _parameter;
+      private ReactionBuilder _reactionBuilder;
+
+      protected override void Context()
+      {
+         base.Context();
+         _buildingBlock = new MoBiReactionBuildingBlock
+         {
+            DiagramManager = new MoBiReactionDiagramManager()
+         };
+         _reactionBuilder = new ReactionBuilder
+         {
+            Formula = new ExplicitFormula("5"),
+            Name = "oldName"
+         };
+         _reactionBuilder.Formula.AddObjectPath(new FormulaUsablePath("oldName"));
+         _parameter = new Parameter
+         {
+            Formula = new ExplicitFormula("5")
+         };
+         _parameter.Formula.AddObjectPath(new FormulaUsablePath("oldName"));
+         _reactionBuilder.AddParameter(_parameter);
+
+         _itemsToAdd = new List<ReactionBuilder>
+         {
+            _reactionBuilder
+         };
+
+         A.CallTo(() => _interactionTaskContext.InteractionTask.CorrectName(_reactionBuilder, A<IEnumerable<string>>._)).Invokes(x => x.Arguments.Get<ReactionBuilder>(0).Name = "newName").Returns(true);
+      }
+
+      protected override void Because()
+      {
+         sut.AddTo(_itemsToAdd, _buildingBlock);
+      }
+
+      [Observation]
+      public void must_add_the_reaction_builders_to_the_building_block()
+      {
+         _itemsToAdd.Each(x => _buildingBlock.ShouldContain(x));
+      }
+
+      [Observation]
+      public void the_formulas_object_paths_should_be_adjusted()
+      {
+         _reactionBuilder.Formula.ObjectPaths.ShouldNotContain(new FormulaUsablePath { "oldName" });
+         _reactionBuilder.Formula.ObjectPaths.ShouldContain(new FormulaUsablePath { "newName" });
+
+         _parameter.Formula.ObjectPaths.ShouldNotContain(new FormulaUsablePath { "oldName" });
+         _parameter.Formula.ObjectPaths.ShouldContain(new FormulaUsablePath { "newName" });
       }
    }
 
@@ -64,7 +124,7 @@ namespace MoBi.Presentation.Tasks
 
       protected override void Because()
       {
-         sut.SelectMoleculeNames(_reactionBuildingBlock, new List<string> {"unallowedMolecule"}, "reactionName", "Products");
+         sut.SelectMoleculeNames(_reactionBuildingBlock, new List<string> { "unallowedMolecule" }, "reactionName", "Products");
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #2186 Rename reaction on load should update formula paths

# Description
When loading an object from PKML and a rename is forced, the contained formulas should update paths where the path contains the original name.

I did not limit this to only acting on reactions even though the ticket specifically refers to reactions.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):