### PR TITLE
Fixes #2391 Show formula and paths for transport in simulation

### DIFF
--- a/src/MoBi.Presentation/Mappers/TransportToTransportDTOMapper.cs
+++ b/src/MoBi.Presentation/Mappers/TransportToTransportDTOMapper.cs
@@ -4,7 +4,7 @@ using OSPSuite.Core.Domain;
 
 namespace MoBi.Presentation.Mappers
 {
-   internal interface ITransportToTransportDTOMapper : IMapper<Transport, TransportDTO>
+   public interface ITransportToTransportDTOMapper : IMapper<Transport, TransportDTO>
    {
    }
 

--- a/src/MoBi.Presentation/Presenter/EditInSimulationPresenterFactory.cs
+++ b/src/MoBi.Presentation/Presenter/EditInSimulationPresenterFactory.cs
@@ -32,6 +32,9 @@ namespace MoBi.Presentation.Presenter
          if (entity.IsAnImplementationOf<Reaction>())
             return _container.Resolve<IEditReactionInSimulationPresenter>();
 
+         if (entity.IsAnImplementationOf<Transport>())
+            return _container.Resolve<IEditTransportInSimulationPresenter>();
+
          if (entity.IsAnImplementationOf<IContainer>())
             return _container.Resolve<IEditContainerInSimulationPresenter>();
 

--- a/src/MoBi.Presentation/Presenter/EditProcessInSimulationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditProcessInSimulationPresenter.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using MoBi.Presentation.Presenter.BasePresenter;
+using MoBi.Presentation.Views;
+using OSPSuite.Core.Domain;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Utility.Events;
+
+namespace MoBi.Presentation.Presenter
+{
+   public abstract class EditProcessInSimulationPresenter<TView, TPresenter, TProcess>
+      : AbstractEditPresenter<TView, TPresenter, TProcess>, IEditInSimulationPresenter
+      where TView : class, IEditProcessInSimulationView<TPresenter>
+      where TPresenter : IEditPresenter
+      where TProcess : Process
+   {
+      protected TProcess _process;
+      private readonly IEditParametersInContainerPresenter _editParametersInContainerPresenter;
+      private readonly IFormulaPresenterCache _formulaPresenterCache;
+      private IEditTypedFormulaPresenter _formulaPresenter;
+
+      public TrackableSimulation TrackableSimulation
+      {
+         get;
+         set
+         {
+            field = value;
+            _editParametersInContainerPresenter.EnableSimulationTracking(value);
+         }
+      }
+
+      protected EditProcessInSimulationPresenter(TView view,
+         IEditParametersInContainerPresenter editParametersInContainerPresenter,
+         IFormulaPresenterCache formulaPresenterCache)
+         : base(view)
+      {
+         _editParametersInContainerPresenter = editParametersInContainerPresenter;
+         _formulaPresenterCache = formulaPresenterCache;
+         _editParametersInContainerPresenter.EditMode = EditParameterMode.ValuesOnly;
+         _view.SetParameterView(_editParametersInContainerPresenter.BaseView);
+         AddSubPresenters(_editParametersInContainerPresenter);
+      }
+
+      public void Edit(TProcess process, IReadOnlyList<IObjectBase> existingObjectsInParent)
+      {
+         _process = process;
+         _editParametersInContainerPresenter.Edit(_process);
+         BindProcessToView(_process);
+         initializeFormulaPresenter(_process);
+      }
+
+      public override void Edit(TProcess process)
+      {
+         Edit(process, Array.Empty<IObjectBase>());
+      }
+
+      protected abstract void BindProcessToView(TProcess process);
+
+      private void initializeFormulaPresenter(TProcess process)
+      {
+         _formulaPresenter = _formulaPresenterCache.PresenterFor(process.Formula);
+         _formulaPresenter.InitializeWith(CommandCollector);
+         _view.SetFormulaView(_formulaPresenter.BaseView);
+         _formulaPresenter.ReadOnly = true;
+         _formulaPresenter.Edit(process.Formula, process);
+      }
+
+      public override object Subject => _process;
+
+      public void SelectParameter(IParameter parameter)
+      {
+         _view.ShowParameters();
+         _editParametersInContainerPresenter.Select(parameter);
+      }
+
+      public override void ReleaseFrom(IEventPublisher eventPublisher)
+      {
+         base.ReleaseFrom(eventPublisher);
+         _formulaPresenterCache.ReleaseFrom(eventPublisher);
+      }
+   }
+}

--- a/src/MoBi.Presentation/Presenter/EditReactionInSimulationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditReactionInSimulationPresenter.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Collections.Generic;
 using MoBi.Presentation.Mappers;
-using MoBi.Presentation.Presenter.BasePresenter;
 using MoBi.Presentation.Views;
 using OSPSuite.Core.Domain;
-using OSPSuite.Utility.Events;
 
 namespace MoBi.Presentation.Presenter
 {
@@ -12,71 +8,24 @@ namespace MoBi.Presentation.Presenter
    {
    }
 
-   public class EditReactionInSimulationPresenter : AbstractEditPresenter<IEditReactionInSimulationView, IEditReactionInSimulationPresenter, Reaction>, IEditReactionInSimulationPresenter
+   public class EditReactionInSimulationPresenter
+      : EditProcessInSimulationPresenter<IEditReactionInSimulationView, IEditReactionInSimulationPresenter, Reaction>,
+        IEditReactionInSimulationPresenter
    {
-      private Reaction _reaction;
-      private readonly IEditParametersInContainerPresenter _editParametersInContainerPresenter;
       private readonly IReactionToReactionDTOMapper _reactionToReactionDTOMapper;
-      private readonly IFormulaPresenterCache _formulaPresenterCache;
-      private IEditTypedFormulaPresenter _formulaPresenter;
-      private TrackableSimulation _trackableSimulation;
 
-      public TrackableSimulation TrackableSimulation
-      {
-         get => _trackableSimulation;
-         set
-         {
-            _trackableSimulation = value;
-            _editParametersInContainerPresenter.EnableSimulationTracking(value);
-         }
-      }
-
-      public EditReactionInSimulationPresenter(IEditReactionInSimulationView view, IEditParametersInContainerPresenter editParametersInContainerPresenter, IReactionToReactionDTOMapper reactionToReactionDTOMapper,
+      public EditReactionInSimulationPresenter(IEditReactionInSimulationView view,
+         IEditParametersInContainerPresenter editParametersInContainerPresenter,
+         IReactionToReactionDTOMapper reactionToReactionDTOMapper,
          IFormulaPresenterCache formulaPresenterCache)
-         : base(view)
+         : base(view, editParametersInContainerPresenter, formulaPresenterCache)
       {
-         _editParametersInContainerPresenter = editParametersInContainerPresenter;
-         _formulaPresenterCache = formulaPresenterCache;
          _reactionToReactionDTOMapper = reactionToReactionDTOMapper;
-         _editParametersInContainerPresenter.EditMode = EditParameterMode.ValuesOnly;
-         _view.SetParameterView(_editParametersInContainerPresenter.BaseView);
-         AddSubPresenters(_editParametersInContainerPresenter);
       }
 
-      public void Edit(Reaction reaction, IReadOnlyList<IObjectBase> existingObjectsInParent)
+      protected override void BindProcessToView(Reaction process)
       {
-         _reaction = reaction;
-         _editParametersInContainerPresenter.Edit(_reaction);
-         _view.BindTo(_reactionToReactionDTOMapper.MapFrom(_reaction));
-         initializeFormulaPresenter(reaction);
-      }
-
-      public override void Edit(Reaction reaction)
-      {
-         Edit(reaction, Array.Empty<IObjectBase>());
-      }
-
-      private void initializeFormulaPresenter(Reaction reaction)
-      {
-         _formulaPresenter = _formulaPresenterCache.PresenterFor(reaction.Formula);
-         _formulaPresenter.InitializeWith(CommandCollector);
-         _view.SetFormulaView(_formulaPresenter.BaseView);
-         _formulaPresenter.ReadOnly = true;
-         _formulaPresenter.Edit(reaction.Formula, reaction);
-      }
-
-      public override object Subject => _reaction;
-
-      public void SelectParameter(IParameter parameter)
-      {
-         _view.ShowParameters();
-         _editParametersInContainerPresenter.Select(parameter);
-      }
-
-      public override void ReleaseFrom(IEventPublisher eventPublisher)
-      {
-         base.ReleaseFrom(eventPublisher);
-         _formulaPresenterCache.ReleaseFrom(eventPublisher);
+         _view.BindTo(_reactionToReactionDTOMapper.MapFrom(process));
       }
    }
 }

--- a/src/MoBi.Presentation/Presenter/EditTransportInSimulationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditTransportInSimulationPresenter.cs
@@ -1,0 +1,31 @@
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Views;
+using OSPSuite.Core.Domain;
+
+namespace MoBi.Presentation.Presenter
+{
+   public interface IEditTransportInSimulationPresenter : IEditInSimulationPresenter, IEditPresenterWithParameters<Transport>
+   {
+   }
+
+   public class EditTransportInSimulationPresenter
+      : EditProcessInSimulationPresenter<IEditTransportInSimulationView, IEditTransportInSimulationPresenter, Transport>,
+        IEditTransportInSimulationPresenter
+   {
+      private readonly ITransportToTransportDTOMapper _transportToTransportDTOMapper;
+
+      public EditTransportInSimulationPresenter(IEditTransportInSimulationView view,
+         IEditParametersInContainerPresenter editParametersInContainerPresenter,
+         ITransportToTransportDTOMapper transportToTransportDTOMapper,
+         IFormulaPresenterCache formulaPresenterCache)
+         : base(view, editParametersInContainerPresenter, formulaPresenterCache)
+      {
+         _transportToTransportDTOMapper = transportToTransportDTOMapper;
+      }
+
+      protected override void BindProcessToView(Transport process)
+      {
+         _view.BindTo(_transportToTransportDTOMapper.MapFrom(process));
+      }
+   }
+}

--- a/src/MoBi.Presentation/Views/IEditProcessInSimulationView.cs
+++ b/src/MoBi.Presentation/Views/IEditProcessInSimulationView.cs
@@ -1,0 +1,13 @@
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Views;
+
+namespace MoBi.Presentation.Views
+{
+   public interface IEditProcessInSimulationView<TPresenter> : IView<TPresenter>
+      where TPresenter : IPresenter
+   {
+      void SetParameterView(IView view);
+      void SetFormulaView(IView view);
+      void ShowParameters();
+   }
+}

--- a/src/MoBi.Presentation/Views/IEditReactionInSimulationView.cs
+++ b/src/MoBi.Presentation/Views/IEditReactionInSimulationView.cs
@@ -1,14 +1,10 @@
-﻿using MoBi.Presentation.DTO;
+using MoBi.Presentation.DTO;
 using MoBi.Presentation.Presenter;
-using OSPSuite.Presentation.Views;
 
 namespace MoBi.Presentation.Views
 {
-   public interface IEditReactionInSimulationView : IView<IEditReactionInSimulationPresenter>
+   public interface IEditReactionInSimulationView : IEditProcessInSimulationView<IEditReactionInSimulationPresenter>
    {
       void BindTo(ReactionDTO reactionDTO);
-      void SetParameterView(IView view);
-      void SetFormulaView(IView view);
-      void ShowParameters();
    }
 }

--- a/src/MoBi.Presentation/Views/IEditTransportInSimulationView.cs
+++ b/src/MoBi.Presentation/Views/IEditTransportInSimulationView.cs
@@ -1,0 +1,10 @@
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+
+namespace MoBi.Presentation.Views
+{
+   public interface IEditTransportInSimulationView : IEditProcessInSimulationView<IEditTransportInSimulationPresenter>
+   {
+      void BindTo(TransportDTO transportDTO);
+   }
+}

--- a/src/MoBi.UI/Views/EditExplicitFormulaView.cs
+++ b/src/MoBi.UI/Views/EditExplicitFormulaView.cs
@@ -114,7 +114,7 @@ namespace MoBi.UI.Views
          set
          {
             _readOnly = value;
-            txtFormulaString.Enabled = !_readOnly;
+            txtFormulaString.ReadOnly = _readOnly;
          }
       }
    }

