### PR TITLE
Fixes #2270 use individualcharacteristics to build an individualbuildingblock through pk sim

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -2429,6 +2429,8 @@ namespace MoBi.Assets
          public static readonly string IncompatibleVersionInstalled = "PK-Sim was found on the system, but it was not compatible with this feature. Please make sure that a compatible version of PK-Sim was installed using the provided setup.\n" +
                                                                       "Alternatively, you can specify where PK-Sim is installed on your system under Utilities -> Options -> Application tab\n" +
                                                                       "After changing the PK-Sim installation path, please restart MoBi.";
+
+         public static string CouldNotFindCompatiblePKSimAssemblies(string path) => $"Could not find compatible PK-Sim assemblies {path}";
       }
 
       public static string DefaultFileNameForBuildingBlockExport(string projectName, IBuildingBlock buildingBlock)

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -2431,6 +2431,13 @@ namespace MoBi.Assets
                                                                       "After changing the PK-Sim installation path, please restart MoBi.";
 
          public static string CouldNotFindCompatiblePKSimAssemblies(string path) => $"Could not find compatible PK-Sim assemblies {path}";
+
+         public static string CouldNotFindTypeInAssembly(string type, string assemblyLocation) => $"Could not find type '{type}' in '{assemblyLocation}'";
+
+         public static string CouldNotFindMethodInAssembly(string methodName, string type, string assemblyLocation)
+         {
+            return $"Could not find method '{methodName}' on type '{type}' in '{assemblyLocation}'";
+         }
       }
 
       public static string DefaultFileNameForBuildingBlockExport(string projectName, IBuildingBlock buildingBlock)

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.83" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.83" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.85" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.85" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.83" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.85" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,14 +16,14 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.83" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.83" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.85" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.85" />
       <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.83" />
-      <PackageReference Include="OSPSuite.Presentation" Version="13.0.83" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.83" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.83" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.83" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.85" />
+      <PackageReference Include="OSPSuite.Presentation" Version="13.0.85" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.85" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.85" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.85" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -23,16 +23,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.83" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.85" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.83" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.85" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,13 +31,13 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="8.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.83" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Infrastructure.Reporting" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.85" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MoBi.Core/Services/PKSimAssemblyLoader.cs
+++ b/src/MoBi.Core/Services/PKSimAssemblyLoader.cs
@@ -1,0 +1,30 @@
+﻿using System.Reflection;
+
+namespace MoBi.Core.Services;
+
+public abstract class PKSimAssemblyLoader
+{
+   protected Assembly _externalAssembly;
+
+   protected void LoadPKSimAssembly()
+   {
+      if (_externalAssembly != null)
+         return;
+
+      _externalAssembly = Assembly.LoadFrom(RetrievePKSimAssemblyPath());
+   }
+
+   protected abstract string RetrievePKSimAssemblyPath();
+
+   protected MethodInfo GetMethod(string type, string methodName)
+   {
+      LoadPKSimAssembly();
+
+      return _externalAssembly.GetType(type).GetMethod(methodName);
+   }
+
+   protected object ExecuteMethod(MethodInfo method, object[] parameters = null)
+   {
+      return method.Invoke(null, parameters);
+   }
+}

--- a/src/MoBi.Core/Services/PKSimAssemblyLoader.cs
+++ b/src/MoBi.Core/Services/PKSimAssemblyLoader.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using MoBi.Assets;
+using MoBi.Core.Exceptions;
+using System.Reflection;
 
 namespace MoBi.Core.Services;
 
@@ -20,7 +22,9 @@ public abstract class PKSimAssemblyLoader
    {
       LoadPKSimAssembly();
 
-      return _externalAssembly.GetType(type).GetMethod(methodName);
+      var resolvedType = _externalAssembly.GetType(type) ?? throw new MoBiException(AppConstants.PKSim.CouldNotFindTypeInAssembly(type, _externalAssembly.Location));
+      return resolvedType.GetMethod(methodName) ?? throw new MoBiException(AppConstants.PKSim.CouldNotFindMethodInAssembly(methodName, type, _externalAssembly.Location));
+
    }
 
    protected object ExecuteMethod(MethodInfo method, object[] parameters = null)

