### PR TITLE
Fixes #2329 ParameterValuesTask.SetParameterValue does not update the dimension of an existing entry

### DIFF
--- a/src/MoBi.Core/Services/ExtendPathAndValuesManager.cs
+++ b/src/MoBi.Core/Services/ExtendPathAndValuesManager.cs
@@ -8,6 +8,7 @@ using MoBi.Core.Domain.Services;
 using MoBi.Core.Extensions;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Domain.UnitSystem;
 
 namespace MoBi.Core.Services;
 
@@ -45,12 +46,14 @@ public abstract class ExtendPathAndValuesManager<T> : AbstractMergeManager<T>, I
    private readonly IMoBiFormulaTask _moBiFormulaTask;
    private readonly IObjectTypeResolver _objectTypeResolver;
    private readonly IMoBiContext _context;
+   protected readonly IDimensionFactory _dimensionFactory;
 
-   protected ExtendPathAndValuesManager(IMoBiFormulaTask moBiFormulaTask, IObjectTypeResolver objectTypeResolver, IMoBiContext context)
+   protected ExtendPathAndValuesManager(IMoBiFormulaTask moBiFormulaTask, IObjectTypeResolver objectTypeResolver, IMoBiContext context, IDimensionFactory dimensionFactory)
    {
       _moBiFormulaTask = moBiFormulaTask;
       _objectTypeResolver = objectTypeResolver;
       _context = context;
+      _dimensionFactory = dimensionFactory;
    }
 
    public Action<T> RemoveAction
@@ -112,6 +115,23 @@ public abstract class ExtendPathAndValuesManager<T> : AbstractMergeManager<T>, I
    protected abstract IMoBiCommand GenerateRemoveCommand(ILookupBuildingBlock<T> targetBuildingBlock, T entityToRemove);
 
    public abstract IMoBiCommand GenerateAddCommand(ILookupBuildingBlock<T> targetBuildingBlock, T entityToAdd);
+
+   protected IMoBiCommand UpdateValueAndDimension(IMoBiCommand updateValueCommand, ILookupBuildingBlock<T> buildingBlock, T pathAndValueEntity, string dimensionName)
+   {
+      var newDimension = _dimensionFactory.Dimension(dimensionName);
+      if (Equals(pathAndValueEntity.Dimension, newDimension))
+         return updateValueCommand;
+
+      var macroCommand = new MoBiMacroCommand
+      {
+         CommandType = AppConstants.Commands.UpdateCommand,
+         ObjectType = _objectTypeResolver.TypeFor<T>()
+      };
+
+      macroCommand.Add(updateValueCommand);
+      macroCommand.Add(new UpdateDimensionInPathAndValueEntityCommand<T>(pathAndValueEntity, newDimension, newDimension.DefaultUnit, buildingBlock));
+      return macroCommand;
+   }
 
    public IMoBiCommand Extend(IReadOnlyList<T> pathAndValueEntities, ILookupBuildingBlock<T> buildingBlockToExtend, bool retainConflictingEntities = true)
    {

--- a/src/MoBi.Core/Services/InitialConditionsBuildingBlockExtendManager.cs
+++ b/src/MoBi.Core/Services/InitialConditionsBuildingBlockExtendManager.cs
@@ -5,6 +5,7 @@ using MoBi.Core.Commands;
 using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
+using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
@@ -57,7 +58,7 @@ public class InitialConditionsBuildingBlockExtendManager : ExtendPathAndValuesMa
    {
       var pathAndValueEntity = buildingBlock[properties.ObjectPath];
       if (pathAndValueEntity != null)
-         return new UpdateInitialConditionInBuildingBlockCommand(buildingBlock, properties.ObjectPath, properties.ValueInBaseUnit, properties.IsPresent, properties.ScaleDivisor, properties.NegativeAllowed);
+         return updateValueAndDimension(buildingBlock, pathAndValueEntity, properties);
 
       var moleculeName = properties.ObjectPath.Last();
       var containerPath = properties.ObjectPath.Clone<ObjectPath>();
@@ -77,5 +78,24 @@ public class InitialConditionsBuildingBlockExtendManager : ExtendPathAndValuesMa
       );
 
       return GenerateAddCommand(buildingBlock, initialCondition);
+   }
+
+   private IMoBiCommand updateValueAndDimension(InitialConditionsBuildingBlock buildingBlock, InitialCondition pathAndValueEntity, InitialConditionPropertiesForMerge properties)
+   {
+      var updateValueCommand = new UpdateInitialConditionInBuildingBlockCommand(buildingBlock, properties.ObjectPath, properties.ValueInBaseUnit, properties.IsPresent, properties.ScaleDivisor, properties.NegativeAllowed);
+
+      var newDimension = _dimensionFactory.Dimension(properties.DimensionName);
+      if (Equals(pathAndValueEntity.Dimension, newDimension))
+         return updateValueCommand;
+
+      var macroCommand = new MoBiMacroCommand
+      {
+         CommandType = AppConstants.Commands.UpdateCommand,
+         ObjectType = ObjectTypes.InitialCondition
+      };
+
+      macroCommand.Add(updateValueCommand);
+      macroCommand.Add(new UpdateDimensionInPathAndValueEntityCommand<InitialCondition>(pathAndValueEntity, newDimension, newDimension.DefaultUnit, buildingBlock));
+      return macroCommand;
    }
 }

