### PR TITLE
Fixes #2251 Error when configuring simulation

### DIFF
--- a/src/MoBi.Presentation/Tasks/SimulationUpdateTask.cs
+++ b/src/MoBi.Presentation/Tasks/SimulationUpdateTask.cs
@@ -120,6 +120,9 @@ namespace MoBi.Presentation.Tasks
             results = _simulationFactory.CreateModelAndValidate(simulationConfigurationReferencingTemplates, simulationToUpdate.Model.Name, message);
          }, message);
 
+         if (results == null)
+            return new MoBiEmptyCommand();
+
          //create a clone then that will be saved in the simulation
          var simulationBuildConfiguration = _cloneManager.Clone(simulationConfigurationReferencingTemplates);
 

--- a/tests/MoBi.Tests/Core/Service/SimulationUpdateTaskSpecs.cs
+++ b/tests/MoBi.Tests/Core/Service/SimulationUpdateTaskSpecs.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using FakeItEasy;
+using MoBi.Core.Commands;
 using MoBi.Core.Domain;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
@@ -11,6 +11,7 @@ using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Tasks;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
@@ -109,6 +110,37 @@ namespace MoBi.Core.Service
       public void the_notification_area_should_be_cleared()
       {
          A.CallTo(() => _context.PublishEvent(A<ClearNotificationsEvent>.That.Matches(x => x.MessageOrigin.Equals(MessageOrigin.Simulation)))).MustHaveHappened();
+      }
+   }
+
+   public class When_configuring_a_simulation_fails : concern_for_SimulationUpdateTask
+   {
+      private SimulationConfiguration _simulationConfiguration;
+      private MoBiSimulation _simulation;
+      private ICommand _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulationConfiguration = new SimulationConfiguration();
+         _simulation = new MoBiSimulation
+         {
+            Configuration = _simulationConfiguration,
+            Model = new Model()
+         };
+
+         A.CallTo(() => _simulationFactory.CreateModelAndValidate(A<SimulationConfiguration>._, A<string>._, A<string>._)).Returns(null);
+      }
+
+      protected override void Because()
+      {
+         _result = sut.UpdateSimulation(_simulation);
+      }
+
+      [Observation]
+      public void the_command_to_update_should_be_empty()
+      {
+         _result.ShouldBeAnInstanceOf<MoBiEmptyCommand>();
       }
    }
 


### PR DESCRIPTION
Fixes #2251 Error when configuring simulation

# Description
Should not try to update simulation when the construction fails.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to gracefully manage simulation configuration failures, preventing invalid operations from executing with corrupted state data and improving system reliability

* **Tests**
  * Added test coverage for simulation configuration failure scenarios to validate proper error handling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->