### PR TITLE
Fixes #2325 Symmetric teardown of analysis presenters in EditSimulationPresenter

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
@@ -57,6 +57,7 @@ namespace MoBi.Presentation.Presenter
       private TrackableSimulation _trackableSimulation;
       private readonly ISimulationRunner _simulationRunner;
       private readonly ISimulationAnalysisPresenterFactory _simulationAnalysisPresenterFactory;
+      private readonly IEventPublisher _eventPublisher;
       private readonly IList<ISimulationAnalysisPresenter> _analysisPresenters = new List<ISimulationAnalysisPresenter>();
 
       public EditSimulationPresenter(
@@ -75,7 +76,8 @@ namespace MoBi.Presentation.Presenter
          ISimulationChangesPresenter changesPresenter,
          ISimulationEntitySourceReferenceFactory entitySourceReferenceFactory,
          ISimulationRunner simulationRunner,
-         ISimulationAnalysisPresenterFactory simulationAnalysisPresenterFactory)
+         ISimulationAnalysisPresenterFactory simulationAnalysisPresenterFactory,
+         IEventPublisher eventPublisher)
          : base(view)
       {
          _simulationChangesPresenter = changesPresenter;
@@ -92,6 +94,7 @@ namespace MoBi.Presentation.Presenter
          _context = context;
          _simulationRunner = simulationRunner;
          _simulationAnalysisPresenterFactory = simulationAnalysisPresenterFactory;
+         _eventPublisher = eventPublisher;
          _outputMappingMatchingTask = outputMappingMatchingTask;
          _view.SetTreeView(hierarchicalPresenter.BaseView);
          _view.SetModelDiagram(_simulationDiagramPresenter.View);
@@ -116,20 +119,21 @@ namespace MoBi.Presentation.Presenter
          base.ReleaseFrom(eventPublisher);
          _cacheShowPresenter.Each(p => p.ReleaseFrom(eventPublisher));
          _cacheShowPresenter.Clear();
-         releaseAllAnalysisPresenters(eventPublisher);
+         releaseAllAnalysisPresenters();
       }
 
-      private void releaseAllAnalysisPresenters(IEventPublisher eventPublisher)
+      private void releaseAllAnalysisPresenters()
       {
-         _analysisPresenters.Each(x => releasePresenter(x, eventPublisher));
+         _analysisPresenters.Each(removeAndReleaseAnalysisPresenter);
          _analysisPresenters.Clear();
       }
 
-      private void releasePresenter(ISimulationAnalysisPresenter presenter, IEventPublisher eventPublisher)
+      private void removeAndReleaseAnalysisPresenter(ISimulationAnalysisPresenter presenter)
       {
-         presenter.Clear();
-         presenter.ReleaseFrom(eventPublisher);
          unRegisterObservedDataEvent(presenter);
+         _view.RemoveAnalysis(presenter);
+         presenter.Clear();
+         presenter.ReleaseFrom(_eventPublisher);
       }
 
       public void Edit(IMoBiSimulation simulation)
@@ -143,6 +147,7 @@ namespace MoBi.Presentation.Presenter
          _simulationOutputMappingPresenter.EditSimulation(simulation);
          UpdateCaption();
          _view.Display();
+         releaseAllAnalysisPresenters();
          loadAnalyses();
          _trackableSimulation = new TrackableSimulation(_simulation, _entitySourceReferenceFactory.CreateFor(simulation));
          _favoritesPresenter.TrackableSimulation = _trackableSimulation;
@@ -175,11 +180,9 @@ namespace MoBi.Presentation.Presenter
 
       public void RemoveAnalysis(ISimulationAnalysisPresenter analysisPresenter)
       {
-         _analysisPresenters.Remove(analysisPresenter);
          _simulation.RemoveAnalysis(analysisPresenter.Analysis);
-         _view.RemoveAnalysis(analysisPresenter);
-         analysisPresenter.Clear();
-         unRegisterObservedDataEvent(analysisPresenter);
+         removeAndReleaseAnalysisPresenter(analysisPresenter);
+         _analysisPresenters.Remove(analysisPresenter);
       }
 
       public override void Edit(object subject) => Edit(subject.DowncastTo<IMoBiSimulation>());

--- a/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
@@ -124,8 +124,7 @@ namespace MoBi.Presentation.Presenter
 
       private void releaseAllAnalysisPresenters()
       {
-         _analysisPresenters.Each(removeAndReleaseAnalysisPresenter);
-         _analysisPresenters.Clear();
+         _analysisPresenters.ToList().Each(removeAndReleaseAnalysisPresenter);
       }
 
       private void removeAndReleaseAnalysisPresenter(ISimulationAnalysisPresenter presenter)
@@ -134,6 +133,7 @@ namespace MoBi.Presentation.Presenter
          _view.RemoveAnalysis(presenter);
          presenter.Clear();
          presenter.ReleaseFrom(_eventPublisher);