--- a/src/MoBi.Core/Services/InitialConditionsBuildingBlockExtendManager.cs
+++ b/src/MoBi.Core/Services/InitialConditionsBuildingBlockExtendManager.cs
@@ -5,7 +5,6 @@ using MoBi.Core.Commands;
 using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
-using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
@@ -22,17 +21,15 @@ public interface IInitialConditionsBuildingBlockExtendManager : IExtendPathAndVa
 public class InitialConditionsBuildingBlockExtendManager : ExtendPathAndValuesManager<InitialCondition>, IInitialConditionsBuildingBlockExtendManager
 {
    private readonly IInitialConditionsCreator _initialConditionsCreator;
-   private readonly IDimensionFactory _dimensionFactory;
 
    public InitialConditionsBuildingBlockExtendManager(
       IInitialConditionsCreator initialConditionsCreator,
       IMoBiFormulaTask moBiFormulaTask,
       IObjectTypeResolver objectTypeResolver,
       IMoBiContext moBiContext,
-      IDimensionFactory dimensionFactory) : base(moBiFormulaTask, objectTypeResolver, moBiContext)
+      IDimensionFactory dimensionFactory) : base(moBiFormulaTask, objectTypeResolver, moBiContext, dimensionFactory)
    {
       _initialConditionsCreator = initialConditionsCreator;
-      _dimensionFactory = dimensionFactory;
    }
 
    private void updateDefaultIsPresentToFalseForSpecificExtendedValues(IReadOnlyList<InitialCondition> allInitialConditions, IReadOnlyList<InitialCondition> templateValues)
@@ -58,7 +55,10 @@ public class InitialConditionsBuildingBlockExtendManager : ExtendPathAndValuesMa
    {
       var pathAndValueEntity = buildingBlock[properties.ObjectPath];
       if (pathAndValueEntity != null)
-         return updateValueAndDimension(buildingBlock, pathAndValueEntity, properties);
+      {
+         var updateValueCommand = new UpdateInitialConditionInBuildingBlockCommand(buildingBlock, properties.ObjectPath, properties.ValueInBaseUnit, properties.IsPresent, properties.ScaleDivisor, properties.NegativeAllowed);
+         return UpdateValueAndDimension(updateValueCommand, buildingBlock, pathAndValueEntity, properties.DimensionName);
+      }
 
       var moleculeName = properties.ObjectPath.Last();
       var containerPath = properties.ObjectPath.Clone<ObjectPath>();
@@ -78,24 +78,5 @@ public class InitialConditionsBuildingBlockExtendManager : ExtendPathAndValuesMa
       );
 
       return GenerateAddCommand(buildingBlock, initialCondition);
