### PR TITLE
#2248 extend errors and warnings

### DIFF
--- a/src/MoBi.R/Services/SimulationFactory.cs
+++ b/src/MoBi.R/Services/SimulationFactory.cs
@@ -86,11 +86,22 @@ namespace MoBi.R.Services
 
          var warnings = messages
             .Where(m => m.NotificationType == NotificationType.Warning)
-            .Select(m => m.Text);
+            .Select(m => m.Text)
+            .Concat(
+               messages
+                  .Where(m => m.NotificationType == NotificationType.Warning)
+                  .SelectMany(m => m.Details)
+            );
 
          var errors = messages
             .Where(m => m.NotificationType == NotificationType.Error)
-            .Select(m => m.Text);
+            .Select(m => m.Text)
+            .Concat(
+               messages
+                  .Where(m => m.NotificationType == NotificationType.Error)
+                  .SelectMany(m => m.Details)
+            );
+
 
          return new SimulationCreationResult(null, warnings, errors);
       }

--- a/src/MoBi.R/Services/SimulationFactory.cs
+++ b/src/MoBi.R/Services/SimulationFactory.cs
@@ -82,26 +82,21 @@ namespace MoBi.R.Services
 
       private static SimulationCreationResult createResultWithMessages(ValidationFailedMoBiException e)
       {
-         var messages = e.ValidationResult?.Messages.ToList() ?? new List<ValidationMessage>();
+         var messages = e.ValidationResult?.Messages ?? Enumerable.Empty<ValidationMessage>();
 
-         var warnings = messages
-            .Where(m => m.NotificationType == NotificationType.Warning)
-            .Select(m => m.Text)
-            .Concat(
-               messages
-                  .Where(m => m.NotificationType == NotificationType.Warning)
-                  .SelectMany(m => m.Details)
-            );
+         var grouped = messages
+            .Where(m => m != null)
+            .GroupBy(m => m.NotificationType)
+            .ToDictionary(g => g.Key, g => g.ToList());
 
-         var errors = messages
-            .Where(m => m.NotificationType == NotificationType.Error)
-            .Select(m => m.Text)
-            .Concat(
-               messages
-                  .Where(m => m.NotificationType == NotificationType.Error)
-                  .SelectMany(m => m.Details)
-            );
+         IEnumerable<string> Flatten(IEnumerable<ValidationMessage> ms) =>
+            ms.SelectMany(m =>
+               new[] { m.Text }
+                  .Concat(m.Details ?? Enumerable.Empty<string>())
+            ).Where(s => !string.IsNullOrWhiteSpace(s));
 
+         var warnings = grouped.TryGetValue(NotificationType.Warning, out var w) ? Flatten(w) : Enumerable.Empty<string>();
+         var errors = grouped.TryGetValue(NotificationType.Error, out var er) ? Flatten(er) : Enumerable.Empty<string>();
 
          return new SimulationCreationResult(null, warnings, errors);
       }

--- a/src/MoBi.R/Services/SimulationFactory.cs
+++ b/src/MoBi.R/Services/SimulationFactory.cs
@@ -105,7 +105,15 @@ namespace MoBi.R.Services
 
       private static void addValidationMessage(ValidationMessage message, List<string> messageList)
       {
-         messageList.Add($"{message.Text} - {message.Details}");
+         var detailsText = message.Details != null && message.Details.Any()
+            ? string.Join(", ", message.Details)
+            : string.Empty;
+
+         var fullMessage = string.IsNullOrEmpty(detailsText)
+            ? message.Text
+            : $"{message.Text} - {detailsText}";
+
+         messageList.Add(fullMessage);
       }
    }
 }

--- a/src/MoBi.R/Services/SimulationFactory.cs
+++ b/src/MoBi.R/Services/SimulationFactory.cs
@@ -82,23 +82,30 @@ namespace MoBi.R.Services
 
       private static SimulationCreationResult createResultWithMessages(ValidationFailedMoBiException e)
       {
-         var messages = e.ValidationResult?.Messages ?? Enumerable.Empty<ValidationMessage>();
+         var messages = e.ValidationResult?.Messages.ToList() ?? new List<ValidationMessage>();
 
-         var grouped = messages
-            .Where(m => m != null)
-            .GroupBy(m => m.NotificationType)
-            .ToDictionary(g => g.Key, g => g.ToList());
+         var warnings = new List<string>();
+         var errors = new List<string>();
 
-         IEnumerable<string> Flatten(IEnumerable<ValidationMessage> ms) =>
-            ms.SelectMany(m =>
-               new[] { m.Text }
-                  .Concat(m.Details ?? Enumerable.Empty<string>())
-            ).Where(s => !string.IsNullOrWhiteSpace(s));
-
-         var warnings = grouped.TryGetValue(NotificationType.Warning, out var w) ? Flatten(w) : Enumerable.Empty<string>();
-         var errors = grouped.TryGetValue(NotificationType.Error, out var er) ? Flatten(er) : Enumerable.Empty<string>();
+         messages.Each(message =>
+         {
+            switch (message.NotificationType)
+            {
+               case NotificationType.Warning:
+                  addValidationMessage(message, warnings);
+                  break;
+               case NotificationType.Error:
+                  addValidationMessage(message, errors);
+                  break;
+            }
+         });
 
          return new SimulationCreationResult(null, warnings, errors);
+      }
+
+      private static void addValidationMessage(ValidationMessage message, List<string> messageList)
+      {
+         messageList.Add($"{message.Text} - {message.Details}");
       }
    }
 }


### PR DESCRIPTION
Fixes #2248

# Description

Extend errors and warning details on response

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error and warning messages now include appended detail text when available (e.g., "message - details"), producing clearer diagnostics.
  * Message aggregation and routing are more robust, reducing missing or miscategorized validation notes.
  * Public result structure and surface remain unchanged, so existing integrations continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->