### PR TITLE
Fixes #2303 Converting PK-Sim modules when a project isn't open (as in MoBi.R)

### DIFF
--- a/src/MoBi.Core/Domain/Model/MoBiContext.cs
+++ b/src/MoBi.Core/Domain/Model/MoBiContext.cs
@@ -279,7 +279,7 @@ namespace MoBi.Core.Domain.Model
          if (!changeCommand.WillConvertPKSimModuleToExtensionModule)
             return;
 
-         if (!CurrentProject.Modules.Contains(changeCommand.Module))
+         if (CurrentProject == null || !CurrentProject.Modules.Contains(changeCommand.Module))
             return;
 
          if (confirmedModuleConversions.Contains(changeCommand.Module))

--- a/tests/MoBi.Tests/Core/MoBiContextSpecs.cs
+++ b/tests/MoBi.Tests/Core/MoBiContextSpecs.cs
@@ -417,4 +417,39 @@ namespace MoBi.Core
          A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).MustNotHaveHappened();
       }
    }
+
+   public class When_running_module_commands_that_converts_a_module_and_there_isnt_a_current_project : concern_for_MoBiContext
+   {
+      private MoBiMacroCommand _command;
+      private ParameterValue _parameterValue;
+      private ParameterValuesBuildingBlock _buildingBlock;
+      private Module _module;
+
+      protected override void Context()
+      {
+         base.Context();
+         _command = new MoBiMacroCommand();
+         sut.CurrentProject = null;
+         _parameterValue = new ParameterValue();
+         _buildingBlock = new ParameterValuesBuildingBlock();
+         _module = new Module
+         {
+            IsPKSimModule = true
+         };
+         _module.Add(_buildingBlock);
+         _command.Add(new AddParameterValueToBuildingBlockCommand(_buildingBlock, _parameterValue));
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).Returns(ViewResult.Yes);
+      }
+
+      protected override void Because()
+      {
+         sut.PromptForCancellation(_command);
+      }
+
+      [Observation]
+      public void the_user_should_not_be_prompted()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).MustNotHaveHappened();
+      }
+   }
 }


### PR DESCRIPTION
Fixes #2303 Converting PK-Sim modules when a project isn't open (as in MoBi.R)

# Description
Need to check `CurrentProject` for null

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of module operations when a project context is unavailable to prevent unintended behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->