-   }
-
-   private IMoBiCommand updateValueAndDimension(InitialConditionsBuildingBlock buildingBlock, InitialCondition pathAndValueEntity, InitialConditionPropertiesForMerge properties)
-   {
-      var updateValueCommand = new UpdateInitialConditionInBuildingBlockCommand(buildingBlock, properties.ObjectPath, properties.ValueInBaseUnit, properties.IsPresent, properties.ScaleDivisor, properties.NegativeAllowed);
-
-      var newDimension = _dimensionFactory.Dimension(properties.DimensionName);
-      if (Equals(pathAndValueEntity.Dimension, newDimension))
-         return updateValueCommand;
-
-      var macroCommand = new MoBiMacroCommand
-      {
-         CommandType = AppConstants.Commands.UpdateCommand,
-         ObjectType = ObjectTypes.InitialCondition
-      };
-
-      macroCommand.Add(updateValueCommand);
-      macroCommand.Add(new UpdateDimensionInPathAndValueEntityCommand<InitialCondition>(pathAndValueEntity, newDimension, newDimension.DefaultUnit, buildingBlock));
-      return macroCommand;
    }
 }

--- a/src/MoBi.Core/Services/ParameterValueBuildingBlockExtendManager.cs
+++ b/src/MoBi.Core/Services/ParameterValueBuildingBlockExtendManager.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using MoBi.Assets;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
+using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
@@ -36,7 +38,7 @@ public class ParameterValueBuildingBlockExtendManager : ExtendPathAndValuesManag
    {
       var pathAndValueEntity = buildingBlock[objectPath];
       if (pathAndValueEntity != null)
-         return new UpdateParameterValueInBuildingBlockCommand(buildingBlock, objectPath, valueInBaseUnit);
+         return updateValueAndDimension(buildingBlock, pathAndValueEntity, objectPath, valueInBaseUnit, dimensionName);
 
       var dimension = _dimensionFactory.Dimension(dimensionName);
 
@@ -49,5 +51,24 @@ public class ParameterValueBuildingBlockExtendManager : ExtendPathAndValuesManag
       );
 
       return GenerateAddCommand(buildingBlock, parameterValue);
+   }
+
+   private IMoBiCommand updateValueAndDimension(ParameterValuesBuildingBlock buildingBlock, ParameterValue pathAndValueEntity, ObjectPath objectPath, double valueInBaseUnit, string dimensionName)
+   {
+      var updateValueCommand = new UpdateParameterValueInBuildingBlockCommand(buildingBlock, objectPath, valueInBaseUnit);
+
+      var newDimension = _dimensionFactory.Dimension(dimensionName);
+      if (Equals(pathAndValueEntity.Dimension, newDimension))
+         return updateValueCommand;
+
+      var macroCommand = new MoBiMacroCommand
+      {
+         CommandType = AppConstants.Commands.UpdateCommand,
+         ObjectType = ObjectTypes.ParameterValue
+      };
+
+      macroCommand.Add(updateValueCommand);
+      macroCommand.Add(new UpdateDimensionInPathAndValueEntityCommand<ParameterValue>(pathAndValueEntity, newDimension, newDimension.DefaultUnit, buildingBlock));
+      return macroCommand;
    }
 }

--- a/src/MoBi.Core/Services/ParameterValueBuildingBlockExtendManager.cs
+++ b/src/MoBi.Core/Services/ParameterValueBuildingBlockExtendManager.cs
@@ -1,9 +1,7 @@
 ﻿using System.Collections.Generic;
