### PR TITLE
2360 remap input project to pksim module

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-wxJqq" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-wxJqq" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,14 +16,14 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.101" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.0-wxJqq" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.0-wxJqq" />
       <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-      <PackageReference Include="OSPSuite.Presentation" Version="13.0.101" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.101" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.101" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.101" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
+      <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-wxJqq" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.0-wxJqq" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-wxJqq" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-wxJqq" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,14 +16,14 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.0-wxJqq" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.0-wxJqq" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.102" />
       <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
-      <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-wxJqq" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.0-wxJqq" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-wxJqq" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-wxJqq" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+      <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.102" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.102" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.102" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -23,16 +23,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.102" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -23,16 +23,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-wxJqq" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-wxJqq" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,12 +31,12 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="8.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.102" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,12 +31,12 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="8.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.0-wxJqq" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
+++ b/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
@@ -75,8 +75,8 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
       //PKSimModule (when supplied) so PK-Sim's per-module partitioning picks the right
       //inputs for each module without any extra filtering on the MoBi side.
       qualificationConfiguration.Inputs?
-         .Where(i => !string.IsNullOrEmpty(i.PKSimModule))
-         .Each(i => i.Project = i.PKSimModule);
+         .Where(x => !string.IsNullOrEmpty(x.PKSimModule))
+         .Each(x => x.Project = x.PKSimModule);
 
       InputMapping[] inputMappings = [];
 

--- a/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
+++ b/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
@@ -70,6 +70,14 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
    /// <returns>The project that was created and any input mappings that were exported</returns>
    public async Task<(ModelProject, InputMapping[])> MapToModelAndExportInputs(SnapshotProject snapshot, ProjectContext projectContext, QualificationConfiguration qualificationConfiguration)
    {
+      //The qualification plan scopes Inputs by the MoBi project Id, but PK-Sim resolves
+      //inputs per PKSimModule using Input.Project == PKSimProject.Name. Rewrite Project to
+      //PKSimModule (when supplied) so PK-Sim's per-module partitioning picks the right
+      //inputs for each module without any extra filtering on the MoBi side.
+      qualificationConfiguration.Inputs?
+         .Where(i => !string.IsNullOrEmpty(i.PKSimModule))
+         .Each(i => i.Project = i.PKSimModule);
+
       InputMapping[] inputMappings = [];
 
       return (await mapToModel(snapshot, projectContext, (module, project) => inputMappings = loadModulesAndExportInputsFromPKSimSnapshot(module, project, qualificationConfiguration)), inputMappings);

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-wxJqq" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -23,9 +23,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -23,9 +23,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.0-wxJqq" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.102" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.5" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.5" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -67,13 +67,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-wxJqq" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -67,13 +67,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.101" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-wxJqq" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectMapperSpecs.cs
+++ b/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectMapperSpecs.cs
@@ -206,6 +206,70 @@ namespace MoBi.IntegrationTests.Snapshots
       }
    }
 
+   internal class When_mapping_snapshot_to_project_and_exporting_inputs_with_PKSimModule_on_inputs : concern_for_ProjectMapper
+   {
+      private SnapshotProject _snapshot;
+      private QualificationConfiguration _configuration;
+      private Input _inputWithPKSimModule;
+      private Input _inputWithoutPKSimModule;
+      private Input _inputWithEmptyPKSimModule;
+
+      protected override void Context()
+      {
+         base.Context();
+         _snapshot = sut.MapToSnapshot(_project).Result;
+
+         _inputWithPKSimModule = new Input
+         {
+            Name = "Amikacin",
+            Project = "MoBi_Project_Id",
+            PKSimModule = "PKSim Module Name",
+            Type = PKSimBuildingBlockType.Compound
+         };
+         _inputWithoutPKSimModule = new Input
+         {
+            Name = "OtherCompound",
+            Project = "MoBi_Project_Id",
+            PKSimModule = null,
+            Type = PKSimBuildingBlockType.Compound
+         };
+         _inputWithEmptyPKSimModule = new Input
+         {
+            Name = "YetAnother",
+            Project = "MoBi_Project_Id",
+            PKSimModule = "",
+            Type = PKSimBuildingBlockType.Compound
+         };
+         _configuration = new QualificationConfiguration
+         {
+            Inputs = new[] { _inputWithPKSimModule, _inputWithoutPKSimModule, _inputWithEmptyPKSimModule }
+         };
+      }
+
+      protected override void Because()
+      {
+         sut.MapToModelAndExportInputs(_snapshot, new ProjectContext(new MoBiProject(), runSimulations: false), _configuration).Wait();
+      }
+
+      [Observation]
+      public void the_input_with_PKSimModule_set_should_have_its_Project_rewritten_to_the_PKSimModule_value()
+      {
+         _inputWithPKSimModule.Project.ShouldBeEqualTo("PKSim Module Name");
+      }
+
+      [Observation]
+      public void the_input_with_null_PKSimModule_should_have_its_Project_preserved()
+      {
+         _inputWithoutPKSimModule.Project.ShouldBeEqualTo("MoBi_Project_Id");
+      }
+
+      [Observation]
+      public void the_input_with_empty_PKSimModule_should_have_its_Project_preserved()
+      {
+         _inputWithEmptyPKSimModule.Project.ShouldBeEqualTo("MoBi_Project_Id");
+      }
+   }
+
    internal class When_mapping_snapshot_to_project : concern_for_ProjectMapper
    {
       private SnapshotProject _snapshot;

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.102" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-wxJqq" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.102" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.101" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.101" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-wxJqq" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.0-wxJqq" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #2360 remap input project to pksim module

# Description
Remaps the `Projects` property of an Input to the PKSim project name when mapping outputs

## Type of change

Please mark relevant options with an `x` in the brackets.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires documentation changes (link at least one [user](https://github.com/Open-Systems-Pharmacology/docs) or [developer](https://github.com/Open-Systems-Pharmacology/developer-docs) documentation issue):
- [ ] Algorithm update - updates algorithm documentation/questions/answers etc.
- [ ] Other (please describe):

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Integration tests
- [x] Unit tests
- [x] Manual tests 
- [ ] No tests required

# Reviewer checklist

Mark everything that needs to be checked before merging the PR.

- [ ] Check if the code is well documented
- [ ] Check if the behavior is what is expected
- [ ] Check if the code is well tested
- [ ] Check if the code is readable and well formatted
- [ ] Additional checks (document below if any)
- [ ] Check if documentation update issue(s) are created if the option `This change requires a documentation update` above is selected

# Screenshots (if appropriate):

# Questions (if appropriate):