--- a/src/MoBi.Core/Services/PKSimStarter.cs
+++ b/src/MoBi.Core/Services/PKSimStarter.cs
@@ -48,7 +48,7 @@ namespace MoBi.Core.Services
       IndividualBuildingBlock LoadIndividualFromSnapshot(string serializedSnapshot);
    }
 
-   public class PKSimStarter : IPKSimStarter
+   public class PKSimStarter : PKSimAssemblyLoader, IPKSimStarter
    {
       private const string CREATE_INDIVIDUAL_ENZYME_EXPRESSION_PROFILE = "CreateIndividualEnzymeExpressionProfile";
       private const string CREATE_BINDING_PARTNER_EXPRESSION_PROFILE = "CreateBindingPartnerExpressionProfile";
@@ -67,7 +67,6 @@ namespace MoBi.Core.Services
       private readonly IMoBiConfiguration _configuration;
       private readonly IApplicationSettings _applicationSettings;
       private readonly IStartableProcessFactory _startableProcessFactory;
-      private Assembly _externalAssembly;
       private readonly ICloneManagerForBuildingBlock _cloneManager;
       private readonly IMoBiProjectRetriever _projectRetriever;
       private readonly IXmlSerializationService _serializationService;
@@ -111,18 +110,17 @@ namespace MoBi.Core.Services
          if (string.IsNullOrEmpty(methodName))
             return null;
 
-         return executeAndCloneBuildingBlock<ExpressionProfileBuildingBlock>(getMethod(PKSIM_UI_STARTER_EXPRESSION_PROFILE_CREATOR, methodName));
+         return executeAndCloneBuildingBlock<ExpressionProfileBuildingBlock>(GetMethod(PKSIM_UI_STARTER_EXPRESSION_PROFILE_CREATOR, methodName));
       }
 
       public IBuildingBlock CreateIndividual()
       {
-         return executeAndCloneBuildingBlock<IndividualBuildingBlock>(getMethod(PKSIM_UI_STARTER_INDIVIDUAL_CREATOR, CREATE_INDIVIDUAL));
+         return executeAndCloneBuildingBlock<IndividualBuildingBlock>(GetMethod(PKSIM_UI_STARTER_INDIVIDUAL_CREATOR, CREATE_INDIVIDUAL));
       }
 
       private TBuildingBlock executeAndCloneBuildingBlock<TBuildingBlock>(MethodInfo method) where TBuildingBlock : class, IBuildingBlock
       {
-         loadPKSimAssembly();
-         var buildingBlock = executeMethod(method) as TBuildingBlock;
+         var buildingBlock = ExecuteMethod(method) as TBuildingBlock;
 
          //in case of cancelling
          if (buildingBlock == null)
@@ -133,13 +131,13 @@ namespace MoBi.Core.Services
 
       public IReadOnlyList<ExpressionParameterValueUpdate> UpdateExpressionProfileFromDatabase(ExpressionProfileBuildingBlock expressionProfile)
       {
-         loadPKSimAssembly();
-         return executeMethod(getMethod(PKSIM_UI_STARTER_EXPRESSION_PROFILE_CREATOR, GET_EXPRESSION_DATABASE_QUERY), [expressionProfile]) as List<ExpressionParameterValueUpdate>;
+         LoadPKSimAssembly();
+         return ExecuteMethod(GetMethod(PKSIM_UI_STARTER_EXPRESSION_PROFILE_CREATOR, GET_EXPRESSION_DATABASE_QUERY), [expressionProfile]) as List<ExpressionParameterValueUpdate>;
       }
 
       public Module LoadModuleFromSnapshot(string serializedSnapshot)
       {
-         var element = executeMethod(getMethod(PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE, CREATE_MODULE), [serializedSnapshot]) as string;
+         var element = ExecuteMethod(GetMethod(PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE, CREATE_MODULE), [serializedSnapshot]) as string;
 
          // all object exchanges should be done using serialization to ensure that objects are recreated in MoBi.
          return _serializationService.Deserialize<Module>(element, _projectRetriever.Current);
@@ -147,7 +145,7 @@ namespace MoBi.Core.Services
 
       public (Module module, InputMapping[] inputMappings) LoadModuleFromSnapshotAndExportInputs(string serializedSnapshot, QualificationConfiguration qualificationConfiguration)
       {
-         var tuple = executeMethod(getMethod(PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE, CREATE_MODULE_AND_EXPORT_INPUTS), [serializedSnapshot, qualificationConfiguration]);
+         var tuple = ExecuteMethod(GetMethod(PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE, CREATE_MODULE_AND_EXPORT_INPUTS), [serializedSnapshot, qualificationConfiguration]);
 
          var (element, mappings) = tuple as (string element, InputMapping[] mappings)? ?? (null, null);
 
@@ -159,7 +157,7 @@ namespace MoBi.Core.Services
 
       public ExpressionProfileBuildingBlock LoadExpressionProfileFromSnapshot(string serializedSnapshot)
       {
-         var pkml = executeMethod(getMethod(PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE, CREATE_EXPRESSION_PROFILE_BUILDING_BLOCK), [serializedSnapshot]) as string;
+         var pkml = ExecuteMethod(GetMethod(PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE, CREATE_EXPRESSION_PROFILE_BUILDING_BLOCK), [serializedSnapshot]) as string;
 
          // all object exchanges should be done using serialization to ensure that objects are recreated in MoBi.
          return _serializationService.Deserialize<ExpressionProfileBuildingBlock>(pkml, _projectRetriever.Current);
@@ -167,30 +165,10 @@ namespace MoBi.Core.Services
 
       public IndividualBuildingBlock LoadIndividualFromSnapshot(string serializedSnapshot)
       {
-         var pkml = executeMethod(getMethod(PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE, CREATE_INDIVIDUAL_BUILDING_BLOCK), [serializedSnapshot]) as string;
+         var pkml = ExecuteMethod(GetMethod(PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE, CREATE_INDIVIDUAL_BUILDING_BLOCK), [serializedSnapshot]) as string;
 
          // all object exchanges should be done using serialization to ensure that objects are recreated in MoBi.
          return _serializationService.Deserialize<IndividualBuildingBlock>(pkml, _projectRetriever.Current);
-      }
-
-      private object executeMethod(MethodInfo method, object[] parameters = null)
-      {
-         return method.Invoke(null, parameters);
-      }
-
-      private void loadPKSimAssembly()
-      {
-         if (_externalAssembly != null)
-            return;
-
-         _externalAssembly = Assembly.LoadFrom(retrievePKSimUIStarterPath());
-      }
-
-      private MethodInfo getMethod(string type, string methodName)
-      {
-         loadPKSimAssembly();
-
-         return _externalAssembly.GetType(type).GetMethod(methodName);
       }
 
       private void startPKSimWithFile(string filePathToStart, string option)
@@ -207,7 +185,7 @@ namespace MoBi.Core.Services
          this.DoWithinExceptionHandler(() => { _startableProcessFactory.CreateStartableProcess(pkSimPath, args).Start(); });
       }
 
-      private string retrievePKSimUIStarterPath()
+      protected override string RetrievePKSimAssemblyPath()
       {
          var pkSimPath = retrievePKSimExecutablePath();
          var directory = Path.GetDirectoryName(pkSimPath);

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.83" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.85" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -23,9 +23,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.83" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.85" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.83" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.85" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.R/Services/IndividualTask.cs
+++ b/src/MoBi.R/Services/IndividualTask.cs
@@ -1,17 +1,48 @@
-﻿using OSPSuite.Core.Domain.Builder;
+﻿using MoBi.Assets;
+using MoBi.Core.Exceptions;
+using MoBi.Core.Serialization.Xml.Services;
+using MoBi.Core.Services;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.R.Domain;
+using OSPSuite.Utility;
+using System.IO;
+using System.Reflection;
 
-namespace MoBi.R.Services
+namespace MoBi.R.Services;
+
+public interface IIndividualTask
 {
-   public interface IIndividualTask
+   IndividualBuildingBlock CreateIndividual(IndividualCharacteristics individualCharacteristics);
+}
+
+public class IndividualTask : PKSimAssemblyLoader, IIndividualTask
+{
+   private readonly IXmlSerializationService _xmlSerializationService;
+   private readonly IMoBiProjectRetriever _projectRetriever;
+
+   public IndividualTask(IXmlSerializationService xmlSerializationService, IMoBiProjectRetriever projectRetriever)
    {
-      IndividualBuildingBlock CreateIndividual(string name);
+      _xmlSerializationService = xmlSerializationService;
+      _projectRetriever = projectRetriever;
    }
 
-   public class IndividualTask : IIndividualTask
+   private const string PKSIM_R_DLL = "PKSim.R.dll";
+
+   public IndividualBuildingBlock CreateIndividual(IndividualCharacteristics individualCharacteristics)
    {
-      public IndividualBuildingBlock CreateIndividual(string name)
-      {
-         return new IndividualBuildingBlock { Name = name };
-      }
+      LoadPKSimAssembly();
+
+      var serializedIndividual = ExecuteMethod(GetMethod("PKSim.R.Exchange.BuildingBlockCreator", "CreateIndividual"), [individualCharacteristics]) as string;
+
+      return _xmlSerializationService.Deserialize<IndividualBuildingBlock>(serializedIndividual, _projectRetriever.Current);
+   }
+
+   protected override string RetrievePKSimAssemblyPath()
+   {
+      var assemblyFile = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), PKSIM_R_DLL);
+      if (FileHelper.FileExists(assemblyFile))
+         return assemblyFile;
+
+      throw new MoBiException(AppConstants.PKSim.CouldNotFindCompatiblePKSimAssemblies(assemblyFile));
    }
 }

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.5" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.83" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.85" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -67,13 +67,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.83" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.85" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.83" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.85" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.83" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.85" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.83" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.85" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.75" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/Presentation/Mapper/DataTableToImportQuantityDTOMapperForMoleculesSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Mapper/DataTableToImportQuantityDTOMapperForMoleculesSpecs.cs
@@ -64,18 +64,12 @@ namespace MoBi.Presentation.Mapper
       protected IDimension _concentrationDimension;
       protected IDimension _amountDimension;
       private IDimension _timeDimension;
-      private IInitialConditionsCreator _msvCreator;
 
       protected InitialConditionsBuildingBlock _startValuesBuildingBlock;
       private IReactionDimensionRetriever _reactionDimensionRetriever;
 
       protected override void Context()
       {
-         _msvCreator = A.Fake<IInitialConditionsCreator>();
-
-         A.CallTo(() => _msvCreator.CreateInitialCondition(A<ObjectPath>.Ignored, A<string>.Ignored, A<IDimension>.Ignored, A<Unit>._, A<ValueOrigin>._, A<bool>._, A<double>._, A<double>._, A<bool>._))
-            .ReturnsLazily((ObjectPath path, string moleculeName, IDimension dimension) => new InitialCondition { ContainerPath = path, Name = moleculeName, Dimension = dimension});
-
          _concentrationDimension = new Dimension(new BaseDimensionRepresentation(), Constants.Dimension.MOLAR_CONCENTRATION, "mol/l");
 
          _amountDimension = new Dimension(new BaseDimensionRepresentation(), Constants.Dimension.MOLAR_AMOUNT, "mol");
@@ -131,7 +125,7 @@ namespace MoBi.Presentation.Mapper
    }
 
 
-   public class When_converting_and_validating_rows_resulting_in_duplicated_entriues: concern_for_DataTableToImportQuantityDTOMapperForMolecules
+   public class When_converting_and_validating_rows_resulting_in_duplicated_entries: concern_for_DataTableToImportQuantityDTOMapperForMolecules
    {
       private QuantityImporterDTO _result;
       private DataTable _tables;

--- a/tests/MoBi.Tests/Presentation/Mapper/DataTableToImportQuantityDTOMapperForMoleculesSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Mapper/DataTableToImportQuantityDTOMapperForMoleculesSpecs.cs
@@ -73,7 +73,7 @@ namespace MoBi.Presentation.Mapper
       {
          _msvCreator = A.Fake<IInitialConditionsCreator>();
 
-         A.CallTo(() => _msvCreator.CreateInitialCondition(A<ObjectPath>.Ignored, A<string>.Ignored, A<IDimension>.Ignored, A<Unit>._, A<ValueOrigin>._))
+         A.CallTo(() => _msvCreator.CreateInitialCondition(A<ObjectPath>.Ignored, A<string>.Ignored, A<IDimension>.Ignored, A<Unit>._, A<ValueOrigin>._, A<bool>._, A<double>._, A<double>._, A<bool>._))
             .ReturnsLazily((ObjectPath path, string moleculeName, IDimension dimension) => new InitialCondition { ContainerPath = path, Name = moleculeName, Dimension = dimension});
 
          _concentrationDimension = new Dimension(new BaseDimensionRepresentation(), Constants.Dimension.MOLAR_CONCENTRATION, "mol/l");

--- a/tests/MoBi.Tests/Presentation/Tasks/InitialConditionsTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InitialConditionsTaskSpecs.cs
@@ -167,7 +167,7 @@ namespace MoBi.Presentation.Tasks
          for (var i = 1; i < 3; i++)
          {
             var dto = _initialConditions[i];
-            A.CallTo(() => _initialConditionsCreator.CreateInitialCondition(dto.ContainerPath, dto.Name, A<IDimension>._, A<Unit>._, A<ValueOrigin>._)).Returns(
+            A.CallTo(() => _initialConditionsCreator.CreateInitialCondition(dto.ContainerPath, dto.Name, A<IDimension>._, A<Unit>._, A<ValueOrigin>._, A<bool>._, A<double>._, A<double>._, A<bool>._)).Returns(
                new InitialCondition
                {
                   ContainerPath = dto.ContainerPath,

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.83" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.83" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.85" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.85" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #2270 use individualcharacteristics to build an individualbuildingblock through pk sim

# Description
We are using a similar strategy to the PKSimStarter, which allows MoBi to dynamically load assemblies from PK-Sim and use algorithms (and the database). The difference is that we are not going to target the same assembly on the PK-Sim side because that assembly requires UI and Presentation to be loaded as well.

In this case, we are giving the characteristics just as is done in PK-Sim.R and we are mapping those characteristics to a PK-Sim `Individual` and the mapping to an `IndividualBuildingBlock`.

Domain transfers from PK-Sim and MoBi have to go through a serialze/deserialize to make sure that the MoBi/OSPSuite.Core dimensions are used rather than the PK-Sim dimensions. We have this limitation in the PKSimStarter too.

I could only manually test this because it requires PK-Sim assemblies to be present.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [ ] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create individuals from external PK‑Sim data sources; results are deserialized into internal building blocks.
  * Improved diagnostic messages when PK‑Sim assemblies, types, or methods cannot be located.

* **Refactor**
  * Centralized external PK‑Sim assembly loading and invocation to reduce duplication and simplify integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->