### PR TITLE
Fixes #2301 Add convenience methods where rSharp/R will automatically convert arrays to scalar

### DIFF
--- a/src/MoBi.R/Services/ExpressionProfileTask.cs
+++ b/src/MoBi.R/Services/ExpressionProfileTask.cs
@@ -15,6 +15,7 @@ public interface IExpressionProfileTask
 {
    ExpressionProfileBuildingBlock CreateExpressionProfile(string category, string moleculeName, string speciesName);
    void SetExpressionParameter(ExpressionProfileBuildingBlock buildingBlock, string[] quantityPaths, double[] quantityValues);
+   void SetExpressionParameter(ExpressionProfileBuildingBlock buildingBlock, string quantityPath, double quantityValue);
 }
 
 public class ExpressionProfileTask : PKSimPathAndValuesTask, IExpressionProfileTask
@@ -57,4 +58,6 @@ public class ExpressionProfileTask : PKSimPathAndValuesTask, IExpressionProfileT
 
       _context.AddToHistory(macroCommand.RunCommand(_context));
    }
+
+   public void SetExpressionParameter(ExpressionProfileBuildingBlock buildingBlock, string quantityPath, double quantityValue) => SetExpressionParameter(buildingBlock, [quantityPath], [quantityValue]);
 }

--- a/src/MoBi.R/Services/ExtendablePathAndValuesTask.cs
+++ b/src/MoBi.R/Services/ExtendablePathAndValuesTask.cs
@@ -16,8 +16,8 @@ namespace MoBi.R.Services;
 public interface IPathAndValuesTask<TBuildingBlock, TBuilder> where TBuildingBlock : PathAndValueEntityBuildingBlock<TBuilder> where TBuilder : PathAndValueEntity
 {
    string[] AllPathsFrom(TBuildingBlock buildingBlock);
-   double[] AllValuesFrom(TBuildingBlock buildingBlock, string[] paths);
-   string[] AllDimensionsFrom(TBuildingBlock buildingBlock, string[] paths);
+   double[] AllValuesFrom(TBuildingBlock buildingBlock, params string[] paths);
+   string[] AllDimensionsFrom(TBuildingBlock buildingBlock, params string[] paths);
 }
 
 public abstract class ExtendablePathAndValuesTask<TBuildingBlock, TBuilder>: IPathAndValuesTask<TBuildingBlock, TBuilder> where TBuildingBlock : PathAndValueEntityBuildingBlock<TBuilder> where TBuilder : PathAndValueEntity
@@ -104,7 +104,7 @@ public abstract class ExtendablePathAndValuesTask<TBuildingBlock, TBuilder>: IPa
 
    public string[] AllPathsFrom(TBuildingBlock buildingBlock) => AllFrom(buildingBlock, paths:null, x => x.Path.PathAsString);
 
-   public double[] AllValuesFrom(TBuildingBlock buildingBlock, string[] paths) => AllFrom(buildingBlock, paths, x => x.Value ?? double.NaN);
+   public double[] AllValuesFrom(TBuildingBlock buildingBlock, params string[] paths) => AllFrom(buildingBlock, paths, x => x.Value ?? double.NaN);
 
-   public string[] AllDimensionsFrom(TBuildingBlock buildingBlock, string[] paths) => AllFrom(buildingBlock, paths, x => x.Dimension.Name);
+   public string[] AllDimensionsFrom(TBuildingBlock buildingBlock, params string[] paths) => AllFrom(buildingBlock, paths, x => x.Dimension.Name);
 }

--- a/src/MoBi.R/Services/ExtendablePathAndValuesTask.cs
+++ b/src/MoBi.R/Services/ExtendablePathAndValuesTask.cs
@@ -18,6 +18,7 @@ public interface IPathAndValuesTask<TBuildingBlock, TBuilder> where TBuildingBlo
    string[] AllPathsFrom(TBuildingBlock buildingBlock);
    double[] AllValuesFrom(TBuildingBlock buildingBlock, params string[] paths);
    string[] AllDimensionsFrom(TBuildingBlock buildingBlock, params string[] paths);
