### PR TITLE
#2231 run simulation and preserve the selected node

### DIFF
--- a/src/MoBi.Presentation/Presenter/Main/SimulationExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/SimulationExplorerPresenter.cs
@@ -163,8 +163,8 @@ namespace MoBi.Presentation.Presenter.Main
          if (simulationNode == null)
             return;
 
-         var simulationNodeExpanded = _view.IsNodeExpanded(simulationNode);
-         var wasSelected = _view.TreeView.SelectedNode?.Id == simulationNode.Id;
+         bool simulationNodeExpanded = _view.IsNodeExpanded(simulationNode);
+         bool wasSelected = _view.TreeView.SelectedNode?.Id == simulationNode.Id;
 
          var parentNode = simulationNode.ParentNode.DowncastTo<ITreeNode<IClassification>>();
          RemoveNodeFor(simulation);

--- a/src/MoBi.Presentation/Presenter/Main/SimulationExplorerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/SimulationExplorerPresenter.cs
@@ -163,12 +163,19 @@ namespace MoBi.Presentation.Presenter.Main
          if (simulationNode == null)
             return;
 
-         bool simulationNodeExpanded = _view.IsNodeExpanded(simulationNode);
+         var simulationNodeExpanded = _view.IsNodeExpanded(simulationNode);
+         var wasSelected = _view.TreeView.SelectedNode?.Id == simulationNode.Id;
+
          var parentNode = simulationNode.ParentNode.DowncastTo<ITreeNode<IClassification>>();
          RemoveNodeFor(simulation);
+
          var classifiableSimulation = _projectRetriever.CurrentProject.GetOrCreateClassifiableFor<ClassifiableSimulation, IMoBiSimulation>(simulation);
          simulationNode = addClassifiableSimulationToTree(parentNode, classifiableSimulation);
+
          _view.ExpandNodeIfRequired(simulationNode, simulationNodeExpanded);
+
+         if (wasSelected)
+            _view.SelectNode(simulationNode);
       }
 
       private void refreshDisplayedSimulation(IMoBiSimulation simulation)

