### PR TITLE
Fixes #2331 Always show building block selection dialog when extending

### DIFF
--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExtendablePathAndValueEntity.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForExtendablePathAndValueEntity.cs
@@ -277,13 +277,6 @@ namespace MoBi.Presentation.Tasks.Interaction
          if (moleculeBlockCollection.Count == 0 && spatialStructureCollection.Count == 0)
             return (null, Enumerable.Empty<MoleculeBuilder>().ToList());
 
-         // If there is only one option that could be selected for each required building block, then we just use those options and don't
-         // need to ask the user to make a selection
-         if (!shouldSelectBuildingBlocks(moleculeBlockCollection, spatialStructureCollection))
-         {
-            return (spatialStructureCollection.Single(), moleculeBlockCollection.Single().ToList());
-         }
-
          using (var selectorPresenter = Context.Resolve<ISelectSpatialStructureAndMoleculesPresenter>())
          {
             actionToSelectBuildingBlocks(selectorPresenter);
@@ -291,15 +284,6 @@ namespace MoBi.Presentation.Tasks.Interaction
          }
       }
 
-      private static bool shouldSelectBuildingBlocks(IReadOnlyList<MoleculeBuildingBlock> moleculeBlockCollection, IReadOnlyList<MoBiSpatialStructure> spatialStructureCollection)
-      {
-         return shouldSelectMolecules(moleculeBlockCollection) || spatialStructureCollection.Count > 1;
-      }
-
-      private static bool shouldSelectMolecules(IReadOnlyList<MoleculeBuildingBlock> moleculeBlockCollection)
-      {
-         return moleculeBlockCollection.Count > 1 || moleculeBlockCollection.Any(x => x.Count() > 1);
-      }
 
       public IMoBiCommand AddOrExtendWith(TBuildingBlock buildingBlock, Module module)
       {

--- a/tests/MoBi.Tests/Presentation/Tasks/InitialConditionsTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/InitialConditionsTaskSpecs.cs
@@ -511,13 +511,13 @@ namespace MoBi.Presentation.Tasks
       }
 
       [Observation]
-      public void the_spatial_structure_and_molecule_selection_presenter_is_not_used_to_select_the_building_blocks()
+      public void the_spatial_structure_and_molecule_selection_presenter_is_used_to_select_the_building_blocks()
       {
-         A.CallTo(() => _context.Context.Resolve<ISelectSpatialStructureAndMoleculesPresenter>()).MustNotHaveHappened();
+         A.CallTo(() => _selectionPresenter.SelectBuildingBlocksForExtend(A<MoleculeBuildingBlock>._, A<SpatialStructure>._)).MustHaveHappened();
       }
 
       [Observation]
-      public void the_only_valid_values_should_be_used_to_create_new_initial_conditions()
+      public void the_selected_values_should_be_used_to_create_new_initial_conditions()
       {
          A.CallTo(() => _initialConditionsCreator.CreateFrom(_moBiSpatialStructure, A<IReadOnlyList<MoleculeBuilder>>._)).MustHaveHappened();
       }


### PR DESCRIPTION
## Summary
- Removed the `shouldSelectBuildingBlocks` shortcut that auto-selected building blocks when only one of each type was available
- The selection dialog is now always shown so users get feedback even when nothing is added from the extension
- Updated tests to reflect the new behavior

Fixes #2331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic pre-selection behavior that bypassed the spatial structure and molecule selection interface when only one option was available. The selection dialog now consistently appears for all scenarios, ensuring a uniform user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->