### PR TITLE
2363 molecules building block property access

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.103" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.103" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.103" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,14 +16,14 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.102" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.103" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.103" />
       <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
-      <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.102" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.102" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.102" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.103" />
+      <PackageReference Include="OSPSuite.Presentation" Version="13.0.103" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.103" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.103" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.103" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -23,16 +23,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.103" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.103" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,12 +31,12 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="8.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.103" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.103" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -23,9 +23,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />  
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.103" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.R/Api.cs
+++ b/src/MoBi.R/Api.cs
@@ -34,6 +34,8 @@ namespace MoBi.R
 
       public static IInitialConditionsTask GetInitialConditionsTask() => resolveTask<IInitialConditionsTask>();
 
+      public static IMoleculesTask GetMoleculesTask() => resolveTask<IMoleculesTask>();
+
       private static T resolveTask<T>()
       {
          try

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.103" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.R/Services/MoleculesTask.cs
+++ b/src/MoBi.R/Services/MoleculesTask.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using MoBi.Assets;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+
+namespace MoBi.R.Services;
+
+public interface IMoleculesTask
+{
+   string[] AllMoleculeNames(MoleculeBuildingBlock buildingBlock);
+   string[] AllFloatingMoleculeNames(MoleculeBuildingBlock buildingBlock);
+   string[] AllStationaryMoleculeNames(MoleculeBuildingBlock buildingBlock);
+   string[] AllMoleculeNamesOfType(MoleculeBuildingBlock buildingBlock, QuantityType quantityType);
+   string MoleculeTypeFor(MoleculeBuildingBlock buildingBlock, string moleculeName);
+}
+
+public class MoleculesTask : IMoleculesTask
+{
+   public string[] AllMoleculeNames(MoleculeBuildingBlock buildingBlock) =>
+      buildingBlock.Select(x => x.Name).ToArray();
+
+   public string[] AllFloatingMoleculeNames(MoleculeBuildingBlock buildingBlock) =>
+      buildingBlock.Where(x => x.IsFloating).Select(x => x.Name).ToArray();
+
+   public string[] AllStationaryMoleculeNames(MoleculeBuildingBlock buildingBlock) =>
+      buildingBlock.Where(x => !x.IsFloating).Select(x => x.Name).ToArray();
+
+   public string[] AllMoleculeNamesOfType(MoleculeBuildingBlock buildingBlock, QuantityType quantityType) =>
+      buildingBlock.Where(x => x.QuantityType.Is(quantityType)).Select(x => x.Name).ToArray();
+
+   public string MoleculeTypeFor(MoleculeBuildingBlock buildingBlock, string moleculeName)
+   {
+      var molecule = buildingBlock[moleculeName];
+      return molecule == null ? throw new ArgumentException(AppConstants.Exceptions.MoleculeNotFoundInBuildingBlock(moleculeName)) : molecule.QuantityType.ToString();
+   }
+}

--- a/src/MoBi.R/Services/MoleculesTask.cs
+++ b/src/MoBi.R/Services/MoleculesTask.cs
@@ -12,6 +12,8 @@ public interface IMoleculesTask
    string[] AllFloatingMoleculeNames(MoleculeBuildingBlock buildingBlock);
    string[] AllStationaryMoleculeNames(MoleculeBuildingBlock buildingBlock);
    string[] AllMoleculeNamesOfType(MoleculeBuildingBlock buildingBlock, QuantityType quantityType);
+   string[] AllXenobioticFloatingMoleculeNames(MoleculeBuildingBlock buildingBlock);
+   string[] AllEndogenousStationaryMoleculeNames(MoleculeBuildingBlock buildingBlock);
    string MoleculeTypeFor(MoleculeBuildingBlock buildingBlock, string moleculeName);
 }
 
@@ -28,6 +30,12 @@ public class MoleculesTask : IMoleculesTask
 
    public string[] AllMoleculeNamesOfType(MoleculeBuildingBlock buildingBlock, QuantityType quantityType) =>
       buildingBlock.Where(x => x.QuantityType.Is(quantityType)).Select(x => x.Name).ToArray();