-using MoBi.Assets;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
-using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
@@ -19,12 +17,10 @@ public interface IParameterValueBuildingBlockExtendManager : IExtendPathAndValue
 public class ParameterValueBuildingBlockExtendManager : ExtendPathAndValuesManager<ParameterValue>, IParameterValueBuildingBlockExtendManager
 {
    private readonly IParameterValuesCreator _parameterValuesCreator;
-   private readonly IDimensionFactory _dimensionFactory;
 
-   public ParameterValueBuildingBlockExtendManager(IParameterValuesCreator parameterValuesCreator, IMoBiFormulaTask moBiFormulaTask, IObjectTypeResolver objectTypeResolver, IMoBiContext moBiContext, IDimensionFactory dimensionFactory) : base(moBiFormulaTask, objectTypeResolver, moBiContext)
+   public ParameterValueBuildingBlockExtendManager(IParameterValuesCreator parameterValuesCreator, IMoBiFormulaTask moBiFormulaTask, IObjectTypeResolver objectTypeResolver, IMoBiContext moBiContext, IDimensionFactory dimensionFactory) : base(moBiFormulaTask, objectTypeResolver, moBiContext, dimensionFactory)
    {
       _parameterValuesCreator = parameterValuesCreator;
-      _dimensionFactory = dimensionFactory;
    }
 
    protected override IReadOnlyList<ParameterValue> CreatePathAndValueEntitiesBasedOnUsedTemplates(SpatialStructure spatialStructure, IReadOnlyList<MoleculeBuilder> molecules, ILookupBuildingBlock<ParameterValue> buildingBlock) =>
@@ -38,7 +34,10 @@ public class ParameterValueBuildingBlockExtendManager : ExtendPathAndValuesManag
    {
       var pathAndValueEntity = buildingBlock[objectPath];
       if (pathAndValueEntity != null)
-         return updateValueAndDimension(buildingBlock, pathAndValueEntity, objectPath, valueInBaseUnit, dimensionName);
+      {
+         var updateValueCommand = new UpdateParameterValueInBuildingBlockCommand(buildingBlock, objectPath, valueInBaseUnit);
+         return UpdateValueAndDimension(updateValueCommand, buildingBlock, pathAndValueEntity, dimensionName);
+      }
 
       var dimension = _dimensionFactory.Dimension(dimensionName);
 
@@ -51,24 +50,5 @@ public class ParameterValueBuildingBlockExtendManager : ExtendPathAndValuesManag
       );
 
       return GenerateAddCommand(buildingBlock, parameterValue);
-   }
-
-   private IMoBiCommand updateValueAndDimension(ParameterValuesBuildingBlock buildingBlock, ParameterValue pathAndValueEntity, ObjectPath objectPath, double valueInBaseUnit, string dimensionName)
-   {
-      var updateValueCommand = new UpdateParameterValueInBuildingBlockCommand(buildingBlock, objectPath, valueInBaseUnit);
-
-      var newDimension = _dimensionFactory.Dimension(dimensionName);
-      if (Equals(pathAndValueEntity.Dimension, newDimension))
-         return updateValueCommand;
-
-      var macroCommand = new MoBiMacroCommand
-      {
-         CommandType = AppConstants.Commands.UpdateCommand,
-         ObjectType = ObjectTypes.ParameterValue
-      };
-
-      macroCommand.Add(updateValueCommand);
-      macroCommand.Add(new UpdateDimensionInPathAndValueEntityCommand<ParameterValue>(pathAndValueEntity, newDimension, newDimension.DefaultUnit, buildingBlock));
-      return macroCommand;
    }
 }

--- a/src/MoBi.R/Services/ParameterValuesTask.cs
+++ b/src/MoBi.R/Services/ParameterValuesTask.cs
@@ -13,10 +13,13 @@ namespace MoBi.R.Services;
 
 public interface IParameterValuesTask : IPathAndValuesTask<ParameterValuesBuildingBlock, ParameterValue>
 {
-   void SetParameterValue(ParameterValuesBuildingBlock buildingBlock, string[] quantityPaths, double[] quantityValues, string[] dimensionNames);
-   void SetParameterValue(ParameterValuesBuildingBlock buildingBlock, string quantityPath, double quantityValue, string dimensionName);
+   void SetParameterValues(ParameterValuesBuildingBlock buildingBlock, string[] quantityPaths, double[] quantityValues, string[] dimensionNames);
+   
+   void SetParameterValues(ParameterValuesBuildingBlock buildingBlock, string quantityPath, double quantityValue, string dimensionName);
 
    void DeleteParameterValues(ParameterValuesBuildingBlock buildingBlock, params string[] pathsToDelete);
+   
+   void DeleteParameterValues(ParameterValuesBuildingBlock buildingBlock, string pathToDelete);
 
    string[] AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, params string[] moleculeNames);
 }
@@ -30,7 +33,7 @@ public class ParameterValuesTask : ExtendablePathAndValuesTask<ParameterValuesBu
       _extendManager = extendManager;
    }
 
