### PR TITLE
Fixes #2291 For multiple doses, use the presentation to clean up how he applications are organized

### DIFF
--- a/src/MoBi.Core/Domain/Extensions/ContainerExtensions.cs
+++ b/src/MoBi.Core/Domain/Extensions/ContainerExtensions.cs
@@ -38,12 +38,12 @@ namespace MoBi.Core.Domain.Extensions
 
       public static IEnumerable<T> GetChildrenSortedByName<T>(this IContainer container, Func<T, bool> pred) where T : class, IEntity
       {
-         return container.GetChildren(pred).OrderBy(x => x.Name);
+         return container.GetChildren(pred).OrderBy(x => x.Name, new IndexedNameComparer());
       }
 
       public static IEnumerable<T> GetChildrenSortedByName<T>(this IContainer container) where T : class, IEntity
       {
-         return container.GetChildren<T>().OrderBy(x => x.Name);
+         return container.GetChildren<T>().OrderBy(x => x.Name, new IndexedNameComparer());
       }
    }
 }

--- a/src/MoBi.Core/Domain/Extensions/ContainerExtensions.cs
+++ b/src/MoBi.Core/Domain/Extensions/ContainerExtensions.cs
@@ -43,7 +43,7 @@ namespace MoBi.Core.Domain.Extensions
 
       public static IEnumerable<T> GetChildrenSortedByName<T>(this IContainer container) where T : class, IEntity
       {
-         return container.GetChildren<T>().OrderBy(x => x.Name, new IndexedNameComparer());
+         return container.GetChildrenSortedByName<T>(x => true);
       }
    }
 }

--- a/src/MoBi.Core/Domain/Extensions/IndexedNameComparer.cs
+++ b/src/MoBi.Core/Domain/Extensions/IndexedNameComparer.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MoBi.Core.Domain.Extensions
+{
+   public class IndexedNameComparer : IComparer<string>
+   {
+      public int Compare(string x, string y)
+      {
+         var xParts = x.Split('_');
+         var yParts = y.Split('_');
+
+         var prefixX = string.Join("_", xParts.Take(xParts.Length - 1));
+         var prefixY = string.Join("_", yParts.Take(yParts.Length - 1));
+
+         var prefixComparison = string.Compare(prefixX, prefixY, StringComparison.Ordinal);
+
+         // if the prefix strings are not equal then use the string comparison
+         if (prefixComparison != 0)
+            return prefixComparison;
+
+         var suffixX = xParts.Last();
+         var suffixY = yParts.Last();
+
+         // both have a numeric suffix, compare them as numbers
+         if (int.TryParse(suffixX, out var numX) && int.TryParse(suffixY, out var numY))
+            return numX.CompareTo(numY);
+
+         // fall back to string comparison if either suffix is not numeric
+         return string.Compare(suffixX, suffixY, StringComparison.Ordinal);
+      }
+   }
+}

