### PR TITLE
Fixes #2290 Support overriding molecule used calculation methods in MoBi.R

### DIFF
--- a/src/MoBi.R/Domain/SimulationRequest.cs
+++ b/src/MoBi.R/Domain/SimulationRequest.cs
@@ -1,5 +1,8 @@
 using System.Collections.Generic;
+using System.Linq;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Utility.Collections;
+using OSPSuite.Utility.Extensions;
 
 namespace MoBi.R.Domain
 {
@@ -7,12 +10,30 @@ namespace MoBi.R.Domain
    {
       private readonly List<ModuleConfiguration> _moduleConfigurations = new();
       private readonly List<ExpressionProfileBuildingBlock> _expressionProfiles = new();
+      private readonly Cache<(string moleculeName, string category), string> _moleculeCalculationMethodOverrides = new();
 
       public SimulationSettings SimulationSettings { get; set; }
       public bool CreateAllProcessRateParameters { get; set; }
       public IndividualBuildingBlock Individual { get; private set; }
       public IReadOnlyList<ModuleConfiguration> ModuleConfigurations => _moduleConfigurations;
       public IReadOnlyList<ExpressionProfileBuildingBlock> ExpressionProfiles => _expressionProfiles;
+
+      /// <summary>
+      ///    Returns all molecule calculation method overrides that have been added to this request.
+      /// </summary>
+      public IReadOnlyList<MoleculeCalculationMethodOverride> AllCalculationMethodOverrides()
+      {
+         return _moleculeCalculationMethodOverrides.KeyValues
+            .GroupBy(keyValue => keyValue.Key.moleculeName)
+            .Select(g => moleculeCalculationMethodOverrideForMolecule(g.Key, g.All().Select(kv => (kv.Key.category, kv.Value)))).ToList();
+      }
+
+      private static MoleculeCalculationMethodOverride moleculeCalculationMethodOverrideForMolecule(string moleculeName, IEnumerable<(string category, string name)> allOverrides)
+      {
+         var moleculeOverride = new MoleculeCalculationMethodOverride(moleculeName);
+         allOverrides.Each(x => moleculeOverride.AddUsedCalculationMethod(new UsedCalculationMethod(x.category, x.name)));
+         return moleculeOverride;
+      }
 
       /// <summary>
       ///    Adds a module configuration to this simulation request.
@@ -32,6 +53,17 @@ namespace MoBi.R.Domain
       {
          if (expressionProfile != null)
             _expressionProfiles.Add(expressionProfile);
+      }
+
+      /// <summary>
+      ///    Adds or overrides the used calculation method for a molecule in a given category.
+      /// </summary>
+      /// <param name="moleculeName">The name of the molecule.</param>
+      /// <param name="category">The calculation method category.</param>
+      /// <param name="calculationMethodName">The name of the calculation method to use.</param>
+      public void AddMoleculeUsedCalculationMethod(string moleculeName, string category, string calculationMethodName)
+      {
+         _moleculeCalculationMethodOverrides[(moleculeName, category)] = calculationMethodName;
       }
 
       /// <summary>

--- a/src/MoBi.R/Services/SimulationFactory.cs
+++ b/src/MoBi.R/Services/SimulationFactory.cs
@@ -20,6 +20,7 @@ namespace MoBi.R.Services
       SimulationCreationResult CreateSimulationFrom(string simulationName, RModuleConfiguration[] moduleConfigurations,
          ExpressionProfileBuildingBlock[] expressionProfiles,
          IndividualBuildingBlock individual,
+         IReadOnlyList<MoleculeCalculationMethodOverride> calculationMethodOverrides,
          bool createAllProcessRateParameters = false,
          SimulationSettings simulationSettings = null);
    }
@@ -43,6 +44,7 @@ namespace MoBi.R.Services
       public SimulationCreationResult CreateSimulationFrom(string simulationName, RModuleConfiguration[] moduleConfigurations,
          ExpressionProfileBuildingBlock[] expressionProfiles,
          IndividualBuildingBlock individual,
+         IReadOnlyList<MoleculeCalculationMethodOverride> calculationMethodOverrides,
          bool createAllProcessRateParameters = false,
          SimulationSettings simulationSettings = null)
       {
@@ -66,6 +68,8 @@ namespace MoBi.R.Services
          });
 
          typedExpressionProfiles.Each(simulationConfiguration.AddExpressionProfile);