--- a/src/MoBi.UI/Views/EditTransportInSimulationView.Designer.cs
+++ b/src/MoBi.UI/Views/EditTransportInSimulationView.Designer.cs
@@ -1,0 +1,316 @@
+namespace MoBi.UI.Views
+{
+   partial class EditTransportInSimulationView
+   {
+      /// <summary>
+      /// Required designer variable.
+      /// </summary>
+      private System.ComponentModel.IContainer components = null;
+
+      /// <summary>
+      /// Clean up any resources being used.
+      /// </summary>
+      /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+      protected override void Dispose(bool disposing)
+      {
+         if (disposing && (components != null))
+         {
+            components.Dispose();
+         }
+         base.Dispose(disposing);
+      }
+
+      #region Windows Form Designer generated code
+
+      /// <summary>
+      /// Required method for Designer support - do not modify
+      /// the contents of this method with the code editor.
+      /// </summary>
+      private void InitializeComponent()
+      {
+         this.tabPagesControl = new DevExpress.XtraTab.XtraTabControl();
+         this.tabProperties = new DevExpress.XtraTab.XtraTabPage();
+         this.layoutControl1 = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.pnlKinetic = new DevExpress.XtraEditors.PanelControl();
+         this.htmlEditor = new DevExpress.XtraEditors.MemoExEdit();
+         this.txtName = new DevExpress.XtraEditors.TextEdit();
+         this.txtSource = new DevExpress.XtraEditors.TextEdit();
+         this.txtTarget = new DevExpress.XtraEditors.TextEdit();
+         this.txtMolecule = new DevExpress.XtraEditors.TextEdit();
+         this.txtDimension = new DevExpress.XtraEditors.TextEdit();
+         this.layoutControlGroup1 = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.layoutItemName = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemSource = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemTarget = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemMolecule = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemDimension = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutControlKinetic = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutControlDescription = new DevExpress.XtraLayout.LayoutControlItem();
+         this.tabParameters = new DevExpress.XtraTab.XtraTabPage();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.tabPagesControl)).BeginInit();
+         this.tabPagesControl.SuspendLayout();
+         this.tabProperties.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl1)).BeginInit();
+         this.layoutControl1.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.pnlKinetic)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.htmlEditor.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.txtName.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.txtSource.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.txtTarget.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.txtMolecule.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.txtDimension.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup1)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemName)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemSource)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemTarget)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemMolecule)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDimension)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlKinetic)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlDescription)).BeginInit();
+         this.SuspendLayout();
+         //
+         // tabPagesControl
+         //
+         this.tabPagesControl.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.tabPagesControl.Location = new System.Drawing.Point(0, 0);
+         this.tabPagesControl.Name = "tabPagesControl";
+         this.tabPagesControl.SelectedTabPage = this.tabProperties;
+         this.tabPagesControl.Size = new System.Drawing.Size(924, 563);
+         this.tabPagesControl.TabIndex = 0;
+         this.tabPagesControl.TabPages.AddRange(new DevExpress.XtraTab.XtraTabPage[] {
+            this.tabProperties,
+            this.tabParameters});
+         //
+         // tabProperties
+         //
+         this.tabProperties.Controls.Add(this.layoutControl1);
+         this.tabProperties.Name = "tabProperties";
+         this.tabProperties.Size = new System.Drawing.Size(918, 535);
+         this.tabProperties.Text = "Properties";
+         //
+         // layoutControl1
+         //
+         this.layoutControl1.Controls.Add(this.pnlKinetic);
+         this.layoutControl1.Controls.Add(this.htmlEditor);
+         this.layoutControl1.Controls.Add(this.txtName);
+         this.layoutControl1.Controls.Add(this.txtSource);
+         this.layoutControl1.Controls.Add(this.txtTarget);
+         this.layoutControl1.Controls.Add(this.txtMolecule);
+         this.layoutControl1.Controls.Add(this.txtDimension);
+         this.layoutControl1.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.layoutControl1.Location = new System.Drawing.Point(0, 0);
+         this.layoutControl1.Name = "layoutControl1";
+         this.layoutControl1.Root = this.layoutControlGroup1;
+         this.layoutControl1.Size = new System.Drawing.Size(918, 535);
+         this.layoutControl1.TabIndex = 0;
+         this.layoutControl1.Text = "layoutControl1";
+         //
+         // pnlKinetic
+         //
+         this.pnlKinetic.Location = new System.Drawing.Point(147, 132);
+         this.pnlKinetic.Name = "pnlKinetic";
+         this.pnlKinetic.Size = new System.Drawing.Size(759, 367);
+         this.pnlKinetic.TabIndex = 7;
+         //
+         // htmlEditor
+         //
+         this.htmlEditor.Location = new System.Drawing.Point(147, 503);
+         this.htmlEditor.Name = "htmlEditor";
+         this.htmlEditor.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+         this.htmlEditor.Properties.ShowIcon = false;
+         this.htmlEditor.Size = new System.Drawing.Size(759, 20);
+         this.htmlEditor.StyleController = this.layoutControl1;
+         this.htmlEditor.TabIndex = 5;
+         //
+         // txtName
+         //
+         this.txtName.Location = new System.Drawing.Point(147, 12);
+         this.txtName.Name = "txtName";
+         this.txtName.Size = new System.Drawing.Size(759, 20);
+         this.txtName.StyleController = this.layoutControl1;
+         this.txtName.TabIndex = 4;
+         //
+         // txtSource
+         //
+         this.txtSource.Location = new System.Drawing.Point(147, 36);
+         this.txtSource.Name = "txtSource";
+         this.txtSource.Size = new System.Drawing.Size(759, 20);
+         this.txtSource.StyleController = this.layoutControl1;
+         this.txtSource.TabIndex = 8;
+         //
+         // txtTarget
+         //
+         this.txtTarget.Location = new System.Drawing.Point(147, 60);
+         this.txtTarget.Name = "txtTarget";
+         this.txtTarget.Size = new System.Drawing.Size(759, 20);
+         this.txtTarget.StyleController = this.layoutControl1;
+         this.txtTarget.TabIndex = 9;
+         //
+         // txtMolecule
+         //
+         this.txtMolecule.Location = new System.Drawing.Point(147, 84);
+         this.txtMolecule.Name = "txtMolecule";
+         this.txtMolecule.Size = new System.Drawing.Size(759, 20);
+         this.txtMolecule.StyleController = this.layoutControl1;
+         this.txtMolecule.TabIndex = 10;
+         //
+         // txtDimension
+         //
+         this.txtDimension.Location = new System.Drawing.Point(147, 108);
+         this.txtDimension.Name = "txtDimension";
+         this.txtDimension.Size = new System.Drawing.Size(759, 20);
+         this.txtDimension.StyleController = this.layoutControl1;
+         this.txtDimension.TabIndex = 11;
+         //
+         // layoutControlGroup1
+         //
+         this.layoutControlGroup1.CustomizationFormText = "layoutControlGroup1";
+         this.layoutControlGroup1.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
+         this.layoutControlGroup1.GroupBordersVisible = false;
+         this.layoutControlGroup1.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutItemName,
+            this.layoutItemSource,
+            this.layoutItemTarget,
+            this.layoutItemMolecule,
+            this.layoutItemDimension,
+            this.layoutControlKinetic,
+            this.layoutControlDescription});
+         this.layoutControlGroup1.Location = new System.Drawing.Point(0, 0);
+         this.layoutControlGroup1.Name = "layoutControlGroup1";
+         this.layoutControlGroup1.Size = new System.Drawing.Size(918, 535);
+         this.layoutControlGroup1.Text = "layoutControlGroup1";
+         this.layoutControlGroup1.TextVisible = false;
+         //
+         // layoutItemName
+         //
+         this.layoutItemName.Control = this.txtName;
+         this.layoutItemName.CustomizationFormText = "layoutItemName";
+         this.layoutItemName.Location = new System.Drawing.Point(0, 0);
+         this.layoutItemName.Name = "layoutItemName";
+         this.layoutItemName.Size = new System.Drawing.Size(898, 24);
+         this.layoutItemName.Text = "layoutItemName";
+         this.layoutItemName.TextSize = new System.Drawing.Size(132, 13);
+         //
+         // layoutItemSource
+         //
+         this.layoutItemSource.Control = this.txtSource;
+         this.layoutItemSource.CustomizationFormText = "layoutItemSource";
+         this.layoutItemSource.Location = new System.Drawing.Point(0, 24);
+         this.layoutItemSource.Name = "layoutItemSource";
+         this.layoutItemSource.Size = new System.Drawing.Size(898, 24);
+         this.layoutItemSource.Text = "layoutItemSource";
+         this.layoutItemSource.TextSize = new System.Drawing.Size(132, 13);
+         //
+         // layoutItemTarget
+         //
+         this.layoutItemTarget.Control = this.txtTarget;
+         this.layoutItemTarget.CustomizationFormText = "layoutItemTarget";
+         this.layoutItemTarget.Location = new System.Drawing.Point(0, 48);
+         this.layoutItemTarget.Name = "layoutItemTarget";
+         this.layoutItemTarget.Size = new System.Drawing.Size(898, 24);
+         this.layoutItemTarget.Text = "layoutItemTarget";
+         this.layoutItemTarget.TextSize = new System.Drawing.Size(132, 13);
+         //
+         // layoutItemMolecule
+         //
+         this.layoutItemMolecule.Control = this.txtMolecule;
+         this.layoutItemMolecule.CustomizationFormText = "layoutItemMolecule";
+         this.layoutItemMolecule.Location = new System.Drawing.Point(0, 72);
+         this.layoutItemMolecule.Name = "layoutItemMolecule";
+         this.layoutItemMolecule.Size = new System.Drawing.Size(898, 24);
+         this.layoutItemMolecule.Text = "layoutItemMolecule";
+         this.layoutItemMolecule.TextSize = new System.Drawing.Size(132, 13);
+         //
+         // layoutItemDimension
+         //
+         this.layoutItemDimension.Control = this.txtDimension;
+         this.layoutItemDimension.CustomizationFormText = "layoutItemDimension";
+         this.layoutItemDimension.Location = new System.Drawing.Point(0, 96);
+         this.layoutItemDimension.Name = "layoutItemDimension";
+         this.layoutItemDimension.Size = new System.Drawing.Size(898, 24);
+         this.layoutItemDimension.Text = "layoutItemDimension";
+         this.layoutItemDimension.TextSize = new System.Drawing.Size(132, 13);
+         //
+         // layoutControlKinetic
+         //
+         this.layoutControlKinetic.Control = this.pnlKinetic;
+         this.layoutControlKinetic.CustomizationFormText = "layoutControlKinetic";
+         this.layoutControlKinetic.Location = new System.Drawing.Point(0, 120);
+         this.layoutControlKinetic.Name = "layoutControlKinetic";
+         this.layoutControlKinetic.Size = new System.Drawing.Size(898, 371);
+         this.layoutControlKinetic.Text = "layoutControlKinetic";
+         this.layoutControlKinetic.TextSize = new System.Drawing.Size(132, 13);
+         //
+         // layoutControlDescription
+         //
+         this.layoutControlDescription.Control = this.htmlEditor;
+         this.layoutControlDescription.CustomizationFormText = "layoutControlDescription";
+         this.layoutControlDescription.Location = new System.Drawing.Point(0, 491);
+         this.layoutControlDescription.Name = "layoutControlDescription";
+         this.layoutControlDescription.Size = new System.Drawing.Size(898, 24);
+         this.layoutControlDescription.Text = "layoutControlDescription";
+         this.layoutControlDescription.TextSize = new System.Drawing.Size(132, 13);
+         //
+         // tabParameters
+         //
+         this.tabParameters.Name = "tabParameters";
+         this.tabParameters.Size = new System.Drawing.Size(918, 535);
+         this.tabParameters.Text = "Parameter";
+         //
+         // EditTransportInSimulationView
+         //
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.Controls.Add(this.tabPagesControl);
+         this.Name = "EditTransportInSimulationView";
+         this.Size = new System.Drawing.Size(924, 563);
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.tabPagesControl)).EndInit();
+         this.tabPagesControl.ResumeLayout(false);
+         this.tabProperties.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl1)).EndInit();
+         this.layoutControl1.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.pnlKinetic)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.htmlEditor.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.txtName.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.txtSource.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.txtTarget.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.txtMolecule.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.txtDimension.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup1)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemName)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemSource)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemTarget)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemMolecule)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDimension)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlKinetic)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlDescription)).EndInit();
+         this.ResumeLayout(false);
+
+      }
+
+      #endregion
+
+      private DevExpress.XtraTab.XtraTabControl tabPagesControl;
+      private DevExpress.XtraTab.XtraTabPage tabProperties;
+      private DevExpress.XtraTab.XtraTabPage tabParameters;
+      private OSPSuite.UI.Controls.UxLayoutControl layoutControl1;
+      private DevExpress.XtraEditors.PanelControl pnlKinetic;
+      private DevExpress.XtraEditors.MemoExEdit htmlEditor;
+      private DevExpress.XtraEditors.TextEdit txtName;
+      private DevExpress.XtraEditors.TextEdit txtSource;
+      private DevExpress.XtraEditors.TextEdit txtTarget;
+      private DevExpress.XtraEditors.TextEdit txtMolecule;
+      private DevExpress.XtraEditors.TextEdit txtDimension;
+      private DevExpress.XtraLayout.LayoutControlGroup layoutControlGroup1;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemName;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemSource;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemTarget;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemMolecule;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemDimension;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlKinetic;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlDescription;
+   }
+}

