### PR TITLE
Fixes #2250 Formula string editor: show evaluation unit

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1441,6 +1441,7 @@ namespace MoBi.Assets
          public static readonly string FormulaType = "Formula Type";
          public static readonly string FormulaName = "Formula Name";
          public static readonly string Formula = "Formula";
+         public static string FormulaUnit(string unitName) => $"[{unitName}]";
          public static readonly string ExplicitFormula = "Formula (an explicit formula)";
          public static readonly string ConstantFormula = "Constant (a single numeric value)";
          public static readonly string TableFormula = "Table (multiple time discrete and piecewise constant numeric values)";

--- a/src/MoBi.Presentation/Presenter/EditExplicitFormulaPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditExplicitFormulaPresenter.cs
@@ -62,6 +62,12 @@ namespace MoBi.Presentation.Presenter
             _view.SetFormulaCaption(caption);
       }
 
+      private void updateFormulaUnit(IFormula formula)
+      {
+         var unitName = formula?.Dimension?.BaseUnit?.Name;
+         _view.SetFormulaUnit(unitName);
+      }
+
       public override IBuildingBlock BuildingBlock
       {
          set
@@ -104,6 +110,7 @@ namespace MoBi.Presentation.Presenter
             _view.Enabled = false;
 
          updateFormulaCaption();
+         updateFormulaUnit(formula);
       }
 
       public void SetFormulaString(string newFormulaString)

--- a/src/MoBi.Presentation/Views/IEditExplicitFormulaView.cs
+++ b/src/MoBi.Presentation/Views/IEditExplicitFormulaView.cs
@@ -11,6 +11,7 @@ namespace MoBi.Presentation.Views
       bool Enabled { get; set; }
       void SetFormulaCaption(string caption);
       void HideFormulaCaption();
+      void SetFormulaUnit(string unitName);
       void AddFormulaPathListView(IView view);
    }
 }

--- a/src/MoBi.UI/Views/EditExplicitFormulaView.Designer.cs
+++ b/src/MoBi.UI/Views/EditExplicitFormulaView.Designer.cs
@@ -30,10 +30,12 @@
       private void InitializeComponent()
       {
          this.txtFormulaString = new DevExpress.XtraEditors.TextEdit();
+         this.lblFormulaUnit = new DevExpress.XtraEditors.LabelControl();
          this.layoutControl1 = new OSPSuite.UI.Controls.UxLayoutControl();
          this.panelReferencePaths = new DevExpress.XtraEditors.PanelControl();
          this.layoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
          this.layoutItemFormulaString = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemFormulaUnit = new DevExpress.XtraLayout.LayoutControlItem();
          this.layoutControlItem1 = new DevExpress.XtraLayout.LayoutControlItem();
          ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.txtFormulaString.Properties)).BeginInit();
@@ -42,22 +44,33 @@
          ((System.ComponentModel.ISupportInitialize)(this.panelReferencePaths)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemFormulaString)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemFormulaUnit)).BeginInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).BeginInit();
          this.SuspendLayout();
-         // 
+         //
          // txtFormulaString
-         // 
-         this.txtFormulaString.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+         //
+         this.txtFormulaString.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
          this.txtFormulaString.Location = new System.Drawing.Point(123, 400);
          this.txtFormulaString.Name = "txtFormulaString";
-         this.txtFormulaString.Size = new System.Drawing.Size(478, 20);
+         this.txtFormulaString.Size = new System.Drawing.Size(398, 20);
          this.txtFormulaString.StyleController = this.layoutControl1;
          this.txtFormulaString.TabIndex = 6;
-         // 
+         //
+         // lblFormulaUnit
+         //
+         this.lblFormulaUnit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+         this.lblFormulaUnit.Location = new System.Drawing.Point(525, 402);
+         this.lblFormulaUnit.Name = "lblFormulaUnit";
+         this.lblFormulaUnit.Size = new System.Drawing.Size(76, 16);
+         this.lblFormulaUnit.StyleController = this.layoutControl1;
+         this.lblFormulaUnit.TabIndex = 9;
+         //
          // layoutControl1
-         // 
+         //
          this.layoutControl1.AllowCustomization = false;
+         this.layoutControl1.Controls.Add(this.lblFormulaUnit);
          this.layoutControl1.Controls.Add(this.panelReferencePaths);
          this.layoutControl1.Controls.Add(this.txtFormulaString);
          this.layoutControl1.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -74,31 +87,42 @@
          this.panelReferencePaths.Name = "panelReferencePaths";
          this.panelReferencePaths.Size = new System.Drawing.Size(599, 394);
          this.panelReferencePaths.TabIndex = 8;
-         // 
+         //
          // layoutControlGroup
-         // 
+         //
          this.layoutControlGroup.CustomizationFormText = "layoutControlGroup";
          this.layoutControlGroup.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
          this.layoutControlGroup.GroupBordersVisible = false;
          this.layoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
             this.layoutItemFormulaString,
+            this.layoutItemFormulaUnit,
             this.layoutControlItem1});
          this.layoutControlGroup.Name = "layoutControlGroup";
          this.layoutControlGroup.Padding = new DevExpress.XtraLayout.Utils.Padding(0, 0, 0, 0);
          this.layoutControlGroup.Size = new System.Drawing.Size(603, 422);
          this.layoutControlGroup.TextVisible = false;
-         // 
+         //
          // layoutItemFormulaString
-         // 
+         //
          this.layoutItemFormulaString.Control = this.txtFormulaString;
          this.layoutItemFormulaString.CustomizationFormText = "layoutItemFormulaString";
          this.layoutItemFormulaString.Location = new System.Drawing.Point(0, 398);
          this.layoutItemFormulaString.Name = "layoutItemFormulaString";