+
+         addCalculationMethodOverrides(simulationConfiguration, calculationMethodOverrides);
 
          simulationConfiguration.Individual = individual;
          simulationConfiguration.ShouldValidate = true;
@@ -108,6 +112,9 @@ namespace MoBi.R.Services
 
          return new SimulationCreationResult(null, warnings, errors);
       }
+
+      private static void addCalculationMethodOverrides(SimulationConfiguration simulationConfiguration, IReadOnlyList<MoleculeCalculationMethodOverride> overrides) => 
+         overrides.Each(x => simulationConfiguration.AddCalculationMethodsOverridesFor(x.MoleculeName, x.UsedCalculationMethods));
 
       private static void addValidationMessage(ValidationMessage message, List<string> messageList)
       {

--- a/src/MoBi.R/Services/SimulationTask.cs
+++ b/src/MoBi.R/Services/SimulationTask.cs
@@ -65,6 +65,7 @@ namespace MoBi.R.Services
             modulesArray,
             expressionsArray,
             request.Individual,
+            request.AllCalculationMethodOverrides(),
             request.CreateAllProcessRateParameters,
             request.SimulationSettings);
       }

--- a/tests/MoBi.R.Tests/Domain/SimulationRequestSpecs.cs
+++ b/tests/MoBi.R.Tests/Domain/SimulationRequestSpecs.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using MoBi.R.Domain;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain.Builder;
+
+namespace MoBi.R.Tests.Domain;
+
+internal abstract class concern_for_SimulationRequest : ContextSpecification<SimulationRequest>
+{
+   protected override void Context()
+   {
+      sut = new SimulationRequest();
+   }
+}
+
+internal class when_adding_a_duplicate_molecule_calculation_method : concern_for_SimulationRequest
+{
+   private IReadOnlyList<MoleculeCalculationMethodOverride> _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      sut.AddMoleculeUsedCalculationMethod("Molecule1", "Category1", "OriginalMethod");
+   }
+
+   protected override void Because()
+   {
+      sut.AddMoleculeUsedCalculationMethod("Molecule1", "Category1", "ReplacedMethod");
+      _result = sut.AllCalculationMethodOverrides();
+   }
+
+   [Observation]
+   public void should_replace_the_previously_added_calculation_method()
+   {
+      _result.Count.ShouldBeEqualTo(1);
+      _result[0].MoleculeName.ShouldBeEqualTo("Molecule1");
+      _result[0].UsedCalculationMethods.Count.ShouldBeEqualTo(1);
+      var method = _result[0].UsedCalculationMethods.First();
+      method.Category.ShouldBeEqualTo("Category1");
+      method.CalculationMethod.ShouldBeEqualTo("ReplacedMethod");
+   }
+}

--- a/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
+++ b/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
@@ -252,3 +252,48 @@ internal class when_creating_simulation_with_custom_simulation_settings : concer
       _creationResult.Simulation.Settings.Name.ShouldBeEqualTo("CustomSettings");
    }
 }