--- a/src/MoBi.UI/Views/EditTransportInSimulationView.cs
+++ b/src/MoBi.UI/Views/EditTransportInSimulationView.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 using DevExpress.Utils;
 using MoBi.Assets;
 using MoBi.Presentation.DTO;
@@ -11,25 +11,28 @@ using OSPSuite.UI.Extensions;
 
 namespace MoBi.UI.Views
 {
-   public partial class EditReactionInSimulationView : BaseUserControl, IEditReactionInSimulationView
+   public partial class EditTransportInSimulationView : BaseUserControl, IEditTransportInSimulationView
    {
-      private IEditReactionInSimulationPresenter _presenter;
+      private IEditTransportInSimulationPresenter _presenter;
 
-      public EditReactionInSimulationView()
+      public EditTransportInSimulationView()
       {
          InitializeComponent();
       }
 
-      public void AttachPresenter(IEditReactionInSimulationPresenter presenter)
+      public void AttachPresenter(IEditTransportInSimulationPresenter presenter)
       {
          _presenter = presenter;
       }
 
-      public void BindTo(ReactionDTO dtoReaction)
+      public void BindTo(TransportDTO dtoTransport)
       {
-         lblStoichiometric.Text = dtoReaction.Stoichiometric;
-         txtName.Text = dtoReaction.Name;
-         htmlEditor.Text = dtoReaction.Description;
+         txtName.Text = dtoTransport.Name;
+         txtSource.Text = dtoTransport.Source;
+         txtTarget.Text = dtoTransport.Target;
+         txtMolecule.Text = dtoTransport.Molecule;
+         txtDimension.Text = dtoTransport.Dimension?.DisplayName;
+         htmlEditor.Text = dtoTransport.Description;
       }
 
       public void SetParameterView(IView view)
@@ -54,9 +57,16 @@ namespace MoBi.UI.Views
          layoutControlKinetic.Text = AppConstants.Captions.Kinetic.FormatForLabel();
          layoutControlKinetic.TextLocation = Locations.Top;
          layoutControlKinetic.MinSize = new Size(3 * OSPSuite.UI.UIConstants.Size.BUTTON_HEIGHT, 2 * OSPSuite.UI.UIConstants.Size.BUTTON_WIDTH);
-         layoutControlStoichiometrie.Text = AppConstants.Captions.Stoichiometry.FormatForLabel();
          layoutItemName.Text = AppConstants.Captions.Name.FormatForLabel();
+         layoutItemSource.Text = AppConstants.Captions.Source.FormatForLabel();
+         layoutItemTarget.Text = AppConstants.Captions.Target.FormatForLabel();
+         layoutItemMolecule.Text = AppConstants.Captions.Molecule.FormatForLabel();
+         layoutItemDimension.Text = AppConstants.Captions.Dimension.FormatForLabel();
          txtName.Properties.ReadOnly = true;
+         txtSource.Properties.ReadOnly = true;
+         txtTarget.Properties.ReadOnly = true;
+         txtMolecule.Properties.ReadOnly = true;
+         txtDimension.Properties.ReadOnly = true;
          htmlEditor.Properties.ReadOnly = true;
       }
    }

