### PR TITLE
2357 batchstarter fails to start

### DIFF
--- a/src/MoBi.BatchTool/BatchStarter.cs
+++ b/src/MoBi.BatchTool/BatchStarter.cs
@@ -33,7 +33,7 @@ namespace MoBi.BatchTool
                x.FromType<OSPSuite.Core.CoreRegister>();
                x.FromType<BatchRegister>();
                x.FromType<EngineRegister>();
-               x.FromType<InfrastructureRegister>();
+               // x.FromType<InfrastructureRegister>();
                x.FromInstance(new PresentationRegister(false));
                x.FromInstance(register);
             });

--- a/src/MoBi.BatchTool/BatchStarter.cs
+++ b/src/MoBi.BatchTool/BatchStarter.cs
@@ -8,7 +8,6 @@ using OSPSuite.Core;
 using OSPSuite.Core.Diagram;
 using OSPSuite.Core.Journal;
 using OSPSuite.Core.Serialization.Diagram;
-using OSPSuite.Infrastructure;
 using OSPSuite.Presentation;
 using OSPSuite.Utility.Container;
 using CoreRegister = MoBi.Core.CoreRegister;
@@ -33,7 +32,6 @@ namespace MoBi.BatchTool
                x.FromType<OSPSuite.Core.CoreRegister>();
                x.FromType<BatchRegister>();
                x.FromType<EngineRegister>();
-               // x.FromType<InfrastructureRegister>();
                x.FromInstance(new PresentationRegister(false));
                x.FromInstance(register);
             });


### PR DESCRIPTION
Duplicated registration when starting BatchStarter.

Fixes #2357 batchstarter fails to start