+         _analysisPresenters.Remove(presenter);
       }
 
       public void Edit(IMoBiSimulation simulation)
@@ -182,7 +182,6 @@ namespace MoBi.Presentation.Presenter
       {
          _simulation.RemoveAnalysis(analysisPresenter.Analysis);
          removeAndReleaseAnalysisPresenter(analysisPresenter);
-         _analysisPresenters.Remove(analysisPresenter);
       }
 
       public override void Edit(object subject) => Edit(subject.DowncastTo<IMoBiSimulation>());

--- a/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
@@ -16,6 +16,7 @@ using OSPSuite.Core.Events;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Views;
+using OSPSuite.Utility.Events;
 
 namespace MoBi.Presentation
 {
@@ -35,6 +36,7 @@ namespace MoBi.Presentation
       protected ISimulationEntitySourceReferenceFactory _entitySourceReferenceFactory;
       protected ISimulationRunner _simulationRunner;
       protected ISimulationAnalysisPresenterFactory _simulationAnalysisPresenterFactory;
+      protected IEventPublisher _eventPublisher;
       private ISimulationChangesPresenter _simulationChangesPresenter;
 
       protected override void Context()
@@ -54,12 +56,13 @@ namespace MoBi.Presentation
          _entitySourceReferenceFactory = A.Fake<ISimulationEntitySourceReferenceFactory>();
          _simulationRunner = A.Fake<ISimulationRunner>();
          _simulationAnalysisPresenterFactory = A.Fake<ISimulationAnalysisPresenterFactory>();
+         _eventPublisher = A.Fake<IEventPublisher>();
 
          sut = new EditSimulationPresenter(_view, _hierarchicalSimulationPresenter, _diagramPresenter,
             _solverSettings, _outputSchemaPresenter, _presenterFactory, new HeavyWorkManagerForSpecs(),
             _editFavoritePresenter, _userDefinedParametersPresenter, _simulationOutputMappingPresenter,
             _context, _outputMappingMatchingTask, _simulationChangesPresenter, _entitySourceReferenceFactory,
-            _simulationRunner, _simulationAnalysisPresenterFactory);
+            _simulationRunner, _simulationAnalysisPresenterFactory, _eventPublisher);
       }
    }
 
@@ -270,6 +273,12 @@ namespace MoBi.Presentation
       {
          A.CallTo(() => _analysisPresenter.Clear()).MustHaveHappened();
       }
+
+      [Observation]
+      public void should_release_the_presenter_from_events()
+      {
+         A.CallTo(() => _analysisPresenter.ReleaseFrom(_eventPublisher)).MustHaveHappened();
+      }
    }
 
    public class When_the_simulation_presenter_is_handling_a_favorite_selected_event : concern_for_EditSimulationPresenter
@@ -339,11 +348,17 @@ namespace MoBi.Presentation
    public class When_the_simulation_presenter_is_notified_that_the_edit_simulation_was_reloaded : concern_for_EditSimulationPresenter
    {
       private IMoBiSimulation _simulation;
+      private ISimulationAnalysisPresenter _analysisPresenter;
+      private MoBiSimulationTimeProfileChart _chart;
 
       protected override void Context()
       {
          base.Context();
          _simulation = A.Fake<IMoBiSimulation>();
+         _chart = new MoBiSimulationTimeProfileChart();
+         A.CallTo(() => _simulation.Analyses).Returns(new ISimulationAnalysis[] { _chart });
+         _analysisPresenter = A.Fake<ISimulationAnalysisPresenter>();
+         A.CallTo(() => _simulationAnalysisPresenterFactory.PresenterFor(_chart)).Returns(_analysisPresenter);
          sut.Edit(_simulation);
       }
 
@@ -363,6 +378,13 @@ namespace MoBi.Presentation
       {
          // Needs to be at least twice because first time it's called during set up.
          A.CallTo(() => _hierarchicalSimulationPresenter.Edit(_simulation)).MustHaveHappenedTwiceOrMore();
+      }
+
+      [Observation]
+      public void should_release_existing_analysis_presenters_before_reloading()
+      {
+         A.CallTo(() => _analysisPresenter.Clear()).MustHaveHappened();
+         A.CallTo(() => _analysisPresenter.ReleaseFrom(_eventPublisher)).MustHaveHappened();
       }
    }
 


### PR DESCRIPTION
Fixes #2325 Symmetric teardown of analysis presenters in EditSimulationPresenter

# Description
- Add removeAndReleaseAnalysisPresenter helper for consistent cleanup
- Clear existing analysis presenters before loadAnalyses in Edit()
- Fix RemoveAnalysis to call ReleaseFrom on the presenter
- Inject IEventPublisher for use during teardown

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved event handling and presenter cleanup during analysis removal and simulation switching for better stability and reliability.
* **Tests**
  * Added/updated tests to ensure analysis presenters are properly released during removal and simulation reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->