+
+   public string[] AllXenobioticFloatingMoleculeNames(MoleculeBuildingBlock buildingBlock) =>
+      buildingBlock.Where(x => x.IsFloating && x.IsXenobiotic).Select(x => x.Name).ToArray();
+
+   public string[] AllEndogenousStationaryMoleculeNames(MoleculeBuildingBlock buildingBlock) =>
+      buildingBlock.Where(x => !x.IsFloating && !x.IsXenobiotic).Select(x => x.Name).ToArray();
 
    public string MoleculeTypeFor(MoleculeBuildingBlock buildingBlock, string moleculeName)
    {

--- a/src/MoBi.R/Services/MoleculesTask.cs
+++ b/src/MoBi.R/Services/MoleculesTask.cs
@@ -20,22 +20,22 @@ public interface IMoleculesTask
 public class MoleculesTask : IMoleculesTask
 {
    public string[] AllMoleculeNames(MoleculeBuildingBlock buildingBlock) =>
-      buildingBlock.Select(x => x.Name).ToArray();
+      buildingBlock.AllNames().ToArray();
 
    public string[] AllFloatingMoleculeNames(MoleculeBuildingBlock buildingBlock) =>
-      buildingBlock.Where(x => x.IsFloating).Select(x => x.Name).ToArray();
+      buildingBlock.AllFloating().AllNames().ToArray();
 
    public string[] AllStationaryMoleculeNames(MoleculeBuildingBlock buildingBlock) =>
-      buildingBlock.Where(x => !x.IsFloating).Select(x => x.Name).ToArray();
+      buildingBlock.AllStationary().AllNames().ToArray();
 
    public string[] AllMoleculeNamesOfType(MoleculeBuildingBlock buildingBlock, QuantityType quantityType) =>
-      buildingBlock.Where(x => x.QuantityType.Is(quantityType)).Select(x => x.Name).ToArray();
+      buildingBlock.AllOfType(quantityType).AllNames().ToArray();
 
    public string[] AllXenobioticFloatingMoleculeNames(MoleculeBuildingBlock buildingBlock) =>
-      buildingBlock.Where(x => x.IsFloating && x.IsXenobiotic).Select(x => x.Name).ToArray();
+      buildingBlock.AllXenobioticFloating().AllNames().ToArray();
 
    public string[] AllEndogenousStationaryMoleculeNames(MoleculeBuildingBlock buildingBlock) =>
-      buildingBlock.Where(x => !x.IsFloating && !x.IsXenobiotic).Select(x => x.Name).ToArray();
+      buildingBlock.AllEndogenousStationary().AllNames().ToArray();
 
    public string MoleculeTypeFor(MoleculeBuildingBlock buildingBlock, string moleculeName)
    {

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.5" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.103" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -67,13 +67,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.103" />
     <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.102" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.103" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.103" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.R.Tests/Services/MoleculesTaskSpecs.cs
+++ b/tests/MoBi.R.Tests/Services/MoleculesTaskSpecs.cs
@@ -23,13 +23,14 @@ internal abstract class concern_for_MoleculesTask : ContextForIntegration<IMolec
       _buildingBlock = new MoleculeBuildingBlock().WithName("Molecules");
    }
 
-   protected MoleculeBuilder addMolecule(string name, bool isFloating, QuantityType quantityType)
+   protected MoleculeBuilder addMolecule(string name, bool isFloating, QuantityType quantityType, bool isXenobiotic = true)
    {
       var molecule = new MoleculeBuilder
       {
          Name = name,
          IsFloating = isFloating,
-         QuantityType = quantityType
+         QuantityType = quantityType,
+         IsXenobiotic = isXenobiotic
       };
       _buildingBlock.Add(molecule);
       return molecule;
@@ -171,6 +172,58 @@ internal class When_getting_all_molecule_names_of_type_drug : concern_for_Molecu
    public void should_return_only_drug_molecule_names()
    {
       _result.ShouldOnlyContainInOrder("Drug1", "Drug2");
+   }
+}
+
+internal class When_getting_all_xenobiotic_floating_molecule_names : concern_for_MoleculesTask
+{
+   private string[] _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      addMolecule("Drug", isFloating: true, QuantityType.Drug, isXenobiotic: true);
+      addMolecule("Metabolite", isFloating: true, QuantityType.Metabolite, isXenobiotic: true);
+      addMolecule("Enzyme", isFloating: false, QuantityType.Enzyme, isXenobiotic: false);
+      addMolecule("FloatingEnzyme", isFloating: true, QuantityType.Enzyme, isXenobiotic: false);
+      addMolecule("StationaryDrug", isFloating: false, QuantityType.Drug, isXenobiotic: true);
+   }
+
+   protected override void Because()
+   {
+      _result = sut.AllXenobioticFloatingMoleculeNames(_buildingBlock);
+   }
+
+   [Observation]
+   public void should_return_only_xenobiotic_floating_molecule_names()
+   {
+      _result.ShouldOnlyContainInOrder("Drug", "Metabolite");
+   }
+}
+
+internal class When_getting_all_endogenous_stationary_molecule_names : concern_for_MoleculesTask
+{
+   private string[] _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      addMolecule("Drug", isFloating: true, QuantityType.Drug, isXenobiotic: true);
+      addMolecule("Enzyme", isFloating: false, QuantityType.Enzyme, isXenobiotic: false);
+      addMolecule("Transporter", isFloating: false, QuantityType.Transporter, isXenobiotic: false);
+      addMolecule("StationaryDrug", isFloating: false, QuantityType.Drug, isXenobiotic: true);
+      addMolecule("FloatingEnzyme", isFloating: true, QuantityType.Enzyme, isXenobiotic: false);
+   }
+
+   protected override void Because()
+   {
+      _result = sut.AllEndogenousStationaryMoleculeNames(_buildingBlock);
+   }
+
+   [Observation]
+   public void should_return_only_endogenous_stationary_molecule_names()
+   {
+      _result.ShouldOnlyContainInOrder("Enzyme", "Transporter");
    }
 }
 