+
+internal class when_creating_simulation_with_calculation_method_override : concern_for_SimulationTask
+{
+   private SimulationCreationResult _creationResult;
+   private string _category;
+   private const string _overriddenCalculationMethod = "OverriddenMethod";
+
+   protected override void Context()
+   {
+      base.Context();
+
+      _moduleForSimulation = _projectTask.ModuleByName(_project, "Module1");
+      var moduleConfig = sut.CreateModuleConfiguration(_moduleForSimulation, "Parameter Values", "Initial Conditions");
+      _moduleForSimulation.Molecules.Add(new MoleculeBuilder().WithName("Molecule name"));
+      var molecule = _moduleForSimulation.Molecules.First();
+      molecule.AddUsedCalculationMethod(new UsedCalculationMethod("someCategory", "someName"));
+      
+      var usedCalculationMethod = molecule.UsedCalculationMethods.First();
+      _category = usedCalculationMethod.Category;
+
+      _request = new SimulationRequest();
+      _request.AddModuleConfiguration(moduleConfig);
+      _request.SetIndividual(_projectTask.IndividualBuildingBlockByName(_project, "European (P-gp modified, CYP3A4 36 h)"));
+      _request.AddMoleculeUsedCalculationMethod("Molecule name", _category, _overriddenCalculationMethod);
+
+      _projectTask.CloseProject();
+   }
+
+   protected override void Because()
+   {
+      _creationResult = sut.CreateSimulationAndValidateFrom(_simulationName, _request);
+   }
+
+   [Observation]
+   public void should_contain_the_override_in_the_simulation_configuration()
+   {
+      _creationResult.ShouldNotBeNull();
+      _creationResult.Simulation.ShouldNotBeNull();
+      var overrideForMolecule = _creationResult.Simulation.Configuration.CalculationMethodOverridesFor("Molecule name");
+      overrideForMolecule.ShouldNotBeNull();
+      overrideForMolecule.UsedCalculationMethods
+         .Single(ucm => ucm.Category == _category)
+         .CalculationMethod.ShouldBeEqualTo(_overriddenCalculationMethod);
+   }
+}

--- a/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
+++ b/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
@@ -264,16 +264,17 @@ internal class when_creating_simulation_with_calculation_method_override : conce
       base.Context();
 
       _moduleForSimulation = _projectTask.ModuleByName(_project, "Module1");
-      var moduleConfig = sut.CreateModuleConfiguration(_moduleForSimulation, "Parameter Values", "Initial Conditions");
       _moduleForSimulation.Molecules.Add(new MoleculeBuilder().WithName("Molecule name"));
+
       var molecule = _moduleForSimulation.Molecules.First();
-      molecule.AddUsedCalculationMethod(new UsedCalculationMethod("someCategory", "someName"));
-      
       var usedCalculationMethod = molecule.UsedCalculationMethods.First();
       _category = usedCalculationMethod.Category;
+      molecule.AddUsedCalculationMethod(new UsedCalculationMethod("someCategory", "someName"));
+
+      var moduleConfiguration = sut.CreateModuleConfiguration(_moduleForSimulation, "Parameter Values", "Initial Conditions");
 
       _request = new SimulationRequest();
-      _request.AddModuleConfiguration(moduleConfig);
+      _request.AddModuleConfiguration(moduleConfiguration);
       _request.SetIndividual(_projectTask.IndividualBuildingBlockByName(_project, "European (P-gp modified, CYP3A4 36 h)"));
       _request.AddMoleculeUsedCalculationMethod("Molecule name", _category, _overriddenCalculationMethod);
 

--- a/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
+++ b/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
@@ -267,10 +267,10 @@ internal class when_creating_simulation_with_calculation_method_override : conce
       _moduleForSimulation.Molecules.Add(new MoleculeBuilder().WithName("Molecule name"));
 
       var molecule = _moduleForSimulation.Molecules.First();
+      molecule.AddUsedCalculationMethod(new UsedCalculationMethod("someCategory", "someName"));
       var usedCalculationMethod = molecule.UsedCalculationMethods.First();
       _category = usedCalculationMethod.Category;
-      molecule.AddUsedCalculationMethod(new UsedCalculationMethod("someCategory", "someName"));
-
+      
       var moduleConfiguration = sut.CreateModuleConfiguration(_moduleForSimulation, "Parameter Values", "Initial Conditions");
 
       _request = new SimulationRequest();


### PR DESCRIPTION
Fixes #2290 Support overriding molecule used calculation methods in MoBi.R

# Description
Adding string based R interface to enable overriding calculation methods during simulation construction

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests
- [x] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for molecule-specific calculation method overrides during simulation creation
  * Overrides are applied to the resulting simulation configuration so simulations use the specified methods

* **Bug Fixes**
  * Adding a duplicate override for the same molecule/category replaces the previous value

* **Tests**
  * Added tests validating override application and duplicate-replace behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->