### PR TITLE
Fixes #2386 Upgrade to .NET 10

### DIFF
--- a/.github/workflows/build-and-publish_v13.yml
+++ b/.github/workflows/build-and-publish_v13.yml
@@ -39,6 +39,7 @@ jobs:
         run: dotnet pack .\MoBi.sln --no-build --no-restore -o ./ -p:PackageVersion=${{env.APP_VERSION}} --configuration=Debug
 
       - name: Push test log as artifact
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: testLog_Windows

--- a/.github/workflows/build-and-publish_v13.yml
+++ b/.github/workflows/build-and-publish_v13.yml
@@ -9,9 +9,6 @@ on:
 permissions:
   packages: write
 
-env:
-  DevExpress_License: ${{ secrets.DEV_EXPRESS_KEY }}
-
 jobs:
   build-test-publish:
     runs-on: ${{ vars.GHA_DEFAULT_RUNNER_WINDOWS || 'windows-latest' }}
@@ -30,6 +27,8 @@ jobs:
           echo "APP_VERSION=13.0.${{ github.run_number }}" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Build
+        env:
+          DevExpress_License: ${{ secrets.DEV_EXPRESS_KEY }}
         run: dotnet build MoBi.sln -p:Version=${{env.APP_VERSION}} -p:ExcludeDesigner=true
 
       - name : Test

--- a/.github/workflows/build-and-publish_v13.yml
+++ b/.github/workflows/build-and-publish_v13.yml
@@ -9,12 +9,15 @@ on:
 permissions:
   packages: write
 
+env:
+  DevExpress_License: ${{ secrets.DEV_EXPRESS_KEY }}
+
 jobs:
   build-test-publish:
-    runs-on: windows-latest
+    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_WINDOWS }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -30,16 +33,16 @@ jobs:
         run: dotnet build MoBi.sln -p:Version=${{env.APP_VERSION}} -p:ExcludeDesigner=true
 
       - name : Test
-        run: dotnet test MoBi.sln -v normal --no-build  --logger:"html;LogFileName=/testLog_Windows.html"
+        run: dotnet test MoBi.sln -v normal --no-build  --logger:"html;LogFileName=testLog_Windows.html"
 
       - name: Pack the project
         run: dotnet pack .\MoBi.sln --no-build --no-restore -o ./ -p:PackageVersion=${{env.APP_VERSION}} --configuration=Debug
 
       - name: Push test log as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testLog_Windows
-          path: /testLog*.html
+          path: ./**/testLog*.html
 
       - name: Publish to GitHub registry
         run: dotnet nuget push *.nupkg --source https://nuget.pkg.github.com/${{github.repository_owner}}/index.json --api-key ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-publish_v13.yml
+++ b/.github/workflows/build-and-publish_v13.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build-test-publish:
-    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_WINDOWS }}
+    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_WINDOWS || 'windows-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
     - v13
-  push:
-    branches:
-    - v13
 
 permissions:
   contents: read

--- a/.github/workflows/build-nightly_v13.yml
+++ b/.github/workflows/build-nightly_v13.yml
@@ -43,7 +43,7 @@ jobs:
     # - either the workflow was triggered manually (on 'workflow_dispatch')
     # - or the workflow was triggered on schedule and last repository commit is not older than 24h (=86400 sec)
     if: needs.get-latest-commit-timespan.outputs.LATEST_COMMIT_TIMESPAN < 86400 || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_WINDOWS }}
+    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_WINDOWS || 'windows-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/build-nightly_v13.yml
+++ b/.github/workflows/build-nightly_v13.yml
@@ -10,9 +10,6 @@ permissions:
   contents: read
   packages: read
 
-env:
-  DevExpress_License: ${{ secrets.DEV_EXPRESS_KEY }}
-
 jobs:
   get-latest-commit-timespan:
     runs-on: ubuntu-latest
@@ -59,6 +56,8 @@ jobs:
           echo "APP_VERSION=13.0.${{ github.run_number }}" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Build
+        env:
+          DevExpress_License: ${{ secrets.DEV_EXPRESS_KEY }}
         run: |
           rake "update_go_license[ApplicationStartup.cs, ${{ secrets.GO_DIAGRAM_KEY }}]"
           dotnet build MoBi.sln /p:Version=${{env.APP_VERSION}} -p:ExcludeDesigner=true

--- a/.github/workflows/build-nightly_v13.yml
+++ b/.github/workflows/build-nightly_v13.yml
@@ -92,6 +92,7 @@ jobs:
           file_path: ./setup/deploy/MoBi.${{ env.APP_VERSION }}.msi
 
       - name: Push test log as artifact
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: testLog_Windows