-   public void SetParameterValue(ParameterValuesBuildingBlock buildingBlock, string[] quantityPaths, double[] quantityValues, string[] dimensionNames)
+   public void SetParameterValues(ParameterValuesBuildingBlock buildingBlock, string[] quantityPaths, double[] quantityValues, string[] dimensionNames)
    {
       if (!quantityPaths.HasConsistentLengthWith(dimensionNames, quantityValues))
          throw new ArgumentException(Exceptions.AllArraysMustHaveTheSameLength);
@@ -42,9 +45,11 @@ public class ParameterValuesTask : ExtendablePathAndValuesTask<ParameterValuesBu
       _context.AddToHistory(macroCommand.RunCommand(_context));
    }
 
-   public void SetParameterValue(ParameterValuesBuildingBlock buildingBlock, string quantityPath, double quantityValue, string dimensionName) => SetParameterValue(buildingBlock, [quantityPath], [quantityValue], [dimensionName]);
+   public void SetParameterValues(ParameterValuesBuildingBlock buildingBlock, string quantityPath, double quantityValue, string dimensionName) => SetParameterValues(buildingBlock, [quantityPath], [quantityValue], [dimensionName]);
 
    public void DeleteParameterValues(ParameterValuesBuildingBlock buildingBlock, string[] pathsToDelete) => Delete(buildingBlock, pathsToDelete);
+
+   public void DeleteParameterValues(ParameterValuesBuildingBlock buildingBlock, string pathToDelete) => DeleteParameterValues(buildingBlock, [pathToDelete]);
 
    public string[] AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, string[] moleculeNames) =>
       Extend(buildingBlock, spatialStructure, moleculeBuildingBlock, moleculeNames);

--- a/src/MoBi.R/Services/ParameterValuesTask.cs
+++ b/src/MoBi.R/Services/ParameterValuesTask.cs
@@ -22,7 +22,6 @@ public interface IParameterValuesTask : IPathAndValuesTask<ParameterValuesBuildi
    void DeleteParameterValues(ParameterValuesBuildingBlock buildingBlock, string pathToDelete);
 
    string[] AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, params string[] moleculeNames);
-   string[] AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, string moleculeName);
 }
 
 public class ParameterValuesTask : ExtendablePathAndValuesTask<ParameterValuesBuildingBlock, ParameterValue>, IParameterValuesTask
@@ -52,11 +51,8 @@ public class ParameterValuesTask : ExtendablePathAndValuesTask<ParameterValuesBu
 
    public void DeleteParameterValues(ParameterValuesBuildingBlock buildingBlock, string pathToDelete) => DeleteParameterValues(buildingBlock, [pathToDelete]);
 
-   public string[] AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, string[] moleculeNames) =>
+   public string[] AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, params string[] moleculeNames) =>
       Extend(buildingBlock, spatialStructure, moleculeBuildingBlock, moleculeNames);
-
-   public string[] AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, string moleculeName) =>
-      AddLocalMoleculeParameters(buildingBlock, spatialStructure, moleculeBuildingBlock, [moleculeName]);
 
    protected override string RemoveCommandDescription() => Commands.RemoveManyParameterValues;
 

--- a/src/MoBi.R/Services/ParameterValuesTask.cs
+++ b/src/MoBi.R/Services/ParameterValuesTask.cs
@@ -22,6 +22,7 @@ public interface IParameterValuesTask : IPathAndValuesTask<ParameterValuesBuildi
    void DeleteParameterValues(ParameterValuesBuildingBlock buildingBlock, string pathToDelete);
 
    string[] AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, params string[] moleculeNames);
+   string[] AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, string moleculeName);
 }
 
 public class ParameterValuesTask : ExtendablePathAndValuesTask<ParameterValuesBuildingBlock, ParameterValue>, IParameterValuesTask
@@ -53,6 +54,9 @@ public class ParameterValuesTask : ExtendablePathAndValuesTask<ParameterValuesBu
 
    public string[] AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, string[] moleculeNames) =>
       Extend(buildingBlock, spatialStructure, moleculeBuildingBlock, moleculeNames);
+
+   public string[] AddLocalMoleculeParameters(ParameterValuesBuildingBlock buildingBlock, MoBiSpatialStructure spatialStructure, MoleculeBuildingBlock moleculeBuildingBlock, string moleculeName) =>
+      AddLocalMoleculeParameters(buildingBlock, spatialStructure, moleculeBuildingBlock, [moleculeName]);
 
    protected override string RemoveCommandDescription() => Commands.RemoveManyParameterValues;
 