+   string[] AllUnitsFrom(TBuildingBlock buildingBlock, params string[] paths);
 }
 
 public abstract class ExtendablePathAndValuesTask<TBuildingBlock, TBuilder>: IPathAndValuesTask<TBuildingBlock, TBuilder> where TBuildingBlock : PathAndValueEntityBuildingBlock<TBuilder> where TBuilder : PathAndValueEntity
@@ -107,4 +108,6 @@ public abstract class ExtendablePathAndValuesTask<TBuildingBlock, TBuilder>: IPa
    public double[] AllValuesFrom(TBuildingBlock buildingBlock, params string[] paths) => AllFrom(buildingBlock, paths, x => x.Value ?? double.NaN);
 
    public string[] AllDimensionsFrom(TBuildingBlock buildingBlock, params string[] paths) => AllFrom(buildingBlock, paths, x => x.Dimension.Name);
+
+   public string[] AllUnitsFrom(TBuildingBlock buildingBlock, params string[] paths) => AllFrom(buildingBlock, paths, x => x.Dimension.BaseUnit.Name);
 }

--- a/src/MoBi.R/Services/IndividualTask.cs
+++ b/src/MoBi.R/Services/IndividualTask.cs
@@ -16,6 +16,7 @@ public interface IIndividualTask
 {
    IndividualBuildingBlock CreateIndividual(IndividualCharacteristics individualCharacteristics);
    void SetIndividualParameter(IndividualBuildingBlock buildingBlock, string[] quantityPaths, double[] quantityValues);
+   void SetIndividualParameter(IndividualBuildingBlock buildingBlock, string quantityPath, double quantityValue);
 }
 
 public class IndividualTask : PKSimPathAndValuesTask, IIndividualTask
@@ -58,4 +59,6 @@ public class IndividualTask : PKSimPathAndValuesTask, IIndividualTask
 
       _context.AddToHistory(macroCommand.RunCommand(_context));
    }
+
+   public void SetIndividualParameter(IndividualBuildingBlock buildingBlock, string quantityPath, double quantityValue) => SetIndividualParameter(buildingBlock, [quantityPath], [quantityValue]);
 }

--- a/src/MoBi.R/Services/InitialConditionsTask.cs
+++ b/src/MoBi.R/Services/InitialConditionsTask.cs
@@ -24,7 +24,7 @@ public interface IInitialConditionsTask : IPathAndValuesTask<InitialConditionsBu
 
    double[] AllScaleDivisorsFrom(InitialConditionsBuildingBlock buildingBlock, params string[] paths);
 
-   bool[] AllIsPresentFrom(InitialConditionsBuildingBlock buildingBlock, string[] paths);
+   bool[] AllIsPresentFrom(InitialConditionsBuildingBlock buildingBlock, params string[] paths);
 
    bool[] AllNegativeValuesAllowedFrom(InitialConditionsBuildingBlock buildingBlock, params string[] paths);
 }

--- a/src/MoBi.R/Services/InitialConditionsTask.cs
+++ b/src/MoBi.R/Services/InitialConditionsTask.cs
@@ -13,19 +13,20 @@ namespace MoBi.R.Services;
 
 public interface IInitialConditionsTask : IPathAndValuesTask<InitialConditionsBuildingBlock, InitialCondition>
 {
-   void DeleteInitialConditions(InitialConditionsBuildingBlock buildingBlock, string[] pathsToDelete);
+   void DeleteInitialConditions(InitialConditionsBuildingBlock buildingBlock, params string[] pathsToDelete);
 
-   void ExtendInitialConditions(InitialConditionsBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, string[] moleculeNames);
+   void ExtendInitialConditions(InitialConditionsBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, params string[] moleculeNames);
 
    void SetInitialConditions(InitialConditionsBuildingBlock buildingBlock, string[] quantityPaths, string[] dimensionNames, double[] quantityValues, double[] scaleDivisors, bool[] isPresent, bool[] negativeAllowed);
+   void SetInitialConditions(InitialConditionsBuildingBlock buildingBlock, string quantityPath, string dimensionName, double quantityValue, double scaleDivisor, bool isPresent, bool negativeAllowed);
 
-   string[] AllMoleculeNamesFrom(InitialConditionsBuildingBlock buildingBlock, string[] paths);
+   string[] AllMoleculeNamesFrom(InitialConditionsBuildingBlock buildingBlock, params string[] paths);
 
-   double[] AllScaleDivisorsFrom(InitialConditionsBuildingBlock buildingBlock, string[] paths);
+   double[] AllScaleDivisorsFrom(InitialConditionsBuildingBlock buildingBlock, params string[] paths);
 
    bool[] AllIsPresentFrom(InitialConditionsBuildingBlock buildingBlock, string[] paths);
 
-   bool[] AllNegativeValuesAllowedFrom(InitialConditionsBuildingBlock buildingBlock, string[] paths);
+   bool[] AllNegativeValuesAllowedFrom(InitialConditionsBuildingBlock buildingBlock, params string[] paths);
 }
 
 public class InitialConditionsTask : ExtendablePathAndValuesTask<InitialConditionsBuildingBlock, InitialCondition>, IInitialConditionsTask