-         this.layoutItemFormulaString.Size = new System.Drawing.Size(603, 24);
+         this.layoutItemFormulaString.Size = new System.Drawing.Size(523, 24);
          this.layoutItemFormulaString.TextSize = new System.Drawing.Size(118, 13);
-         // 
+         //
+         // layoutItemFormulaUnit
+         //
+         this.layoutItemFormulaUnit.Control = this.lblFormulaUnit;
+         this.layoutItemFormulaUnit.CustomizationFormText = "layoutItemFormulaUnit";
+         this.layoutItemFormulaUnit.Location = new System.Drawing.Point(523, 398);
+         this.layoutItemFormulaUnit.Name = "layoutItemFormulaUnit";
+         this.layoutItemFormulaUnit.Size = new System.Drawing.Size(80, 24);
+         this.layoutItemFormulaUnit.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutItemFormulaUnit.TextVisible = false;
+         //
          // layoutControlItem1
-         // 
+         //
          this.layoutControlItem1.Control = this.panelReferencePaths;
          this.layoutControlItem1.Location = new System.Drawing.Point(0, 0);
          this.layoutControlItem1.Name = "layoutControlItem1";
@@ -120,6 +144,7 @@
          ((System.ComponentModel.ISupportInitialize)(this.panelReferencePaths)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutItemFormulaString)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemFormulaUnit)).EndInit();
          ((System.ComponentModel.ISupportInitialize)(this.layoutControlItem1)).EndInit();
          this.ResumeLayout(false);
 
@@ -127,9 +152,11 @@
 
       #endregion
       private DevExpress.XtraEditors.TextEdit txtFormulaString;
+      private DevExpress.XtraEditors.LabelControl lblFormulaUnit;
       private OSPSuite.UI.Controls.UxLayoutControl layoutControl1;
       private DevExpress.XtraLayout.LayoutControlGroup layoutControlGroup;
       private DevExpress.XtraLayout.LayoutControlItem layoutItemFormulaString;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemFormulaUnit;
       private DevExpress.XtraEditors.PanelControl panelReferencePaths;
       private DevExpress.XtraLayout.LayoutControlItem layoutControlItem1;
    }

--- a/src/MoBi.UI/Views/EditExplicitFormulaView.cs
+++ b/src/MoBi.UI/Views/EditExplicitFormulaView.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using DevExpress.XtraEditors.DXErrorProvider;
+using MoBi.Assets;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Views;
@@ -86,6 +87,20 @@ namespace MoBi.UI.Views
       public void HideFormulaCaption()
       {
          SetFormulaCaption(string.Empty);
+      }
+
+      public void SetFormulaUnit(string unitName)
+      {
+         if (string.IsNullOrEmpty(unitName))
+         {
+            lblFormulaUnit.Text = string.Empty;
+            layoutItemFormulaUnit.Visibility = DevExpress.XtraLayout.Utils.LayoutVisibility.Never;
+         }
+         else
+         {
+            lblFormulaUnit.Text = AppConstants.Captions.FormulaUnit(unitName);
+            layoutItemFormulaUnit.Visibility = DevExpress.XtraLayout.Utils.LayoutVisibility.Always;
+         }
       }
 
       public void AddFormulaPathListView(IView view)

--- a/tests/MoBi.Tests/Presentation/EditExplicitFormulaPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditExplicitFormulaPresenterSpecs.cs
@@ -176,4 +176,31 @@ namespace MoBi.Presentation
          A.CallTo(() => _view.SetFormulaCaption("THE_RHS_CAPTION")).MustHaveHappened();
       }
    }
+
+   public class When_editing_a_formula_with_a_dimension : concern_for_EditExplicitFormulaPresenter
+   {
+      private ExplicitFormula _formula;
+      private IUsingFormula _parameter;
+      private IDimension _dimension;
+
+      protected override void Context()
+      {
+         base.Context();
+         _dimension = A.Fake<IDimension>();
+         A.CallTo(() => _dimension.BaseUnit).Returns(new Unit("µmol/l", 1, 0));
+         _formula = new ExplicitFormula("TOTO") { Dimension = _dimension };
+         _parameter = A.Fake<IParameter>().WithName("PARA");
+      }
+
+      protected override void Because()
+      {
+         sut.Edit(_formula, _parameter);
+      }
+
+      [Observation]
+      public void should_set_the_formula_unit_to_the_base_unit_of_the_formula_dimension()
+      {
+         A.CallTo(() => _view.SetFormulaUnit("µmol/l")).MustHaveHappened();
+      }
+   }
 }


### PR DESCRIPTION
## Summary
Display the base unit of the formula's dimension in a label to the right of the formula text input in the explicit formula editor, so users can see what unit the formula will evaluate to.

For reactions in concentration mode this is `µmol/l/min`, for amount mode `µmol/min`, and for any other formula it's the base unit of its dimension.

## Test plan
- [x] Open a reaction's kinetic formula — verify `[µmol/l/min]` (concentration mode) or `[µmol/min]` (amount mode) appears to the right of the formula text
- [x] Open a parameter's RHS formula — verify the parameter dimension's base unit appears
- [x] Open a parameter's value formula (no RHS) — verify the unit still appears
- [x] Open a transport's formula — verify `[µmol/min]` appears
- [x] Resize the formula editor — verify the unit label stays anchored to the right and the formula textbox resizes correctly

Fixes #2250

<img width="343" height="370" alt="image" src="https://github.com/user-attachments/assets/b402ddd3-c9f0-495b-ba4e-53970879866e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Formula unit is now displayed when editing explicit formulas, making it easier to verify the measurement context alongside the formula input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->