--- a/src/MoBi.UI/Views/EditTransportInSimulationView.resx
+++ b/src/MoBi.UI/Views/EditTransportInSimulationView.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="errorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/tests/MoBi.Tests/Presentation/EditTransportInSimulationPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditTransportInSimulationPresenterSpecs.cs
@@ -1,0 +1,49 @@
+using FakeItEasy;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Domain;
+
+namespace MoBi.Presentation
+{
+   public abstract class concern_for_EditTransportInSimulationPresenter : ContextSpecification<EditTransportInSimulationPresenter>
+   {
+      private IFormulaPresenterCache _formulaPresenterCache;
+      private ITransportToTransportDTOMapper _transportToTransportDTOMapper;
+      protected IEditParametersInContainerPresenter _editParametersInContainerPresenter;
+      private IEditTransportInSimulationView _view;
+
+      protected override void Context()
+      {
+         _formulaPresenterCache = A.Fake<IFormulaPresenterCache>();
+         _transportToTransportDTOMapper = A.Fake<ITransportToTransportDTOMapper>();
+         _editParametersInContainerPresenter = A.Fake<IEditParametersInContainerPresenter>();
+         _view = A.Fake<IEditTransportInSimulationView>();
+
+         sut = new EditTransportInSimulationPresenter(_view, _editParametersInContainerPresenter, _transportToTransportDTOMapper, _formulaPresenterCache);
+      }
+   }
+
+   public class When_enabling_simulation_tracking_in_transport : concern_for_EditTransportInSimulationPresenter
+   {
+      private TrackableSimulation _trackableSimulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _trackableSimulation = new TrackableSimulation(null, new SimulationEntitySourceReferenceCache());
+      }
+
+      protected override void Because()
+      {
+         sut.TrackableSimulation = _trackableSimulation;
+      }
+
+      [Observation]
+      public void the_parameters_presenter_has_tracking_enabled()
+      {
+         A.CallTo(() => _editParametersInContainerPresenter.EnableSimulationTracking(_trackableSimulation)).MustHaveHappened();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/ShowPresenterFactorySpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ShowPresenterFactorySpecs.cs
@@ -13,6 +13,7 @@ namespace MoBi.Presentation
       protected IEditContainerInSimulationPresenter _showContainerPresenter;
       protected IEditQuantityInSimulationPresenter _editQuantityPresenter;
       protected IEditReactionInSimulationPresenter _showReactionPresenter;
+      protected IEditTransportInSimulationPresenter _showTransportPresenter;
 
       protected override void Context()
       {
@@ -20,8 +21,10 @@ namespace MoBi.Presentation
          _showContainerPresenter = A.Fake<IEditContainerInSimulationPresenter>();
          _editQuantityPresenter = A.Fake<IEditQuantityInSimulationPresenter>();
          _showReactionPresenter = A.Fake<IEditReactionInSimulationPresenter>();
+         _showTransportPresenter = A.Fake<IEditTransportInSimulationPresenter>();
          A.CallTo(() => _ioc.Resolve<IEditQuantityInSimulationPresenter>()).Returns(_editQuantityPresenter);
          A.CallTo(() => _ioc.Resolve<IEditReactionInSimulationPresenter>()).Returns(_showReactionPresenter);
+         A.CallTo(() => _ioc.Resolve<IEditTransportInSimulationPresenter>()).Returns(_showTransportPresenter);
          A.CallTo(() => _ioc.Resolve<IEditContainerInSimulationPresenter>()).Returns(_showContainerPresenter);
          sut = new EditInSimulationPresenterFactory(_ioc);
       }
@@ -39,6 +42,12 @@ namespace MoBi.Presentation
       public void should_return_the_registered_presenter_for_a_neighbhorhood()
       {
          sut.PresenterFor(new Reaction()).ShouldBeEqualTo(_showReactionPresenter);
+      }
+
+      [Observation]
+      public void should_return_the_registered_presenter_for_a_transport()
+      {
+         sut.PresenterFor(new Transport()).ShouldBeEqualTo(_showTransportPresenter);
       }
 
       [Observation]


### PR DESCRIPTION
Fixes #2391

## Summary
Adds an `EditTransportInSimulationPresenter` / `EditTransportInSimulationView` pair so that clicking a `Transport` in the simulation tree shows its resolved rate formula, source/target container paths, moved molecule, dimension, and a read-only parameter values tab — mirroring the existing reaction display.

Shared logic between the reaction and transport in-simulation presenters is lifted into a generic abstract base `EditProcessInSimulationPresenter<TView, TPresenter, TProcess> where TProcess : Process`. The two views remain separate concrete classes (the layouts diverge — stoichiometric label vs. source/target/molecule/dimension fields). The factory `EditInSimulationPresenterFactory.PresenterFor` gets a new `Transport` clause between the `Reaction` and the generic `IContainer` fallback.

Drive-by: changed the read-only name field on the reaction view and the formula string on `EditExplicitFormulaView` from `Enabled = false` to `Properties.ReadOnly = true`, so the text remains selectable/copy-friendly instead of greyed out.

## Test plan
- [x] `dotnet build` succeeds for `MoBi.Presentation`, `MoBi.UI`, and `MoBi.Tests`
- [x] Full `MoBi.Presentation` test namespace passes (1340 passed, 1 skipped, 0 failed)
- [x] New `EditTransportInSimulationPresenterSpecs` mirrors the reaction specs and passes
- [x] `ShowPresenterFactorySpecs` extended with a Transport routing assertion
- [x] Manual smoke: load a simulation with passive transports, click a transport, confirm rate, source path, target path, molecule, dimension, description and read-only parameter values all show
- [x] Manual smoke: regression check that reactions still render identically

<img width="1061" height="831" alt="image" src="https://github.com/user-attachments/assets/94b01ba3-6cbd-4592-b1f9-f139d2384040" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for editing Transport processes during simulations with parameter configuration and kinetic formula viewing.

* **Improvements**
  * Modified read-only field behavior in formula editors and transport views to use read-only mode instead of disabling controls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/MoBi/pull/2393)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->