@@ -37,9 +38,9 @@ public class InitialConditionsTask : ExtendablePathAndValuesTask<InitialConditio
       _extendManager = extendManager;
    }
 
-   public void DeleteInitialConditions(InitialConditionsBuildingBlock buildingBlock, string[] pathsToDelete) => Delete(buildingBlock, pathsToDelete);
+   public void DeleteInitialConditions(InitialConditionsBuildingBlock buildingBlock, params string[] pathsToDelete) => Delete(buildingBlock, pathsToDelete);
 
-   public void ExtendInitialConditions(InitialConditionsBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, string[] moleculeNames) =>
+   public void ExtendInitialConditions(InitialConditionsBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, params string[] moleculeNames) =>
       Extend(buildingBlock, spatialStructure, moleculeBuildingBlock, moleculeNames);
 
    public void SetInitialConditions(InitialConditionsBuildingBlock buildingBlock, string[] quantityPaths, string[] dimensionNames, double[] quantityValues, double[] scaleDivisors, bool[] isPresent, bool[] negativeAllowed)
@@ -63,13 +64,16 @@ public class InitialConditionsTask : ExtendablePathAndValuesTask<InitialConditio
       _context.AddToHistory(macroCommand.RunCommand(_context));
    }
 
-   public string[] AllMoleculeNamesFrom(InitialConditionsBuildingBlock buildingBlock, string[] paths) => AllFrom(buildingBlock, paths, x => x.MoleculeName);
+   public void SetInitialConditions(InitialConditionsBuildingBlock buildingBlock, string quantityPath, string dimensionName, double quantityValue, double scaleDivisor, bool isPresent, bool negativeAllowed) =>
+      SetInitialConditions(buildingBlock, [quantityPath], [dimensionName], [quantityValue], [scaleDivisor], [isPresent], [negativeAllowed]);
 
-   public double[] AllScaleDivisorsFrom(InitialConditionsBuildingBlock buildingBlock, string[] paths) => AllFrom(buildingBlock, paths, x => x.ScaleDivisor);
+   public string[] AllMoleculeNamesFrom(InitialConditionsBuildingBlock buildingBlock, params string[] paths) => AllFrom(buildingBlock, paths, x => x.MoleculeName);
 
-   public bool[] AllIsPresentFrom(InitialConditionsBuildingBlock buildingBlock, string[] paths) => AllFrom(buildingBlock, paths, x => x.IsPresent);
+   public double[] AllScaleDivisorsFrom(InitialConditionsBuildingBlock buildingBlock, params string[] paths) => AllFrom(buildingBlock, paths, x => x.ScaleDivisor);
 
-   public bool[] AllNegativeValuesAllowedFrom(InitialConditionsBuildingBlock buildingBlock, string[] paths) => AllFrom(buildingBlock, paths, x => x.NegativeValuesAllowed);
+   public bool[] AllIsPresentFrom(InitialConditionsBuildingBlock buildingBlock, params string[] paths) => AllFrom(buildingBlock, paths, x => x.IsPresent);
+
+   public bool[] AllNegativeValuesAllowedFrom(InitialConditionsBuildingBlock buildingBlock, params string[] paths) => AllFrom(buildingBlock, paths, x => x.NegativeValuesAllowed);
 
    protected override string RemoveCommandDescription() => AppConstants.Commands.RemoveMultipleInitialConditions;
 