--- a/tests/MoBi.R.Tests/Services/MoleculesTaskSpecs.cs
+++ b/tests/MoBi.R.Tests/Services/MoleculesTaskSpecs.cs
@@ -1,0 +1,212 @@
+using System;
+using MoBi.R.Services;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+
+namespace MoBi.R.Tests.Services;
+
+internal abstract class concern_for_MoleculesTask : ContextForIntegration<IMoleculesTask>
+{
+   protected MoleculeBuildingBlock _buildingBlock;
+
+   public override void GlobalContext()
+   {
+      base.GlobalContext();
+      sut = Api.GetMoleculesTask();
+   }
+
+   protected override void Context()
+   {
+      base.Context();
+      _buildingBlock = new MoleculeBuildingBlock().WithName("Molecules");
+   }
+
+   protected MoleculeBuilder addMolecule(string name, bool isFloating, QuantityType quantityType)
+   {
+      var molecule = new MoleculeBuilder
+      {
+         Name = name,
+         IsFloating = isFloating,
+         QuantityType = quantityType
+      };
+      _buildingBlock.Add(molecule);
+      return molecule;
+   }
+}
+
+internal class When_getting_all_molecule_names_from_a_molecule_building_block : concern_for_MoleculesTask
+{
+   private string[] _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      addMolecule("Drug", isFloating: true, QuantityType.Drug);
+      addMolecule("Enzyme", isFloating: false, QuantityType.Enzyme);
+      addMolecule("Transporter", isFloating: false, QuantityType.Transporter);
+   }
+
+   protected override void Because()
+   {
+      _result = sut.AllMoleculeNames(_buildingBlock);
+   }
+
+   [Observation]
+   public void should_return_all_molecule_names()
+   {
+      _result.ShouldOnlyContainInOrder("Drug", "Enzyme", "Transporter");
+   }
+}
+
+internal class When_getting_all_molecule_names_from_an_empty_molecule_building_block : concern_for_MoleculesTask
+{
+   private string[] _result;
+
+   protected override void Because()
+   {
+      _result = sut.AllMoleculeNames(_buildingBlock);
+   }
+
+   [Observation]
+   public void should_return_an_empty_array()
+   {
+      _result.ShouldBeEmpty();
+   }
+}
+
+internal class When_getting_all_floating_molecule_names : concern_for_MoleculesTask
+{
+   private string[] _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      addMolecule("Drug", isFloating: true, QuantityType.Drug);
+      addMolecule("Metabolite", isFloating: true, QuantityType.Metabolite);
+      addMolecule("Enzyme", isFloating: false, QuantityType.Enzyme);
+   }
+
+   protected override void Because()
+   {
+      _result = sut.AllFloatingMoleculeNames(_buildingBlock);
+   }
+
+   [Observation]
+   public void should_return_only_floating_molecule_names()
+   {
+      _result.ShouldOnlyContainInOrder("Drug", "Metabolite");
+   }
+}
+
+internal class When_getting_all_stationary_molecule_names : concern_for_MoleculesTask
+{
+   private string[] _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      addMolecule("Drug", isFloating: true, QuantityType.Drug);
+      addMolecule("Enzyme", isFloating: false, QuantityType.Enzyme);
+      addMolecule("Transporter", isFloating: false, QuantityType.Transporter);
+   }
+
+   protected override void Because()
+   {
+      _result = sut.AllStationaryMoleculeNames(_buildingBlock);
+   }
+
+   [Observation]
+   public void should_return_only_stationary_molecule_names()
+   {
+      _result.ShouldOnlyContainInOrder("Enzyme", "Transporter");
+   }
+}
+
+internal class When_getting_all_molecule_names_of_type_protein : concern_for_MoleculesTask
+{
+   private string[] _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      addMolecule("Drug", isFloating: true, QuantityType.Drug);
+      addMolecule("Metabolite", isFloating: true, QuantityType.Metabolite);
+      addMolecule("Enzyme", isFloating: false, QuantityType.Enzyme);
+      addMolecule("Transporter", isFloating: false, QuantityType.Transporter);
+      addMolecule("OtherProtein", isFloating: false, QuantityType.OtherProtein);
+   }
+
+   protected override void Because()
+   {
+      _result = sut.AllMoleculeNamesOfType(_buildingBlock, QuantityType.Protein);
+   }
+
+   [Observation]
+   public void should_return_all_protein_molecule_names()
+   {
+      _result.ShouldOnlyContainInOrder("Enzyme", "Transporter", "OtherProtein");
+   }
+}
+
+internal class When_getting_all_molecule_names_of_type_drug : concern_for_MoleculesTask
+{
+   private string[] _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      addMolecule("Drug1", isFloating: true, QuantityType.Drug);
+      addMolecule("Drug2", isFloating: true, QuantityType.Drug);
+      addMolecule("Enzyme", isFloating: false, QuantityType.Enzyme);
+   }
+
+   protected override void Because()
+   {
+      _result = sut.AllMoleculeNamesOfType(_buildingBlock, QuantityType.Drug);
+   }
+
+   [Observation]
+   public void should_return_only_drug_molecule_names()
+   {
+      _result.ShouldOnlyContainInOrder("Drug1", "Drug2");
+   }
+}
+
+internal class When_getting_the_type_of_a_molecule : concern_for_MoleculesTask
+{
+   protected override void Context()
+   {
+      base.Context();
+      addMolecule("Drug", isFloating: true, QuantityType.Drug);
+      addMolecule("Enzyme", isFloating: false, QuantityType.Enzyme);
+   }
+
+   [Observation]
+   public void should_return_drug_for_a_drug_molecule()
+   {
+      sut.MoleculeTypeFor(_buildingBlock, "Drug").ShouldBeEqualTo("Drug");
+   }
+
+   [Observation]
+   public void should_return_enzyme_for_an_enzyme_molecule()
+   {
+      sut.MoleculeTypeFor(_buildingBlock, "Enzyme").ShouldBeEqualTo("Enzyme");
+   }
+}
+
+internal class When_getting_the_type_of_a_molecule_that_does_not_exist : concern_for_MoleculesTask
+{
+   protected override void Context()
+   {
+      base.Context();
+      addMolecule("Drug", isFloating: true, QuantityType.Drug);
+   }
+
+   [Observation]
+   public void should_throw_argument_exception()
+   {
+      The.Action(() => sut.MoleculeTypeFor(_buildingBlock, "NotThere")).ShouldThrowAn<ArgumentException>();
+   }
+}

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -38,9 +38,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.103" />
     <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.102" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.102" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.103" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.103" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #2363