--- a/tests/MoBi.R.Tests/Services/InitialConditionsTaskSpecs.cs
+++ b/tests/MoBi.R.Tests/Services/InitialConditionsTaskSpecs.cs
@@ -8,6 +8,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Utility.Extensions;
 
 namespace MoBi.R.Tests.Services;
@@ -619,6 +620,60 @@ internal class When_setting_initial_conditions_that_all_already_exist_with_proje
       var ic2 = _buildingBlock.FindByPath("TopContainer|Physical|Molecule2");
       ic1.NegativeValuesAllowed.ShouldBeFalse();
       ic2.NegativeValuesAllowed.ShouldBeTrue();
+   }
+}
+
+internal class When_setting_initial_conditions_with_different_dimension_on_existing_entries : concern_for_InitialConditionsTask_with_project
+{
+   private InitialConditionsBuildingBlock _buildingBlock;
+   private IDimension _originalDimension;
+
+   protected override void Context()
+   {
+      base.Context();
+
+      _buildingBlock = new InitialConditionsBuildingBlock().WithName("IC Building Block");
+
+      var dimensionFactory = OSPSuite.R.Api.Container.Resolve<IDimensionFactory>();
+      _originalDimension = dimensionFactory.Dimension("Volume");
+
+      var initialCondition = new InitialCondition
+      {
+         Path = new ObjectPath("TopContainer", "Physical", "Molecule1"),
+         Value = 1.5,
+         Dimension = _originalDimension,
+         IsPresent = true
+      };
+
+      _buildingBlock.Add(initialCondition);
+      AddBuildingBlocksToProject(_buildingBlock);
+   }
+
+   protected override void Because()
+   {
+      sut.SetInitialConditions(
+         _buildingBlock,
+         quantityPaths: ["TopContainer|Physical|Molecule1"],
+         dimensionNames: ["Amount"],
+         quantityValues: [1],
+         scaleDivisors: [1],
+         isPresent: [true],
+         negativeAllowed: [false]
+      );
+   }
+
+   [Observation]
+   public void should_update_the_dimension_of_the_initial_condition()
+   {
+      var ic = _buildingBlock.FindByPath("TopContainer|Physical|Molecule1");
+      ic.Dimension.Name.ShouldBeEqualTo("Amount");
+   }
+
+   [Observation]
+   public void should_update_the_value()
+   {
+      var ic = _buildingBlock.FindByPath("TopContainer|Physical|Molecule1");
+      ic.Value.ShouldBeEqualTo(1);
    }
 }
 

