### PR TITLE
Fixes #2383 Align with new IParameterFactory.CreateDistributedParameter contract

### DIFF
--- a/src/MoBi.Core/Mappers/PathAndValueEntityToDistributedParameterMapper.cs
+++ b/src/MoBi.Core/Mappers/PathAndValueEntityToDistributedParameterMapper.cs
@@ -1,7 +1,7 @@
-﻿using OSPSuite.Core.Domain;
+﻿using System.Collections.Generic;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
-using System.Collections.Generic;
 using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Core.Mappers
@@ -32,6 +32,16 @@ namespace MoBi.Core.Mappers
       {
          subParameters.Each(subParameter =>
          {
+            //the factory pre-creates the sub-parameters referenced by the distribution formula and a Percentile.
+            //If the caller provides a sub-parameter with the same name, just update the existing one's value.
+            var existing = distributedParameter.GetSingleChildByName<IParameter>(subParameter.Name);
+            if (existing != null)
+            {
+               if (subParameter.Value.HasValue)
+                  existing.Value = subParameter.Value.Value;
+               return;
+            }
+
             distributedParameter.Add(_parameterFactory.CreateParameter(subParameter.Name, subParameter.Value, subParameter.Dimension, formula: subParameter.Formula, displayUnit: subParameter.DisplayUnit));
          });
       }

