### PR TITLE
Fixes #2100 New Parameter Value: parameters of the reactions are not shown

### DIFF
--- a/src/MoBi.Presentation/Presenter/SelectReferenceAtParameterPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferenceAtParameterPresenter.cs
@@ -31,7 +31,7 @@ namespace MoBi.Presentation.Presenter
       protected override void AddSpecificInitialObjects()
       {
          AddSpatialStructures();
-         AddReactionBuilders();
+         AddReactions();
       }
 
       public bool ChangeLocalisationAllowed

--- a/src/MoBi.Presentation/Presenter/SelectReferenceAtParameterValuePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferenceAtParameterValuePresenter.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using MoBi.Core.Domain.Extensions;
 using MoBi.Core.Domain.Model;
-using MoBi.Core.Domain.Repository;
 using MoBi.Core.Extensions;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Mappers;
@@ -11,7 +10,6 @@ using MoBi.Presentation.Views;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Extensions;
-using OSPSuite.Presentation.Nodes;
 using OSPSuite.Utility.Collections;
 using OSPSuite.Utility.Extensions;
 using IBuildingBlockRepository = MoBi.Core.Domain.Repository.IBuildingBlockRepository;
@@ -41,6 +39,15 @@ namespace MoBi.Presentation.Presenter
       {
          view.EnableMultiSelect = true;
          _pathAndValueContainers = new Cache<IBuildingBlock, IContainer>();
+         SelectionPredicate = filterObjects;
+      }
+
+      private bool filterObjects(IObjectBase objectBase)
+      {
+         if (objectBase is IParameter parameter && parameter.ParentContainer is ReactionBuilder)
+            return parameter.BuildMode == ParameterBuildMode.Global;
+
+         return true;
       }
 
       public override IEnumerable<ObjectBaseDTO> GetChildObjects(ObjectBaseDTO dto)
@@ -227,6 +234,7 @@ namespace MoBi.Presentation.Presenter
          addIndividuals();
          addExpressions();
          addEvents();
+         AddReactions();
          _view.ChangeLocalisationAllowed = true;
       }
 

--- a/src/MoBi.Presentation/Presenter/SelectReferencePresenterBase.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferencePresenterBase.cs
@@ -145,7 +145,6 @@ namespace MoBi.Presentation.Presenter
             addChildrenFromSpatialStructure(children, objectBase as SpatialStructure);
             addChildrenFromContainer(children, objectBase as IContainer);
             addChildrenFromNeighborhood(children, objectBase as NeighborhoodBuilder);
-            addParametersFromParameterContainer(children, objectBase as IContainsParameters);
             addChildrenFromReaction(children, objectBase as MoBiReactionBuildingBlock);
          }
 
@@ -354,16 +353,6 @@ namespace MoBi.Presentation.Presenter
          return SelectionPredicate(objectBase);
       }
 
-      private void addParametersFromParameterContainer(List<ObjectBaseDTO> children, IContainsParameters parameterContainer)
-      {
-         if (parameterContainer == null)
-            return;
-
-         children.AddRange(parameterContainer.Parameters
-            .OrderBy(x => x.Name)
-            .MapAllUsing(_objectBaseDTOMapper));
-      }
-
       private void addChildrenFromNeighborhood(List<ObjectBaseDTO> children, NeighborhoodBuilder neighborhood)
       {
          if (neighborhood == null)
@@ -465,13 +454,6 @@ namespace MoBi.Presentation.Presenter
       protected void AddReactions()
       {
          var nodes = _buildingBlockRepository.ReactionBlockCollection.Select(x => _referenceMapper.MapFrom(x));
-         _view.AddNodes(nodes);
-      }
-
-      protected void AddReactionBuilders()
-      {
-         var nodes = _buildingBlockRepository.ReactionBlockCollection
-            .Select(block => _referenceMapper.MapFrom(block));
          _view.AddNodes(nodes);
       }
 

--- a/tests/MoBi.Tests/Presentation/SelectReferenceAtParameterValuePresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectReferenceAtParameterValuePresenterSpecs.cs
@@ -477,4 +477,51 @@ namespace MoBi.Presentation
          }
       }
    }
+
+   public class When_getting_child_objects_of_a_reaction_builder : concern_for_SelectReferenceAtParameterValuePresenter
+   {
+      private ObjectBaseDTO _reactionDTO;
+      private ReactionBuilder _reactionBuilder;
+      private IParameter _globalParameter;
+      private IParameter _localParameter;
+      private List<ObjectBaseDTO> _children;
+
+      protected override void Context()
+      {
+         base.Context();
+         _reactionBuilder = new ReactionBuilder().WithName("reaction").WithId("reactionId");
+         _globalParameter = new Parameter().WithName("globalParam").WithId("globalId");
+         _globalParameter.BuildMode = ParameterBuildMode.Global;
+         _localParameter = new Parameter().WithName("localParam").WithId("localId");
+         _localParameter.BuildMode = ParameterBuildMode.Local;
+         _reactionBuilder.AddParameter(_globalParameter);
+         _reactionBuilder.AddParameter(_localParameter);
+
+         _reactionDTO = new ObjectBaseDTO(_reactionBuilder);
+
+         A.CallTo(() => _context.ObjectRepository.ContainsObjectWithId(_reactionBuilder.Id)).Returns(true);
+         A.CallTo(() => _context.Get<IObjectBase>(_reactionBuilder.Id)).Returns(_reactionBuilder);
+         A.CallTo(() => _context.Get<IndividualBuildingBlock>(A<string>._)).Returns(null);
+         A.CallTo(() => _context.Get<ExpressionProfileBuildingBlock>(A<string>._)).Returns(null);
+         A.CallTo(() => _context.Get<EventGroupBuildingBlock>(A<string>._)).Returns(null);
+         A.CallTo(() => _objectBaseDTOMapper.MapFrom(A<IObjectBase>._)).ReturnsLazily(x => new ObjectBaseDTO(x.Arguments.Get<IObjectBase>(0)));
+      }
+
+      protected override void Because()
+      {
+         _children = sut.GetChildObjects(_reactionDTO).ToList();
+      }
+
+      [Observation]
+      public void the_children_should_include_the_global_parameter()
+      {
+         _children.Select(x => x.ObjectBase).ShouldContain(_globalParameter);
+      }
+
+      [Observation]
+      public void the_children_should_not_include_the_local_parameter()
+      {
+         _children.Select(x => x.ObjectBase).ShouldNotContain(_localParameter);
+      }
+   }
 }


### PR DESCRIPTION
Fixes #2100 New Parameter Value: parameters of the reactions are not shown

# Description
add reaction parameters (global only) in the selection tree.

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parameter filtering to correctly handle scope-dependent parameters when selecting references in reaction-based contexts.

* **Refactor**
  * Streamlined reference initialization by removing duplicate reaction handling and simplifying parameter discovery logic.

* **Tests**
  * Added test coverage for parameter filtering behavior to ensure proper exclusion of inappropriate parameter types during reference selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->