## Summary
- New `MoleculesTask` in `MoBi.R.Services` exposing properties of a `MoleculeBuildingBlock` for the R API:
  - `AllMoleculeNames`, `AllFloatingMoleculeNames`, `AllStationaryMoleculeNames`
  - `AllMoleculeNamesOfType(QuantityType)` — pass `QuantityType.Protein` to get all proteins, or any specific type (`Drug`, `Enzyme`, `Transporter`, `OtherProtein`, ...)
  - `MoleculeTypeFor(buildingBlock, moleculeName)` — returns the `QuantityType` of a named molecule as a string (e.g. `"Drug"`, `"Enzyme"`); throws `ArgumentException` if the molecule is not found
- Registered via `Api.GetMoleculesTask()` — DI is picked up automatically by `OSPSuiteRegistrationConvention`.

## Test plan
- [x] `dotnet build` passes for `MoBi.R` and `MoBi.R.Tests`
- [x] New `MoleculesTaskSpecs` — 9 observations passing locally
- [ ] Integration with R wrapper (follow-up in MoBi-R repo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New molecule query capability enabling retrieval and filtering of molecule information from building blocks.
  * Filter molecules by properties: retrieve all molecules, floating or stationary molecules only, or molecules by quantity type.
  * Look up molecule type information by name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->