--- a/src/MoBi.R/Services/ParameterValuesTask.cs
+++ b/src/MoBi.R/Services/ParameterValuesTask.cs
@@ -14,10 +14,11 @@ namespace MoBi.R.Services;
 public interface IParameterValuesTask : IPathAndValuesTask<ParameterValuesBuildingBlock, ParameterValue>
 {
    void SetParameterValue(ParameterValuesBuildingBlock buildingBlock, string[] quantityPaths, double[] quantityValues, string[] dimensionNames);
+   void SetParameterValue(ParameterValuesBuildingBlock buildingBlock, string quantityPath, double quantityValue, string dimensionName);
 
-   void DeleteParameterValues(ParameterValuesBuildingBlock buildingBlock, string[] pathsToDelete);
+   void DeleteParameterValues(ParameterValuesBuildingBlock buildingBlock, params string[] pathsToDelete);
 
-   void AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, string[] moleculeNames);
+   void AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, params string[] moleculeNames);
 }
 
 public class ParameterValuesTask : ExtendablePathAndValuesTask<ParameterValuesBuildingBlock, ParameterValue>, IParameterValuesTask
@@ -40,6 +41,8 @@ public class ParameterValuesTask : ExtendablePathAndValuesTask<ParameterValuesBu
 
       _context.AddToHistory(macroCommand.RunCommand(_context));
    }
+
+   public void SetParameterValue(ParameterValuesBuildingBlock buildingBlock, string quantityPath, double quantityValue, string dimensionName) => SetParameterValue(buildingBlock, [quantityPath], [quantityValue], [dimensionName]);
 
    public void DeleteParameterValues(ParameterValuesBuildingBlock buildingBlock, string[] pathsToDelete) => Delete(buildingBlock, pathsToDelete);
 

--- a/tests/MoBi.R.Tests/Services/ParameterValuesTaskSpecs.cs
+++ b/tests/MoBi.R.Tests/Services/ParameterValuesTaskSpecs.cs
@@ -977,6 +977,49 @@ internal class When_getting_all_dimensions_from_building_block_with_specified_pa
    }
 }
 
+internal class When_getting_all_base_units_from_building_block_with_specified_paths : concern_for_ParameterValuesTask
+{
+   private ParameterValuesBuildingBlock _buildingBlock;
+   private string[] _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      _buildingBlock = new ParameterValuesBuildingBlock().WithName("PV Building Block");
+      _buildingBlock.Add(new ParameterValue
+      {
+         Path = new ObjectPath("Path1", "Container1", "Parameter1"),
+         Value = 100.0,
+         Dimension = Constants.Dimension.NO_DIMENSION
+      });
+      _buildingBlock.Add(new ParameterValue
+      {
+         Path = new ObjectPath("Path2", "Container2", "Parameter2"),
+         Value = 200.0,
+         Dimension = new Dimension(new BaseDimensionRepresentation(), "Time", "min")
+      });
+      _buildingBlock.Add(new ParameterValue
+      {
+         Path = new ObjectPath("Path3", "Container3", "Parameter3"),
+         Value = 300.0,
+         Dimension = new Dimension(new BaseDimensionRepresentation(), "Concentration", "mol/l")
+      });
+   }
+
+   protected override void Because()
+   {
+      _result = sut.AllUnitsFrom(_buildingBlock, ["Path2|Container2|Parameter2", "Path3|Container3|Parameter3"]);
+   }
+
+   [Observation]
+   public void should_return_unit_names_for_specified_paths_in_order()
+   {
+      _result.Length.ShouldBeEqualTo(2);
+      _result[0].ShouldBeEqualTo("min");
+      _result[1].ShouldBeEqualTo("mol/l");
+   }
+}
+
 internal class When_getting_all_dimensions_from_building_block_without_specified_paths : concern_for_ParameterValuesTask
 {
    private ParameterValuesBuildingBlock _buildingBlock;


### PR DESCRIPTION
Fixes #2301

R and C# do not agree on handling of scalars. In some cases we can use the `params` keyword, but in a few cases we need an alternate signature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added convenience methods for setting individual values and retrieving unit information, eliminating the need to wrap single values in arrays.
  * Introduced new unit retrieval capability for building blocks.

* **Refactor**
  * Updated method signatures to accept variable-length arguments, streamlining API calls by removing array syntax requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->