--- a/tests/MoBi.R.Tests/Services/ParameterValuesTaskSpecs.cs
+++ b/tests/MoBi.R.Tests/Services/ParameterValuesTaskSpecs.cs
@@ -527,7 +527,7 @@ internal class When_setting_parameter_values_with_inconsistent_array_lengths : c
    [Observation]
    public void should_throw_argument_exception()
    {
-      The.Action(() => sut.SetParameterValue(
+      The.Action(() => sut.SetParameterValues(
          _buildingBlock,
          quantityPaths: ["Path1|Container1|Parameter1", "Path2|Container2|Parameter2"],
          quantityValues: [100, 200],
@@ -569,7 +569,7 @@ internal class When_setting_parameter_values_that_all_already_exist_with_project
 
    protected override void Because()
    {
-      sut.SetParameterValue(
+      sut.SetParameterValues(
          _buildingBlock,
          quantityPaths: ["TopContainer|Physical|Parameter1", "TopContainer|Physical|Parameter2"],
          quantityValues: [100, 200],
@@ -592,6 +592,56 @@ internal class When_setting_parameter_values_that_all_already_exist_with_project
    }
 }
 
+internal class When_setting_parameter_values_with_different_dimension_on_existing_entries : concern_for_ParameterValuesTask_with_project
+{
+   private ParameterValuesBuildingBlock _buildingBlock;
+   private IDimension _originalDimension;
+
+   protected override void Context()
+   {
+      base.Context();
+
+      _buildingBlock = new ParameterValuesBuildingBlock().WithName("PV Building Block");
+
+      var dimensionFactory = OSPSuite.R.Api.Container.Resolve<IDimensionFactory>();
+      _originalDimension = dimensionFactory.Dimension("Volume");
+
+      var parameterValue = new ParameterValue
+      {
+         Path = new ObjectPath("TopContainer", "Physical", "Parameter1"),
+         Value = 1.5,
+         Dimension = _originalDimension
+      };
+
+      _buildingBlock.Add(parameterValue);
+      AddBuildingBlocksToProject(_buildingBlock);
+   }
+
+   protected override void Because()
+   {
+      sut.SetParameterValues(
+         _buildingBlock,
+         quantityPaths: ["TopContainer|Physical|Parameter1"],
+         quantityValues: [1],
+         dimensionNames: ["Amount"]
+      );
+   }
+
+   [Observation]
+   public void should_update_the_dimension_of_the_parameter_value()
+   {
+      var pv = _buildingBlock.FindByPath("TopContainer|Physical|Parameter1");
+      pv.Dimension.Name.ShouldBeEqualTo("Amount");
+   }
+
+   [Observation]
+   public void should_update_the_value()
+   {
+      var pv = _buildingBlock.FindByPath("TopContainer|Physical|Parameter1");
+      pv.Value.ShouldBeEqualTo(1);
+   }
+}
+
 internal class When_setting_parameter_values_that_dont_exist_with_project : concern_for_ParameterValuesTask_with_project
 {
    private ParameterValuesBuildingBlock _buildingBlock;
@@ -607,7 +657,7 @@ internal class When_setting_parameter_values_that_dont_exist_with_project : conc
 
    protected override void Because()
    {
-      sut.SetParameterValue(
+      sut.SetParameterValues(
          _buildingBlock,
          quantityPaths: ["TopContainer|Physical|Parameter1", "TopContainer|Physical|Parameter2"],
          quantityValues: [150, 250],
@@ -666,7 +716,7 @@ internal class When_setting_parameter_values_with_mix_of_existing_and_new_with_p
 
    protected override void Because()
    {
-      sut.SetParameterValue(
+      sut.SetParameterValues(
          _buildingBlock,
          quantityPaths: ["TopContainer|Physical|Parameter1", "TopContainer|Physical|Parameter2", "TopContainer|Physical|Parameter3"],
          quantityValues: [100, 200, 300],
@@ -735,7 +785,7 @@ internal class When_setting_parameter_values_that_all_already_exist : concern_fo
 
    protected override void Because()
    {
-      sut.SetParameterValue(
+      sut.SetParameterValues(
          _buildingBlock,
          quantityPaths: ["TopContainer|Physical|Parameter1", "TopContainer|Physical|Parameter2"],
          quantityValues: [100, 200],
@@ -771,7 +821,7 @@ internal class When_setting_parameter_values_that_dont_exist : concern_for_Param
 
    protected override void Because()
    {
-      sut.SetParameterValue(
+      sut.SetParameterValues(
          _buildingBlock,
          quantityPaths: ["TopContainer|Physical|Parameter1", "TopContainer|Physical|Parameter2"],
          quantityValues: [150, 250],
@@ -828,7 +878,7 @@ internal class When_setting_parameter_values_with_mix_of_existing_and_new : conc
 
    protected override void Because()
    {
-      sut.SetParameterValue(
+      sut.SetParameterValues(
          _buildingBlock,
          quantityPaths: ["TopContainer|Physical|Parameter1", "TopContainer|Physical|Parameter2", "TopContainer|Physical|Parameter3"],
          quantityValues: [100, 200, 300],


### PR DESCRIPTION
Fixes #2329 ParameterValuesTask.SetParameterValue does not update the dimension of an existing entry

# Description
Added a dimension change to the update for parameter value and initial conditions in MoBi.R

## Type of change

Please mark relevant options with an `x` in the brackets.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [ ] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updates to parameter values and initial conditions now synchronize numeric value and unit/dimension together when a different dimension is supplied.

* **Refactor**
  * Public API renamed for consistency: SetParameterValue → SetParameterValues (single-item overloads added); single-path delete overload added.
  * Dimension-handling centralized so updates can include dimension synchronization.

* **Tests**
  * Added tests verifying dimension changes are applied when updating existing entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->