--- a/.github/workflows/build-nightly_v13.yml
+++ b/.github/workflows/build-nightly_v13.yml
@@ -10,6 +10,9 @@ permissions:
   contents: read
   packages: read
 
+env:
+  DevExpress_License: ${{ secrets.DEV_EXPRESS_KEY }}
+
 jobs:
   get-latest-commit-timespan:
     runs-on: ubuntu-latest
@@ -40,7 +43,7 @@ jobs:
     # - either the workflow was triggered manually (on 'workflow_dispatch')
     # - or the workflow was triggered on schedule and last repository commit is not older than 24h (=86400 sec)
     if: needs.get-latest-commit-timespan.outputs.LATEST_COMMIT_TIMESPAN < 86400 || github.event_name == 'workflow_dispatch'
-    runs-on: windows-latest
+    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_WINDOWS }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -71,7 +74,7 @@ jobs:
           ES_CREDENTIAL_ID: ${{ secrets.ES_CREDENTIAL_ID }}
           ES_TOTP_SECRET: ${{ secrets.ES_TOTP_SECRET }}
         with:
-          file_path: ./src/MoBi/bin/Debug/net8.0-windows/MoBi.exe
+          file_path: ./src/MoBi/bin/Debug/net10.0-windows/MoBi.exe
 
       - name: Create Setup
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   cover:
-    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_WINDOWS }}
+    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_WINDOWS || 'windows-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,10 +10,10 @@ permissions:
 
 jobs:
   cover:
-    runs-on: windows-latest
+    runs-on: ${{ vars.GHA_DEFAULT_RUNNER_WINDOWS }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'true'
 
@@ -23,9 +23,8 @@ jobs:
           dotnet restore
 
       - name: Build
-        run: dotnet build MoBi.sln /p:Version=13.0.9999
+        run: dotnet build MoBi.sln /p:Version=13.0.9999 -p:ExcludeDesigner=true
 
-        
       - name: Cover and report
         uses: Open-Systems-Pharmacology/Workflows/.github/actions/dotCover@main
         with:

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-        <TargetFramework>NET8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <PackageTags>open-systems-pharmacology, ospsuite-components</PackageTags>
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.107" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.107" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.108" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
@@ -8,7 +8,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <OutputPath>bin\$(Configuration)</OutputPath>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <NoWarn>1591, 3246</NoWarn>
+    <NoWarn>1591;3246;WFO1000</NoWarn>
     <ApplicationIcon>MoBi.ico</ApplicationIcon>
     <Description>MoBi.BatchTool</Description>
     <Version Condition="'$(Version)' == ''">13.0.0</Version>
@@ -30,15 +30,6 @@
     <Content Include="..\..\pkparameters\OSPSuite.PKParameters.xml" Link="OSPSuite.PKParameters.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="$(PkgOSPSuite_FuncParser)\OSPSuite.FuncParserNative\bin\native\x64\Release\OSPSuite.FuncParserNative.dll" Link="OSPSuite.FuncParserNative.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(PkgOSPSuite_SimModel)\OSPSuite.SimModelNative\bin\native\x64\Release\OSPSuite.SimModelNative.dll" Link="OSPSuite.SimModelNative.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(PkgOSPSuite_SimModelSolver_CVODES)\OSPSuite.SimModelSolver_CVODES\bin\native\x64\Release\OSPSuite.SimModelSolver_CVODES.dll" Link="OSPSuite.SimModelSolver_CVODES.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">
@@ -48,12 +39,11 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
-    <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
+    <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MoBi.Core\MoBi.Core.csproj" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-	  <TargetFramework>NET8.0</TargetFramework>
+	  <TargetFramework>net10.0</TargetFramework>
       <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
       <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
       <PackageTags>open-systems-pharmacology, ospsuite-components</PackageTags>
@@ -16,14 +16,14 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.107" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.107" />
-      <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.107" />
-      <PackageReference Include="OSPSuite.Presentation" Version="13.0.107" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.107" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.107" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.107" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.108" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.108" />
+      <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+      <PackageReference Include="OSPSuite.Presentation" Version="13.0.108" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.108" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.108" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.108" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -27,7 +27,6 @@
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />
-      <ProjectReference Include="..\MoBi.Core\MoBi.Core.csproj" />
       <ProjectReference Include="..\MoBi.Presentation\MoBi.Presentation.csproj" />
       <ProjectReference Include="..\MoBi.Core\MoBi.Core.csproj" />
 	</ItemGroup>

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <UseWindowsForms>True</UseWindowsForms>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <Authors>Open-Systems-Pharmacology</Authors>
@@ -12,7 +12,6 @@
     <NoWarn>1591, 3246</NoWarn>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Version Condition="'$(Version)' == ''">13.0.0</Version>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -23,31 +22,22 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
+    <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.107" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.108" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
      </Content>
      <Content Include="..\..\pkparameters\OSPSuite.PKParameters.xml" Link="OSPSuite.PKParameters.xml">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-     </Content>
-     <Content Include="$(PkgOSPSuite_FuncParser)\OSPSuite.FuncParserNative\bin\native\x64\Release\OSPSuite.FuncParserNative.dll" Link="OSPSuite.FuncParserNative.dll">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-     </Content>
-     <Content Include="$(PkgOSPSuite_SimModel)\OSPSuite.SimModelNative\bin\native\x64\Release\OSPSuite.SimModelNative.dll" Link="OSPSuite.SimModelNative.dll">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-     </Content>
-     <Content Include="$(PkgOSPSuite_SimModelSolver_CVODES)\OSPSuite.SimModelSolver_CVODES\bin\native\x64\Release\OSPSuite.SimModelSolver_CVODES.dll" Link="OSPSuite.SimModelSolver_CVODES.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
      </Content>
      <Content Include="$(PkgOSPSuite_Presentation)\OSPSuite.Presentation\**">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
-    <PackageReference Include="NHibernate.Extensions.Sqlite" Version="8.0.14" />
+    <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
     <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
@@ -37,7 +37,7 @@
     <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.108" />
     <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.108" />
     <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.108" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>NET8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <PackageTags>open-systems-pharmacology, ospsuite-components</PackageTags>
@@ -30,13 +30,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="8.0.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.107" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.108" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>NET8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <PackageTags>open-systems-pharmacology, ospsuite-components</PackageTags>
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.107" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.108" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>NET8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <Authors>Open-Systems-Pharmacology</Authors>
@@ -22,10 +22,10 @@
 
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
-    <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.107" />  
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />  
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -1,15 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>NET8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.107" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.108" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <OutputPath>bin\$(Configuration)</OutputPath>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>1591;WFO1000</NoWarn>
     <Version Condition="'$(Version)' == ''">13.0.0</Version>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <IsPackable>false</IsPackable>
@@ -19,18 +19,17 @@
 
   <ItemGroup>
     <PackageReference Include="Northwoods.GoWin" Version="5.2.0" />
-    <PackageReference Include="DevExpress.Win.Design" Version="21.2.15" Condition="'$(ExcludeDesigner)' != 'true'" />
+    <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
-    <PackageReference Include="OSPSuite.DataBinding" Version="3.0.1.4" />
-    <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="6.0.1.5" />
-    <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
-    <PackageReference Include="OSPSuite.Utility" Version="4.1.1.5" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.107" />
+    <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
+    <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -61,7 +61,7 @@
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="OSPSuite.Presentation" Version="13.0.108" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -1,18 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <Authors>Open-Systems-Pharmacology</Authors>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <NoWarn>1591, 3246</NoWarn>
+    <NoWarn>1591;3246;WFO1000</NoWarn>
     <ApplicationIcon>MoBi.ico</ApplicationIcon>
 	 <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Version Condition="'$(Version)' == ''">13.0.0</Version>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -30,15 +29,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\pkparameters\OSPSuite.PKParameters.xml" Link="OSPSuite.PKParameters.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(PkgOSPSuite_FuncParser)\OSPSuite.FuncParserNative\bin\native\x64\Release\OSPSuite.FuncParserNative.dll" Link="OSPSuite.FuncParserNative.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(PkgOSPSuite_SimModel)\OSPSuite.SimModelNative\bin\native\x64\Release\OSPSuite.SimModelNative.dll" Link="OSPSuite.SimModelNative.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(PkgOSPSuite_SimModelSolver_CVODES)\OSPSuite.SimModelSolver_CVODES\bin\native\x64\Release\OSPSuite.SimModelSolver_CVODES.dll" Link="OSPSuite.SimModelSolver_CVODES.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="$(PkgOSPSuite_Presentation)\OSPSuite.Presentation\**">
@@ -67,13 +57,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.DevExpress" Version="21.2.15.1" />
-    <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.107" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.108" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>NET8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.107" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.R.Tests/MoBi.R.Tests.csproj
+++ b/tests/MoBi.R.Tests/MoBi.R.Tests.csproj
@@ -1,21 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-	 <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 	<ItemGroup>
-		<Content Include="$(PkgOSPSuite_FuncParser)\OSPSuite.FuncParserNative\bin\native\x64\Release\OSPSuite.FuncParserNative.dll" Link="OSPSuite.FuncParserNative.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="$(PkgOSPSuite_SimModel)\OSPSuite.SimModelNative\bin\native\x64\Release\OSPSuite.SimModelNative.dll" Link="OSPSuite.SimModelNative.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="$(PkgOSPSuite_SimModelSolver_CVODES)\OSPSuite.SimModelSolver_CVODES\bin\native\x64\Release\OSPSuite.SimModelSolver_CVODES.dll" Link="OSPSuite.SimModelSolver_CVODES.dll">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
 	</ItemGroup>
 	<ItemGroup>
 	  <None Include="..\..\src\Data\AllCalculationMethods.pkml" Link="AllCalculationMethods.pkml">
@@ -33,9 +23,9 @@
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
-	 <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
-	 <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
+	 <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+	 <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
 
 	</ItemGroup>
 

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>MoBi</RootNamespace>
     <Version Condition="'$(Version)' == ''">13.0.0</Version>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
@@ -14,15 +13,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\..\pkparameters\OSPSuite.PKParameters.xml" Link="OSPSuite.PKParameters.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(PkgOSPSuite_FuncParser)\OSPSuite.FuncParserNative\bin\native\x64\Release\OSPSuite.FuncParserNative.dll" Link="OSPSuite.FuncParserNative.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(PkgOSPSuite_SimModel)\OSPSuite.SimModelNative\bin\native\x64\Release\OSPSuite.SimModelNative.dll" Link="OSPSuite.SimModelNative.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(PkgOSPSuite_SimModelSolver_CVODES)\OSPSuite.SimModelSolver_CVODES\bin\native\x64\Release\OSPSuite.SimModelSolver_CVODES.dll" Link="OSPSuite.SimModelSolver_CVODES.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="$(PkgOSPSuite_TeXReporting)\OSPSuite.TeXReporting\**">
@@ -38,12 +28,12 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.FuncParser" Version="4.0.0.76" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModel" Version="4.0.0.79" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="4.1.0.19" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -1,13 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
     <RootNamespace>MoBi.UI</RootNamespace>
     <Version Condition="'$(Version)' == ''">13.0.0</Version>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.107" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.107" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.108" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
## Summary

- Retarget MoBi to .NET 10 (`net10.0` / `net10.0-windows`) and pin the new OSP package versions: `OSPSuite.*` 13.0.108 (Open-Systems-Pharmacology/OSPSuite.Core#2859), `OSPSuite.Utility` 5.0.0.7, `OSPSuite.FuncParser` 5.0.0.3, `OSPSuite.SimModel` 5.0.0.76, `OSPSuite.SimModelSolver_CVODES` 5.0.0.53, `OSPSuite.DataBinding` 4.0.0.5, `OSPSuite.DataBinding.DevExpress` 7.0.0.6.
- Drop `OSPSuite.DevExpress` meta-package; DevExpress 25.2 assemblies now flow in transitively via the upgraded `OSPSuite.UI` package. Bump `DevExpress.Win.Design` 21.2.15 → 25.2.7.
- Drop the legacy per-test-project `Content Include` blocks for `OSPSuite.FuncParserNative.dll` / `OSPSuite.SimModelNative.dll` / `OSPSuite.SimModelSolver_CVODES.dll`; the new packages auto-deploy under `runtimes/<rid>/native/`.
- Suppress `WFO1000` (new error-by-default WinForms designer-serialization analyzer in .NET 10) in `MoBi.UI.csproj`, `MoBi.csproj`, `MoBi.BatchTool.csproj`. Properties are runtime-only and don't need designer-serialization attributes.
- Workflows: `build-and-publish_v13.yml` and `build-nightly_v13.yml` get `DEV_EXPRESS_KEY` env (org secret) to clear the DX1000 evaluation watermark on shipped artifacts. `build-nightly_v13.yml`'s code-sign paths bumped from `net8.0-windows` to `net10.0-windows`. `build-and-test.yml` keeps the shared OSP `test-csharp.yml` reusable.

## Out of scope (tracked)

- `OSPSuite.Assets.Images` is still implicitly Windows-coupled via `System.Drawing` and the new DevExpress.Data/Utils refs in Core; will be addressed by Open-Systems-Pharmacology/OSPSuite.Core#2858 (with downstream verification on this repo's R surface tracked in #2385).

## Test plan

- [x] `dotnet build MoBi.sln -p:Version=13.0.9999 -p:ExcludeDesigner=true` — clean (0 errors).
- [x] `dotnet test MoBi.sln` — **2,734 / 2,734 passed**, 4 skipped, 0 failures (MoBi.Tests 2,502 + MoBi.R.Tests 224 + MoBi.UI.Tests 8) against published `OSPSuite.* 13.0.108` from the GitHub Packages registry.

Closes #2386
Closes #2382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded application to .NET 10.0 runtime for enhanced performance and latest platform features
  * Updated core dependencies to latest versions for improved stability and compatibility
  * Updated UI framework to version 25.2.7 for modern interface capabilities
  * Refined CI/CD pipelines and runner configuration for more reliable builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->