--- a/src/MoBi.Presentation/Mappers/IndividualParameterToParameterDTOMapper.cs
+++ b/src/MoBi.Presentation/Mappers/IndividualParameterToParameterDTOMapper.cs
@@ -18,14 +18,12 @@ namespace MoBi.Presentation.Mappers
    {
       private readonly IParameterToParameterDTOMapper _parameterToParameterDTOMapper;
       private readonly IParameterValueToParameterMapper _parameterValueToParameterMapper;
-      private readonly IFormulaFactory _formulaFactory;
       private readonly ICloneManagerForBuildingBlock _cloneManager;
 
-      public IndividualParameterToParameterDTOMapper(IParameterToParameterDTOMapper parameterToParameterDTOMapper, IParameterValueToParameterMapper parameterValueToParameterMapper, IFormulaFactory formulaFactory, ICloneManagerForBuildingBlock cloneManager)
+      public IndividualParameterToParameterDTOMapper(IParameterToParameterDTOMapper parameterToParameterDTOMapper, IParameterValueToParameterMapper parameterValueToParameterMapper, ICloneManagerForBuildingBlock cloneManager)
       {
          _parameterToParameterDTOMapper = parameterToParameterDTOMapper;
          _parameterValueToParameterMapper = parameterValueToParameterMapper;
-         _formulaFactory = formulaFactory;
          _cloneManager = cloneManager;
       }
       
@@ -39,18 +37,32 @@ namespace MoBi.Presentation.Mappers
 
       private IParameter parameterForIndividualParameter(IndividualBuildingBlock selectedIndividual, IndividualParameter individualParameter)
       {
+         //the mapper already takes care of applying the value (constant formula for plain parameters,
+         //fixed value via the distributed parameter Value setter for distributed ones).
          var parameter = _parameterValueToParameterMapper.MapFrom(individualParameter);
          if (parameter is IDistributedParameter distributedParameter)
          {
+            //the factory pre-creates the sub-parameters referenced by the distribution formula plus a Percentile.
+            //If the individual provides matching sub-parameters, update the existing entries so we don't end up
+            //with duplicate children (which would throw a NotUniqueNameException).
             var subParameters = selectedIndividual.Where(x => isSubParameter(x, individualParameter));
-            subParameters.Each(subParameter => distributedParameter.Add(parameterForIndividualParameter(selectedIndividual, subParameter)));
+            subParameters.Each(subParameter =>
+            {
+               var existing = distributedParameter.GetSingleChildByName<IParameter>(subParameter.Name);
+               if (existing != null)
+               {
+                  if (subParameter.Value.HasValue)
+                     existing.Value = subParameter.Value.Value;
+                  return;
+               }
+               distributedParameter.Add(parameterForIndividualParameter(selectedIndividual, subParameter));
+            });
          }
-         else
+         else if (individualParameter.Formula != null && !individualParameter.Value.HasValue)
          {
-            if (individualParameter.Value.HasValue)
-               parameter.Formula = _formulaFactory.ConstantFormula(individualParameter.Value.Value, individualParameter.Dimension);
-            else if (individualParameter.Formula != null)
-               parameter.Formula = _cloneManager.Clone(individualParameter.Formula, new FormulaCache());
+            //only clone an explicit formula here when no value was provided, because a value would already
+            //have been turned into a constant formula by the mapper above and would otherwise be overwritten.
+            parameter.Formula = _cloneManager.Clone(individualParameter.Formula, new FormulaCache());
          }
          return parameter;
       }

--- a/src/MoBi.Presentation/Tasks/SpatialStructureContentExporter.cs
+++ b/src/MoBi.Presentation/Tasks/SpatialStructureContentExporter.cs
@@ -31,23 +31,20 @@ namespace MoBi.Presentation.Tasks
       private readonly IObjectPathFactory _objectPathFactory;
       private readonly ICloneManagerForBuildingBlock _cloneManager;
       private readonly IPathAndValueEntityToParameterValueMapper _pathAndValueEntityToParameterValueMapper;
-      private readonly IFormulaFactory _formulaFactory;
       private readonly IParameterValueToParameterMapper _individualParameterToParameterMapper;
       private readonly IInteractionTaskContext _interactionTaskContext;
       private readonly IMoBiApplicationController _applicationController;
 
-      public SpatialStructureContentExporter(IMoBiSpatialStructureFactory spatialStructureFactory, 
-         ICloneManagerForBuildingBlock cloneManager, 
-         IObjectPathFactory objectPathFactory, 
-         IPathAndValueEntityToParameterValueMapper pathAndValueEntityToParameterValueMapper, 
-         IFormulaFactory formulaFactory, 
+      public SpatialStructureContentExporter(IMoBiSpatialStructureFactory spatialStructureFactory,
+         ICloneManagerForBuildingBlock cloneManager,
+         IObjectPathFactory objectPathFactory,
+         IPathAndValueEntityToParameterValueMapper pathAndValueEntityToParameterValueMapper,
          IParameterValueToParameterMapper individualParameterToParameterMapper, IInteractionTaskContext interactionTaskContext, IMoBiApplicationController applicationController)
       {
          _spatialStructureFactory = spatialStructureFactory;
          _cloneManager = cloneManager;
          _objectPathFactory = objectPathFactory;
          _pathAndValueEntityToParameterValueMapper = pathAndValueEntityToParameterValueMapper;
-         _formulaFactory = formulaFactory;
          _individualParameterToParameterMapper = individualParameterToParameterMapper;
          _interactionTaskContext = interactionTaskContext;
          _applicationController = applicationController;
@@ -230,12 +227,13 @@ namespace MoBi.Presentation.Tasks
 
       private IParameter createParameter(IndividualParameter individualParameter)
       {
+         //the mapper already takes care of applying the value (constant formula for plain parameters,
+         //fixed value via the distributed parameter Value setter for distributed ones).
          var parameterToAdd = _individualParameterToParameterMapper.MapFrom(individualParameter);
 
-         // The mapper does not create a formula for the parameter. Caller must clone or create the formula based on how it will be used 
-         if (individualParameter.Value.HasValue)
-            parameterToAdd.Formula = _formulaFactory.ConstantFormula(individualParameter.Value.Value, individualParameter.Dimension);
-         else if (individualParameter.Formula != null)
+         //only clone an explicit formula here when no value was provided, because a value would already
+         //have been turned into a constant formula by the mapper above and would otherwise be overwritten.
+         if (individualParameter.Formula != null && !individualParameter.Value.HasValue)
             parameterToAdd.Formula = _cloneManager.Clone(individualParameter.Formula);
 
          return parameterToAdd;

--- a/tests/MoBi.Tests/Core/Mapper/PathAndValueEntityToDistributedParameterMapperSpecs.cs
+++ b/tests/MoBi.Tests/Core/Mapper/PathAndValueEntityToDistributedParameterMapperSpecs.cs
@@ -62,4 +62,51 @@ namespace MoBi.Core.Mapper
          _result.Children.Count.ShouldBeEqualTo(2);
       }
    }
+
+   public class When_creating_a_distributed_parameter_whose_factory_already_pre_created_overlapping_sub_parameters : concern_for_PathAndValueEntityToDistributedParameterMapper
+   {
+      private IndividualParameter _individualParameter;
+      private IDistributedParameter _distributedParameter;
+      private IReadOnlyList<IndividualParameter> _subParameters;
+      private IDistributedParameter _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _individualParameter = new IndividualParameter { Name = "Name", Value = 5.0, DistributionType = DistributionType.Discrete };
+         _subParameters = new[] { new IndividualParameter { Name = "Mean", Value = 42.0 }, new IndividualParameter { Name = "Percentile", Value = 0.7 } };
+
+         //factory now returns a distributed parameter that already has Mean and Percentile placeholders
+         _distributedParameter = new DistributedParameter().WithName("Name");
+         _distributedParameter.Add(new Parameter().WithName("Mean"));
+         _distributedParameter.Add(new Parameter().WithName("Percentile"));
+
+         A.CallTo(() => _parameterFactory.CreateDistributedParameter(_individualParameter.Name, _individualParameter.DistributionType.Value, A<double?>._, _individualParameter.Dimension, A<string>._, A<Unit>._)).Returns(_distributedParameter);
+         A.CallTo(() => _parameterFactory.CreateParameter(A<string>._, A<double?>._, A<IDimension>._, A<string>._, A<IFormula>._, A<Unit>._))
+            .ReturnsLazily(x => new Parameter().WithName(x.Arguments.Get<string>(0)).WithValue(x.Arguments.Get<double?>(1) ?? 0));
+      }
+
+      protected override void Because()
+      {
+         _result = sut.MapFrom(_individualParameter, DistributionType.Discrete, _subParameters);
+      }
+
+      [Observation]
+      public void should_not_throw_due_to_duplicate_sub_parameter_names()
+      {
+         _result.ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void should_keep_a_single_child_per_sub_parameter_name()
+      {
+         _result.Children.Count.ShouldBeEqualTo(2);
+      }
+
+      [Observation]
+      public void the_caller_supplied_sub_parameter_values_should_win_over_the_factory_placeholders()
+      {
+         _result.GetSingleChildByName<IParameter>("Mean").Value.ShouldBeEqualTo(42.0);
+      }
+   }
 }

--- a/tests/MoBi.Tests/Presentation/Mapper/IndividualParameterToParameterDTOMapperSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Mapper/IndividualParameterToParameterDTOMapperSpecs.cs
@@ -15,17 +15,15 @@ namespace MoBi.Presentation.Mapper
    internal class concern_for_IndividualParameterToParameterDTOMapper : ContextSpecification<IndividualParameterToParameterDTOMapper>
    {
       protected ICloneManagerForBuildingBlock _cloneManagerForBuildingBlock;
-      protected IFormulaFactory _formulaFactory;
       protected IParameterValueToParameterMapper _parameterValueToParameterMapper;
       protected IParameterToParameterDTOMapper _parameterToParameterDTOMapper;
 
       protected override void Context()
       {
          _cloneManagerForBuildingBlock = A.Fake<ICloneManagerForBuildingBlock>();
-         _formulaFactory = A.Fake<IFormulaFactory>();
          _parameterValueToParameterMapper = A.Fake<IParameterValueToParameterMapper>();
          _parameterToParameterDTOMapper = A.Fake<IParameterToParameterDTOMapper>();
-         sut = new IndividualParameterToParameterDTOMapper(_parameterToParameterDTOMapper, _parameterValueToParameterMapper, _formulaFactory, _cloneManagerForBuildingBlock);
+         sut = new IndividualParameterToParameterDTOMapper(_parameterToParameterDTOMapper, _parameterValueToParameterMapper, _cloneManagerForBuildingBlock);
 
          A.CallTo(() => _parameterToParameterDTOMapper.MapFrom(A<IParameter>._)).ReturnsLazily(x => new ParameterDTO(x.GetArgument<IParameter>(0)));
       }
@@ -69,12 +67,6 @@ namespace MoBi.Presentation.Mapper
       protected override IndividualParameter GetParameter()
       {
          return new IndividualParameter { Value = 4 };
-      }
-
-      [Observation]
-      public void the_formula_factory_creates_a_formula_from_the_value()
-      {
-         A.CallTo(() => _formulaFactory.ConstantFormula(_individualParameter.Value.Value, _individualParameter.Dimension)).MustHaveHappened();
       }
    }
 

--- a/tests/MoBi.Tests/Presentation/Tasks/SpatialStructureContentExporterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/SpatialStructureContentExporterSpecs.cs
@@ -28,7 +28,6 @@ namespace MoBi.Presentation.Tasks
       private IMoBiApplicationController _applicationController;
       protected ISelectFolderAndIndividualAndExpressionFromProjectPresenter _selectIndividualAndExpressionFromProjectPresenter;
       protected ICloneManagerForBuildingBlock _cloneManager;
-      protected IFormulaFactory _formulaFactory;
       protected IPathAndValueEntityToParameterValueMapper _pathAndValueEntityToParameterValueMapper;
       private IObjectBaseFactory _objectBaseFactory;
       private IParameterValueToParameterMapper _individualParameterToParameterMapper;
@@ -36,7 +35,6 @@ namespace MoBi.Presentation.Tasks
 
       protected override void Context()
       {
-         _formulaFactory = A.Fake<IFormulaFactory>();
          _spatialStructureFactory = A.Fake<IMoBiSpatialStructureFactory>();
          _interactionTaskContext = A.Fake<IInteractionTaskContext>();
          _applicationController = A.Fake<IMoBiApplicationController>();
@@ -57,7 +55,7 @@ namespace MoBi.Presentation.Tasks
          A.CallTo(() => _interactionTaskContext.InteractionTask).Returns(_interactionTask);
          A.CallTo(() => _individualParameterToParameterMapper.MapFrom(A<IndividualParameter>._)).ReturnsLazily(x => newParameter(x.Arguments.Get<IndividualParameter>(0)));
          A.CallTo(() => _spatialStructureFactory.Create()).Returns(_spatialStructure);
-         sut = new SpatialStructureContentExporter(_spatialStructureFactory, _cloneManager, _objectPathFactory, _pathAndValueEntityToParameterValueMapper, _formulaFactory, _individualParameterToParameterMapper, _interactionTaskContext, _applicationController);
+         sut = new SpatialStructureContentExporter(_spatialStructureFactory, _cloneManager, _objectPathFactory, _pathAndValueEntityToParameterValueMapper, _individualParameterToParameterMapper, _interactionTaskContext, _applicationController);
       }
 
       private static IParameter newParameter(IndividualParameter individualParameter)
@@ -226,7 +224,6 @@ namespace MoBi.Presentation.Tasks
          A.CallTo(() => _selectIndividualAndExpressionFromProjectPresenter.GetPathIndividualAndExpressionsForExport(_containerToSave)).Returns(("FilePath", _individual, _expressionProfiles));
          A.CallTo(() => _spatialStructureFactory.Create()).Returns(_tmpSpatialStructure);
          A.CallTo(() => _cloneManager.Clone(_containerToSave, _tmpSpatialStructure.FormulaCache)).Returns(_clonedContainer);
-         A.CallTo(() => _formulaFactory.ConstantFormula(replacementIndividualParameter.Value.Value, replacementIndividualParameter.Dimension)).ReturnsLazily(x => new ConstantFormula(x.Arguments.Get<double>(0)));
          A.CallTo(() => _interactionTaskContext.Context.Create<ParameterValuesBuildingBlock>()).Returns(_parameterValuesBuildingBlock);
          A.CallTo(() => _interactionTask.Save(A<SpatialStructureTransfer>._, A<string>._)).Invokes(x => _transfer = x.Arguments.Get<SpatialStructureTransfer>(0));
          A.CallTo(() => _cloneManager.Clone(A<InitialCondition>._, A<FormulaCache>._)).ReturnsLazily(x => newInitialCondition(x.Arguments.Get<InitialCondition>(0)));


### PR DESCRIPTION
## Summary

- OSPSuite.Core's `IParameterFactory.CreateDistributedParameter` is being updated to return a fully-formed distributed parameter — it now pre-creates the sub-parameters referenced by the distribution formula (Mean, Deviation, Percentile, ...) and applies the optional value. See Open-Systems-Pharmacology/OSPSuite.Core#2857.
- This PR adapts MoBi's three callers of the mapper / factory to that new contract:
  - `PathAndValueEntityToDistributedParameterMapper` updates an existing factory-created sub-parameter's value when the caller provides one with a matching name, instead of `Add`-ing a duplicate (which would throw `NotUniqueNameException`).
  - `IndividualParameterToParameterDTOMapper` and `SpatialStructureContentExporter` no longer assign a `ConstantFormula(value)` after the mapper — the OSPSuite.Core mapper now applies the value internally. `IFormulaFactory` is no longer needed in either class.

## Test plan

- [x] New unit test `When_creating_a_distributed_parameter_whose_factory_already_pre_created_overlapping_sub_parameters` covers the duplicate sub-parameter-name case.
- [x] All MoBi unit/integration tests pass: 2215 passed (the obsolete `the_formula_factory_creates_a_formula_from_the_value` test on `IndividualParameterToParameterDTOMapperSpecs` was removed; the corresponding behavior is now covered in OSPSuite.Core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issue where duplicate sub-parameter names could be created in distributed parameters; now correctly updates existing sub-parameters instead.
  * Improved parameter value handling and formula management in mapping operations.

* **Refactor**
  * Simplified internal dependency structure in mappers and export operations for better code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->