--- a/tests/MoBi.Tests/Presentation/SimulationExplorerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SimulationExplorerPresenterSpecs.cs
@@ -1,0 +1,177 @@
+using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Events;
+using MoBi.Presentation.Presenter.Main;
+using MoBi.Presentation.Tasks.Interaction;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Presentation.Nodes;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Presenters.Classifications;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Presentation.Regions;
+using OSPSuite.Presentation.Services;
+using OSPSuite.Presentation.Views;
+using ITreeNodeFactory = MoBi.Presentation.Nodes.ITreeNodeFactory;
+
+namespace MoBi.Presentation
+{
+   public abstract class concern_for_SimulationExplorerPresenter : ContextSpecification<SimulationExplorerPresenter>
+   {
+      protected ISimulationExplorerView _view;
+      protected IRegionResolver _regionResolver;
+      protected ITreeNodeFactory _treeNodeFactory;
+      protected IViewItemContextMenuFactory _viewItemContextMenuFactory;
+      protected IMoBiContext _context;
+      protected IClassificationPresenter _classificationPresenter;
+      protected IToolTipPartCreator _toolTipPartCreator;
+      protected IMultipleTreeNodeContextMenuFactory _multipleTreeNodeContextMenuFactory;
+      protected IProjectRetriever _projectRetriever;
+      protected IInteractionTasksForSimulation _interactionTasksForSimulation;
+      protected IParameterAnalysablesInExplorerPresenter _parameterAnalysablesPresenter;
+      protected IUxTreeView _treeView;
+
+      protected IMoBiSimulation _simulation;
+      protected ITreeNode _oldNode;
+      protected ITreeNode _newNode;
+      protected ITreeNode<IClassification> _parentClassificationNode;
+      protected MoBiProject _fakeProject;
+
+      protected override void Context()
+      {
+         _view = A.Fake<ISimulationExplorerView>();
+         _regionResolver = A.Fake<IRegionResolver>();
+         _treeNodeFactory = A.Fake<ITreeNodeFactory>();
+         _viewItemContextMenuFactory = A.Fake<IViewItemContextMenuFactory>();
+         _context = A.Fake<IMoBiContext>();
+         _classificationPresenter = A.Fake<IClassificationPresenter>();
+         _toolTipPartCreator = A.Fake<IToolTipPartCreator>();
+         _multipleTreeNodeContextMenuFactory = A.Fake<IMultipleTreeNodeContextMenuFactory>();
+         _projectRetriever = A.Fake<IProjectRetriever>();
+         _interactionTasksForSimulation = A.Fake<IInteractionTasksForSimulation>();
+         _parameterAnalysablesPresenter = A.Fake<IParameterAnalysablesInExplorerPresenter>();
+
+         _treeView = A.Fake<IUxTreeView>();
+         A.CallTo(() => _view.TreeView).Returns(_treeView);
+
+         _simulation = A.Fake<IMoBiSimulation>();
+         A.CallTo(() => _simulation.Id).Returns("sim-1");
+
+         _oldNode = A.Fake<ITreeNode>();
+         A.CallTo(() => _oldNode.Id).Returns(_simulation.Id);
+
+         _newNode = A.Fake<ITreeNode>();
+         A.CallTo(() => _newNode.Id).Returns(_simulation.Id); // recreated node shares the same id
+
+         _parentClassificationNode = A.Fake<ITreeNode<IClassification>>();
+         A.CallTo(() => _oldNode.ParentNode).Returns(_parentClassificationNode);
+         A.CallTo(() => _treeView.NodeById(_simulation.Id)).Returns(_oldNode);
+         A.CallTo(() => _treeNodeFactory.CreateFor(A<ClassifiableSimulation>._)).Returns(_newNode);
+
+         _fakeProject = new MoBiProject();
+         A.CallTo(() => _projectRetriever.CurrentProject).Returns(_fakeProject);
+
+         sut = new SimulationExplorerPresenter(
+            _view,
+            _regionResolver,
+            _treeNodeFactory,
+            _viewItemContextMenuFactory,
+            _context,
+            _classificationPresenter,
+            _toolTipPartCreator,
+            _multipleTreeNodeContextMenuFactory,
+            _projectRetriever,
+            _interactionTasksForSimulation,
+            _parameterAnalysablesPresenter);
+      }
+   }
+
+   public class When_recreating_a_selected_simulation_node : concern_for_SimulationExplorerPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _treeView.IsNodeExpanded(_oldNode)).Returns(true);
+         A.CallTo(() => _treeView.SelectedNode).Returns(_oldNode);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new SimulationReloadEvent(_simulation));
+      }
+
+      [Observation]
+      public void should_select_the_recreated_node()
+      {
+         A.CallTo(() => _treeView.SelectNode(_newNode)).MustHaveHappened();
+      }
+   }
+
+   public class When_recreating_a_simulation_node_that_was_not_selected : concern_for_SimulationExplorerPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+
+         var someOtherNode = A.Fake<ITreeNode>();
+         A.CallTo(() => someOtherNode.Id).Returns("other");
+         A.CallTo(() => _treeView.SelectedNode).Returns(someOtherNode);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new SimulationReloadEvent(_simulation));
+      }
+
+      [Observation]
+      public void should_not_change_selection()
+      {
+         A.CallTo(() => _treeView.SelectNode(_newNode)).MustNotHaveHappened();
+      }
+   }
+   public class When_simulation_run_finishes_for_selected_node : concern_for_SimulationExplorerPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _treeView.IsNodeExpanded(_oldNode)).Returns(true);
+         A.CallTo(() => _treeView.SelectedNode).Returns(_oldNode);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new SimulationRunFinishedEvent(_simulation, true));
+      }
+
+      [Observation]
+      public void should_keep_selection_on_the_same_simulation()
+      {
+         A.CallTo(() => _treeView.SelectNode(_newNode)).MustHaveHappened();
+      }
+   }
+
+   public class When_simulation_run_finishes_for_a_node_that_was_not_selected : concern_for_SimulationExplorerPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+
+         var other = A.Fake<ITreeNode>();
+         A.CallTo(() => other.Id).Returns("other");
+         A.CallTo(() => _treeView.SelectedNode).Returns(other);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new SimulationRunFinishedEvent(_simulation, false));
+      }
+
+      [Observation]
+      public void should_not_change_the_selection()
+      {
+         A.CallTo(() => _treeView.SelectNode(_newNode)).MustNotHaveHappened();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2231

# Description

When running a simulation preserve the selected node.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
<img width="1135" height="934" alt="image" src="https://github.com/user-attachments/assets/7b309578-bd9d-472b-a542-9522b1357d30" />

<img width="1805" height="811" alt="image" src="https://github.com/user-attachments/assets/61542f17-569d-4e29-9eee-2d2e8359cac2" />

<img width="1360" height="884" alt="image" src="https://github.com/user-attachments/assets/ddf10c56-38e5-451e-9db7-4282fee83d6c" />


# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simulation explorer now preserves node selection when nodes are recreated, so the previously selected simulation remains selected after refresh.
  * Continued preservation of expanded/collapsed state for nodes during recreation for a more stable exploration experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->