--- a/src/MoBi.Core/Domain/Extensions/IndexedNameComparer.cs
+++ b/src/MoBi.Core/Domain/Extensions/IndexedNameComparer.cs
@@ -8,6 +8,10 @@ namespace MoBi.Core.Domain.Extensions
    {
       public int Compare(string x, string y)
       {
+         if (x == null && y == null) return 0;
+         if (x == null) return -1;
+         if (y == null) return 1;
+
          var xParts = x.Split('_');
          var yParts = y.Split('_');
 

--- a/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalStructurePresenter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;
@@ -24,7 +25,7 @@ namespace MoBi.Presentation.Presenter
    public abstract class HierarchicalStructurePresenter : AbstractCommandCollectorPresenter<IHierarchicalStructureView, IHierarchicalStructurePresenter>
    {
       protected readonly IMoBiContext _context;
-      protected IObjectBaseToObjectBaseDTOMapper _objectBaseMapper;
+      protected readonly IObjectBaseToObjectBaseDTOMapper _objectBaseMapper;
 
       protected HierarchicalStructurePresenter(
          IHierarchicalStructureView view,
@@ -45,7 +46,7 @@ namespace MoBi.Presentation.Presenter
       {
          return container.GetChildren(predicate)
             .OrderBy(groupingTypeFor)
-            .ThenBy(x => x.Name)
+            .ThenBy(x => x.Name, new IndexedNameComparer())
             .MapAllUsing(_objectBaseMapper);
       }
 

--- a/tests/MoBi.Tests/Core/Domain/Extensions/IndexedNameComparerSpecs.cs
+++ b/tests/MoBi.Tests/Core/Domain/Extensions/IndexedNameComparerSpecs.cs
@@ -1,0 +1,73 @@
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+
+namespace MoBi.Core.Domain.Extensions
+{
+   public abstract class concern_for_IndexedNameComparer : ContextSpecification<IndexedNameComparer>
+   {
+      protected override void Context()
+      {
+         sut = new IndexedNameComparer();
+      }
+   }
+
+   public class When_comparing_names_with_same_prefix_and_numeric_indexes : concern_for_IndexedNameComparer
+   {
+      [Observation]
+      public void should_sort_by_numeric_value_of_the_index()
+      {
+         (sut.Compare("application_2", "application_10") < 0).ShouldBeTrue();
+         (sut.Compare("application_10", "application_2") > 0).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_return_zero_for_equal_names()
+      {
+         sut.Compare("application_1", "application_1").ShouldBeEqualTo(0);
+      }
+
+      [Observation]
+      public void should_order_lower_index_before_higher_index()
+      {
+         (sut.Compare("application_1", "application_2") < 0).ShouldBeTrue();
+         (sut.Compare("application_5", "application_3") > 0).ShouldBeTrue();
+      }
+   }
+
+   public class When_comparing_names_with_different_prefixes : concern_for_IndexedNameComparer
+   {
+      [Observation]
+      public void should_sort_by_prefix_first()
+      {
+         (sut.Compare("alpha_1", "beta_1") < 0).ShouldBeTrue();
+         (sut.Compare("beta_1", "alpha_1") > 0).ShouldBeTrue();
+      }
+   }
+
+   public class When_comparing_names_with_multiple_underscores : concern_for_IndexedNameComparer
+   {
+      [Observation]
+      public void should_use_only_the_last_segment_as_index()
+      {
+         (sut.Compare("some_long_prefix_2", "some_long_prefix_10") < 0).ShouldBeTrue();
+         (sut.Compare("some_long_prefix_10", "some_long_prefix_2") > 0).ShouldBeTrue();
+      }
+   }
+
+   public class When_comparing_names_with_non_numeric_suffixes : concern_for_IndexedNameComparer
+   {
+      [Observation]
+      public void should_fall_back_to_string_comparison()
+      {
+         (sut.Compare("application_abc", "application_def") < 0).ShouldBeTrue();
+         (sut.Compare("application_def", "application_abc") > 0).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_fall_back_to_string_comparison_for_mismatches()
+      {
+         (sut.Compare("application_11", "application_def") < 0).ShouldBeTrue();
+         (sut.Compare("application_def", "application_11") > 0).ShouldBeTrue();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Core/Domain/Extensions/IndexedNameComparerSpecs.cs
+++ b/tests/MoBi.Tests/Core/Domain/Extensions/IndexedNameComparerSpecs.cs
@@ -70,4 +70,25 @@ namespace MoBi.Core.Domain.Extensions
          (sut.Compare("application_def", "application_11") > 0).ShouldBeTrue();
       }
    }
+
+   public class When_comparing_names_with_null_values : concern_for_IndexedNameComparer
+   {
+      [Observation]
+      public void should_return_zero_when_both_are_null()
+      {
+         sut.Compare(null, null).ShouldBeEqualTo(0);
+      }
+
+      [Observation]
+      public void should_order_null_before_non_null()
+      {
+         (sut.Compare(null, "application_1") < 0).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_order_non_null_after_null()
+      {
+         (sut.Compare("application_1", null) > 0).ShouldBeTrue();
+      }
+   }
 }


### PR DESCRIPTION
Fixes #2291 For multiple doses, use the presentation to clean up how he applications are organized

# Description
Organized sort by name a little differently

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):
<img width="213" height="181" alt="image" src="https://github.com/user-attachments/assets/b9e8d1fe-015b-4631-9757-bbddcf35250f" />

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting of hierarchical items to use an indexed-aware name comparison, so names with numeric suffixes (e.g., "item_2", "item_10") order intuitively by numeric value when appropriate.

* **Tests**
  * Added comprehensive tests covering numeric and non-numeric suffixes, multiple underscores, null handling, equality, and cross-prefix ordering to validate the new sorting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->