### PR TITLE
Fixes #2306 Remove classifications when removing modules

### DIFF
--- a/src/MoBi.Core/Domain/Model/MoBiProject.cs
+++ b/src/MoBi.Core/Domain/Model/MoBiProject.cs
@@ -58,6 +58,7 @@ namespace MoBi.Core.Domain.Model
       public void RemoveModule(Module module)
       {
          _modules.Remove(module);
+         RemoveClassifiableForWrappedObject(module);
       }
 
       public IReadOnlyList<IMoBiSimulation> Simulations => _allSimulations;
@@ -148,8 +149,8 @@ namespace MoBi.Core.Domain.Model
       }
 
       /// <summary>
-      /// Returns a list of simulations that have a module where the name matches <paramref name="module"/>
-      /// This indicates that the <paramref name="module"/> was used as a template for the simulation
+      ///    Returns a list of simulations that have a module where the name matches <paramref name="module" />
+      ///    This indicates that the <paramref name="module" /> was used as a template for the simulation
       /// </summary>
       public IReadOnlyList<IMoBiSimulation> SimulationsUsing(Module module)
       {

--- a/tests/MoBi.Tests/Core/MoBiProjectSpecs.cs
+++ b/tests/MoBi.Tests/Core/MoBiProjectSpecs.cs
@@ -128,4 +128,29 @@ namespace MoBi.Core
          sut.AllClassifiables.Count.ShouldBeEqualTo(0);
       }
    }
+
+   public class When_removing_a_module : concern_for_MoBiProject
+   {
+      private Module _module;
+
+      protected override void Context()
+      {
+         base.Context();
+         _module = new Module().WithName("module").WithId("Id");
+         sut.AddModule(_module);
+         sut.GetOrCreateClassifiableFor<ClassifiableModule, Module>(_module);
+         sut.AllClassifiables.Count.ShouldBeEqualTo(1);
+      }
+
+      protected override void Because()
+      {
+         sut.RemoveModule(_module);
+      }
+
+      [Observation]
+      public void should_also_remove_the_associated_classifiable_wrapper()
+      {
+         sut.AllClassifiables.Count.ShouldBeEqualTo(0);
+      }
+   }
 }


### PR DESCRIPTION
Fixes #2306 Remove classifications when removing modules

# Description
remove classification when removing its module

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where removing a module did not properly clean up associated internal metadata, which could leave orphaned references in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->