### PR TITLE
Fixes #2385 Consume OSPSuite.Core ApplicationIcon refactor (13.0.110)

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.108" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.109" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-bRFfL" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.110" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.109" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-bRFfL" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,14 +16,14 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.109" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.109" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.0-bRFfL" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.0-bRFfL" />
       <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
-      <PackageReference Include="OSPSuite.Presentation" Version="13.0.109" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.109" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.109" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.109" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+      <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-bRFfL" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.0-bRFfL" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-bRFfL" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-bRFfL" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-	  <TargetFramework>net10.0</TargetFramework>
+	  <TargetFramework>net10.0-windows</TargetFramework>
       <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
       <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
       <PackageTags>open-systems-pharmacology, ospsuite-components</PackageTags>
@@ -16,14 +16,14 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.108" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.108" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.109" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.109" />
       <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
-      <PackageReference Include="OSPSuite.Presentation" Version="13.0.108" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.108" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.108" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.108" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+      <PackageReference Include="OSPSuite.Presentation" Version="13.0.109" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.109" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.109" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.109" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,14 +16,14 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.0-bRFfL" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.0-bRFfL" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.110" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.110" />
       <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
-      <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-bRFfL" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.0-bRFfL" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-bRFfL" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-bRFfL" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
+      <PackageReference Include="OSPSuite.Presentation" Version="13.0.110" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.110" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.110" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.110" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -22,16 +22,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.110" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.110" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -22,16 +22,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-bRFfL" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-bRFfL" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -22,16 +22,16 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.109" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.109" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,13 +31,21 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.109" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <!--
+      Required by IDiagramModelToImageTask (System.Drawing.Bitmap). Previously pulled in transitively
+      via OSPSuite.Assets.Images's DevExpress.Utils dependency, which was removed as part of the
+      ApplicationIcon cross-platform refactor. Long-term: the interface should be redesigned to
+      return a byte[] (PNG) so MoBi.Core can stay honestly cross-platform without referencing
+      System.Drawing.
+    -->
+    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,12 +31,12 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.110" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <!--
       Required by IDiagramModelToImageTask (System.Drawing.Bitmap). Previously pulled in transitively

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,12 +31,12 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.0-bRFfL" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <!--
       Required by IDiagramModelToImageTask (System.Drawing.Bitmap). Previously pulled in transitively

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.109" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.110" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.0-bRFfL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -23,9 +23,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <Authors>Open-Systems-Pharmacology</Authors>
@@ -23,10 +23,10 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />  
-   </ItemGroup>
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">
       <Pack>True</Pack>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -23,9 +23,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/Main/NotificationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/NotificationPresenter.cs
@@ -3,19 +3,18 @@ using System.Collections.Generic;
 using System.Data;
 using System.Drawing;
 using System.Linq;
-using MoBi.Assets;
 using MoBi.Core;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Settings;
 using MoBi.Presentation.Views;
-using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Core;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Presenters.Main;
@@ -114,10 +113,10 @@ namespace MoBi.Presentation.Presenter.Main
          if (!notification.Object.IsAnImplementationOf<ObserverBuilder>())
             return false;
 
-         if (AppConstants.DefaultNames.PKSimStaticObservers.Contains(notification.ObjectName))
+         if (DefaultNames.PKSimStaticObservers.Contains(notification.ObjectName))
             return true;
 
-         return AppConstants.DefaultNames.PKSimDynamicObservers.Any(notification.ObjectName.StartsWith);
+         return DefaultNames.PKSimDynamicObservers.Any(notification.ObjectName.StartsWith);
       }
 
       public void ClearNotifications(MessageOrigin messageOrigin)
@@ -140,30 +139,30 @@ namespace MoBi.Presentation.Presenter.Main
 
       public void ExportToFile()
       {
-         var file = _dialogCreator.AskForFileToSave(AppConstants.Captions.SaveLogToFile, Constants.Filter.CSV_FILE_FILTER, Constants.DirectoryKey.REPORT);
+         var file = _dialogCreator.AskForFileToSave(Captions.SaveLogToFile, Constants.Filter.CSV_FILE_FILTER, Constants.DirectoryKey.REPORT);
          if (string.IsNullOrEmpty(file)) return;
 
          var dataTable = new DataTable();
 
-         dataTable.Columns.Add(AppConstants.Captions.Type, typeof(string));
-         dataTable.Columns.Add(AppConstants.Captions.ObjectType, typeof(string));
-         dataTable.Columns.Add(AppConstants.Captions.ObjectName, typeof(string));
-         dataTable.Columns.Add(AppConstants.Captions.BuildingBlockType, typeof(string));
-         dataTable.Columns.Add(AppConstants.Captions.BuildingBlockName, typeof(string));
-         dataTable.Columns.Add(AppConstants.Captions.Message, typeof(string));
-         dataTable.Columns.Add(AppConstants.Captions.MessageOrigin, typeof(string));
+         dataTable.Columns.Add(Captions.Type, typeof(string));
+         dataTable.Columns.Add(Captions.ObjectType, typeof(string));
+         dataTable.Columns.Add(Captions.ObjectName, typeof(string));
+         dataTable.Columns.Add(Captions.BuildingBlockType, typeof(string));
+         dataTable.Columns.Add(Captions.BuildingBlockName, typeof(string));
+         dataTable.Columns.Add(Captions.Message, typeof(string));
+         dataTable.Columns.Add(Captions.MessageOrigin, typeof(string));
 
 
          foreach (var message in _allNotifications.Where(x => isShowing(x.Type)))
          {
             var newRow = dataTable.NewRow();
-            newRow[AppConstants.Captions.Type] = message.Type;
-            newRow[AppConstants.Captions.ObjectType] = message.ObjectType;
-            newRow[AppConstants.Captions.ObjectName] = message.ObjectName;
-            newRow[AppConstants.Captions.BuildingBlockType] = message.BuildingBlockType;
-            newRow[AppConstants.Captions.BuildingBlockName] = message.BuildingBlockName;
-            newRow[AppConstants.Captions.Message] = message.NotificationMessage + Environment.NewLine + message.Details.ToString(Environment.NewLine);
-            newRow[AppConstants.Captions.MessageOrigin] = Enum.GetName(typeof(MessageOrigin), message.MessageOrigin);
+            newRow[Captions.Type] = message.Type;
+            newRow[Captions.ObjectType] = message.ObjectType;
+            newRow[Captions.ObjectName] = message.ObjectName;
+            newRow[Captions.BuildingBlockType] = message.BuildingBlockType;
+            newRow[Captions.BuildingBlockName] = message.BuildingBlockName;
+            newRow[Captions.Message] = message.NotificationMessage + Environment.NewLine + message.Details.ToString(Environment.NewLine);
+            newRow[Captions.MessageOrigin] = Enum.GetName(typeof(MessageOrigin), message.MessageOrigin);
             dataTable.Rows.Add(newRow);
          }
 
@@ -267,7 +266,7 @@ namespace MoBi.Presentation.Presenter.Main
          if (!simulationsWithUntraceableChanges.Any())
             return;
 
-         _dialogCreator.MessageBoxInfo(AppConstants.Captions.ProjectConversionResultedInSimulationsWithUntraceableChanges(simulationsWithUntraceableChanges.AllNames()));
+         _dialogCreator.MessageBoxInfo(Captions.ProjectConversionResultedInSimulationsWithUntraceableChanges(simulationsWithUntraceableChanges.AllNames()));
       }
 
       public void Handle(RemovedEvent eventToHandle)
@@ -294,7 +293,7 @@ namespace MoBi.Presentation.Presenter.Main
          NotificationMessage = notificationMessage;
       }
 
-      public ApplicationIcon Icon => NotificationMessage.Image;
+      public Image Image => NotificationMessage.Image.ToImage();
       public NotificationType Type => NotificationMessage.Type;
       public NotificationMessage NotificationMessage { get; }
 

--- a/src/MoBi.Presentation/Presenter/Main/NotificationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/NotificationPresenter.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Data;
 using System.Drawing;
 using System.Linq;
+using MoBi.Assets;
 using MoBi.Core;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Events;
 using MoBi.Presentation.Mappers;
 using MoBi.Presentation.Settings;
 using MoBi.Presentation.Views;
+using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Events;
@@ -112,10 +114,10 @@ namespace MoBi.Presentation.Presenter.Main
          if (!notification.Object.IsAnImplementationOf<ObserverBuilder>())
             return false;
 
-         if (DefaultNames.PKSimStaticObservers.Contains(notification.ObjectName))
+         if (AppConstants.DefaultNames.PKSimStaticObservers.Contains(notification.ObjectName))
             return true;
 
-         return DefaultNames.PKSimDynamicObservers.Any(notification.ObjectName.StartsWith);
+         return AppConstants.DefaultNames.PKSimDynamicObservers.Any(notification.ObjectName.StartsWith);
       }
 
       public void ClearNotifications(MessageOrigin messageOrigin)
@@ -138,30 +140,30 @@ namespace MoBi.Presentation.Presenter.Main
 
       public void ExportToFile()
       {
-         var file = _dialogCreator.AskForFileToSave(Captions.SaveLogToFile, Constants.Filter.CSV_FILE_FILTER, Constants.DirectoryKey.REPORT);
+         var file = _dialogCreator.AskForFileToSave(AppConstants.Captions.SaveLogToFile, Constants.Filter.CSV_FILE_FILTER, Constants.DirectoryKey.REPORT);
          if (string.IsNullOrEmpty(file)) return;
 
          var dataTable = new DataTable();
 
-         dataTable.Columns.Add(Captions.Type, typeof(string));
-         dataTable.Columns.Add(Captions.ObjectType, typeof(string));
-         dataTable.Columns.Add(Captions.ObjectName, typeof(string));
-         dataTable.Columns.Add(Captions.BuildingBlockType, typeof(string));
-         dataTable.Columns.Add(Captions.BuildingBlockName, typeof(string));
-         dataTable.Columns.Add(Captions.Message, typeof(string));
-         dataTable.Columns.Add(Captions.MessageOrigin, typeof(string));
+         dataTable.Columns.Add(AppConstants.Captions.Type, typeof(string));
+         dataTable.Columns.Add(AppConstants.Captions.ObjectType, typeof(string));
+         dataTable.Columns.Add(AppConstants.Captions.ObjectName, typeof(string));
+         dataTable.Columns.Add(AppConstants.Captions.BuildingBlockType, typeof(string));
+         dataTable.Columns.Add(AppConstants.Captions.BuildingBlockName, typeof(string));
+         dataTable.Columns.Add(AppConstants.Captions.Message, typeof(string));
+         dataTable.Columns.Add(AppConstants.Captions.MessageOrigin, typeof(string));
 
 
          foreach (var message in _allNotifications.Where(x => isShowing(x.Type)))
          {
             var newRow = dataTable.NewRow();
-            newRow[Captions.Type] = message.Type;
-            newRow[Captions.ObjectType] = message.ObjectType;
-            newRow[Captions.ObjectName] = message.ObjectName;
-            newRow[Captions.BuildingBlockType] = message.BuildingBlockType;
-            newRow[Captions.BuildingBlockName] = message.BuildingBlockName;
-            newRow[Captions.Message] = message.NotificationMessage + Environment.NewLine + message.Details.ToString(Environment.NewLine);
-            newRow[Captions.MessageOrigin] = Enum.GetName(typeof(MessageOrigin), message.MessageOrigin);
+            newRow[AppConstants.Captions.Type] = message.Type;
+            newRow[AppConstants.Captions.ObjectType] = message.ObjectType;
+            newRow[AppConstants.Captions.ObjectName] = message.ObjectName;
+            newRow[AppConstants.Captions.BuildingBlockType] = message.BuildingBlockType;
+            newRow[AppConstants.Captions.BuildingBlockName] = message.BuildingBlockName;
+            newRow[AppConstants.Captions.Message] = message.NotificationMessage + Environment.NewLine + message.Details.ToString(Environment.NewLine);
+            newRow[AppConstants.Captions.MessageOrigin] = Enum.GetName(typeof(MessageOrigin), message.MessageOrigin);
             dataTable.Rows.Add(newRow);
          }
 
@@ -265,7 +267,7 @@ namespace MoBi.Presentation.Presenter.Main
          if (!simulationsWithUntraceableChanges.Any())
             return;
 
-         _dialogCreator.MessageBoxInfo(Captions.ProjectConversionResultedInSimulationsWithUntraceableChanges(simulationsWithUntraceableChanges.AllNames()));
+         _dialogCreator.MessageBoxInfo(AppConstants.Captions.ProjectConversionResultedInSimulationsWithUntraceableChanges(simulationsWithUntraceableChanges.AllNames()));
       }
 
       public void Handle(RemovedEvent eventToHandle)
@@ -292,7 +294,7 @@ namespace MoBi.Presentation.Presenter.Main
          NotificationMessage = notificationMessage;
       }
 
-      public Image Image => NotificationMessage.Image.ToImage();
+      public ApplicationIcon Icon => NotificationMessage.Image;
       public NotificationType Type => NotificationMessage.Type;
       public NotificationMessage NotificationMessage { get; }
 

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -1,15 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <!--
+      Temporary: MoBi.R is meant to be cross-platform net10.0, but transitively pulls
+      OSPSuite.Presentation (Windows-only) via MoBi.CLI.Core / MoBi.Infrastructure,
+      and also pulls a System.Drawing surface from MoBi.Core (IDiagramModelToImageTask
+      returns Bitmap, ChartOptions has Color properties, etc.). Once both are addressed,
+      this TFM returns to net10.0 and the assembly loads honestly on Linux / macOS .NET 10.
+      Tracked in https://github.com/Open-Systems-Pharmacology/MoBi/issues/2388.
+    -->
+    <TargetFramework>net10.0-windows</TargetFramework>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.109" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.110" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.0-bRFfL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -25,11 +25,11 @@
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -25,11 +25,11 @@
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -25,11 +25,11 @@
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/Views/EditBuildingBlockBaseView.cs
+++ b/src/MoBi.UI/Views/EditBuildingBlockBaseView.cs
@@ -34,7 +34,7 @@ namespace MoBi.UI.Views
          {
             //Required because this might be set before the component is actually fully initialized
             if(tabEditBuildingBlock != null)
-               tabEditBuildingBlock.Image = value.ToImage(IconSizes.Size16x16);
+               tabEditBuildingBlock.SetImage(value, IconSizes.Size16x16);
          }
       }
 
@@ -67,7 +67,7 @@ namespace MoBi.UI.Views
       public override void InitializeResources()
       {
          base.InitializeResources();
-         tabFormulaCache.Image = ApplicationIcons.Formula.ToImage(IconSizes.Size16x16);
+         tabFormulaCache.SetImage(ApplicationIcons.Formula, IconSizes.Size16x16);
       }
    }
 }

--- a/src/MoBi.UI/Views/EditExpressionProfileBuildingBlockView.cs
+++ b/src/MoBi.UI/Views/EditExpressionProfileBuildingBlockView.cs
@@ -31,7 +31,7 @@ namespace MoBi.UI.Views
       {
          tabEditInitialConditions.FillWith(baseView);
          tabEditInitialConditions.Text = AppConstants.Captions.InitialConditions;
-         tabEditInitialConditions.SetImage(ApplicationIcons.InitialConditions);
+         tabEditInitialConditions.SetImage(ApplicationIcons.InitialConditions, IconSizes.Size16x16);
       }
 
       public override void InitializeResources()

--- a/src/MoBi.UI/Views/EditExpressionProfileBuildingBlockView.cs
+++ b/src/MoBi.UI/Views/EditExpressionProfileBuildingBlockView.cs
@@ -31,7 +31,7 @@ namespace MoBi.UI.Views
       {
          tabEditInitialConditions.FillWith(baseView);
          tabEditInitialConditions.Text = AppConstants.Captions.InitialConditions;
-         tabEditInitialConditions.Image = ApplicationIcons.InitialConditions;
+         tabEditInitialConditions.SetImage(ApplicationIcons.InitialConditions);
       }
 
       public override void InitializeResources()

--- a/src/MoBi.UI/Views/EditObserverBuilderView.cs
+++ b/src/MoBi.UI/Views/EditObserverBuilderView.cs
@@ -87,7 +87,7 @@ namespace MoBi.UI.Views
          layoutItemMoleculeList.TextVisible = false;
          layoutItemDescriptorConditionList.TextVisible = false;
          layoutGroupInContainerWith.Text = AppConstants.Captions.InContainerWith.FormatForLabel();
-         tabProperties.SetImage(ApplicationIcons.Properties);
+         tabProperties.SetImage(ApplicationIcons.Properties, IconSizes.Size16x16);
       }
 
       public void Activate()

--- a/src/MoBi.UI/Views/EditObserverBuilderView.cs
+++ b/src/MoBi.UI/Views/EditObserverBuilderView.cs
@@ -87,7 +87,7 @@ namespace MoBi.UI.Views
          layoutItemMoleculeList.TextVisible = false;
          layoutItemDescriptorConditionList.TextVisible = false;
          layoutGroupInContainerWith.Text = AppConstants.Captions.InContainerWith.FormatForLabel();
-         tabProperties.Image = ApplicationIcons.Properties.ToImage();
+         tabProperties.SetImage(ApplicationIcons.Properties);
       }
 
       public void Activate()

--- a/src/MoBi.UI/Views/EditParametersInContainerView.cs
+++ b/src/MoBi.UI/Views/EditParametersInContainerView.cs
@@ -107,7 +107,7 @@ namespace MoBi.UI.Views
          return new DXMenuItem(
             AppConstants.Captions.CopyPath,
             (s, args) => copyPath(),
-            ApplicationIcons.Copy
+            ApplicationIcons.Copy.ToImage()
          );
       }
 

--- a/src/MoBi.UI/Views/NotificationView.cs
+++ b/src/MoBi.UI/Views/NotificationView.cs
@@ -29,6 +29,7 @@ namespace MoBi.UI.Views
       private readonly GridViewBinder<NotificationMessageDTO> _gridViewBinder;
       private readonly RepositoryItemPictureEdit _statusIconRepository;
       private readonly IStartOptions _runOptions;
+      private IGridViewColumn _iconColumn;
 
       public NotificationView(IImageListRetriever imageListRetriever, IToolTipCreator toolTipCreator, IStartOptions runOptions)
       {
@@ -59,6 +60,27 @@ namespace MoBi.UI.Views
          //handle filter only if we explicitly hide the record
          if (!e.Visible)
             e.Handled = true;
+      }
+
+      private void updateImage(object sender, CustomColumnDataEventArgs e)
+      {
+         if (!shouldUpdateColumn(e)) 
+            return;
+
+         var notification = _gridViewBinder.SourceElementAt(e.ListSourceRowIndex);
+         if (notification == null) 
+            return;
+
+         e.Value = notification.Icon.ToImage();
+      }
+
+      private bool shouldUpdateColumn(CustomColumnDataEventArgs e)
+      {
+         if (!ReferenceEquals(e.Column, _iconColumn.XtraColumn)) 
+            return false;
+         if (!e.IsGetData) 
+            return false;
+         return true;
       }
 
       private void onGridViewMouseDown(MouseEventArgs e)
@@ -96,10 +118,12 @@ namespace MoBi.UI.Views
 
       public override void InitializeBinding()
       {
-         _gridViewBinder.Bind(x => x.Image)
+         _iconColumn = _gridViewBinder.AddUnboundColumn()
             .WithCaption(AppConstants.Captions.EmptyColumn)
             .WithRepository(x => _statusIconRepository)
             .WithFixedWidth(OSPSuite.UI.UIConstants.Size.EMBEDDED_BUTTON_WIDTH);
+
+         gridViewMessages.CustomUnboundColumnData += updateImage;
 
          _gridViewBinder.AutoBind(x => x.ObjectType)
             .WithCaption(AppConstants.Captions.ObjectType)

--- a/src/MoBi.UI/Views/NotificationView.cs
+++ b/src/MoBi.UI/Views/NotificationView.cs
@@ -29,7 +29,6 @@ namespace MoBi.UI.Views
       private readonly GridViewBinder<NotificationMessageDTO> _gridViewBinder;
       private readonly RepositoryItemPictureEdit _statusIconRepository;
       private readonly IStartOptions _runOptions;
-      private IGridViewColumn _iconColumn;
 
       public NotificationView(IImageListRetriever imageListRetriever, IToolTipCreator toolTipCreator, IStartOptions runOptions)
       {
@@ -60,27 +59,6 @@ namespace MoBi.UI.Views
          //handle filter only if we explicitly hide the record
          if (!e.Visible)
             e.Handled = true;
-      }
-
-      private void updateImage(object sender, CustomColumnDataEventArgs e)
-      {
-         if (!shouldUpdateColumn(e)) 
-            return;
-
-         var notification = _gridViewBinder.SourceElementAt(e.ListSourceRowIndex);
-         if (notification == null) 
-            return;
-
-         e.Value = notification.Icon.ToImage();
-      }
-
-      private bool shouldUpdateColumn(CustomColumnDataEventArgs e)
-      {
-         if (!ReferenceEquals(e.Column, _iconColumn.XtraColumn)) 
-            return false;
-         if (!e.IsGetData) 
-            return false;
-         return true;
       }
 
       private void onGridViewMouseDown(MouseEventArgs e)
@@ -118,12 +96,10 @@ namespace MoBi.UI.Views
 
       public override void InitializeBinding()
       {
-         _iconColumn = _gridViewBinder.AddUnboundColumn()
+         _gridViewBinder.Bind(x => x.Image)
             .WithCaption(AppConstants.Captions.EmptyColumn)
             .WithRepository(x => _statusIconRepository)
             .WithFixedWidth(OSPSuite.UI.UIConstants.Size.EMBEDDED_BUTTON_WIDTH);
-
-         gridViewMessages.CustomUnboundColumnData += updateImage;
 
          _gridViewBinder.AutoBind(x => x.ObjectType)
             .WithCaption(AppConstants.Captions.ObjectType)

--- a/src/MoBi.UI/Views/ObjectBaseSummaryView.cs
+++ b/src/MoBi.UI/Views/ObjectBaseSummaryView.cs
@@ -8,6 +8,7 @@ using MoBi.Presentation.DTO;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Views;
 using OSPSuite.UI.Controls;
+using OSPSuite.UI.Extensions;
 
 namespace MoBi.UI.Views
 {
@@ -32,7 +33,7 @@ namespace MoBi.UI.Views
       {
          _screenBinder.BindToSource(objectBaseDTO);
          _gridViewBinder.BindToSource(objectBaseDTO.Dictionary.OrderBy(x => x.Key));
-         svgImageBox.SvgImage = objectBaseDTO.ApplicationIcon;
+         svgImageBox.SvgImage = objectBaseDTO.ApplicationIcon.ToSvgImage();
       }
 
       public override void InitializeBinding()

--- a/src/MoBi.UI/Views/ObjectBaseSummaryView.cs
+++ b/src/MoBi.UI/Views/ObjectBaseSummaryView.cs
@@ -1,14 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using MoBi.Assets;
-using OSPSuite.DataBinding;
-using OSPSuite.DataBinding.DevExpress;
-using OSPSuite.DataBinding.DevExpress.XtraGrid;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Views;
+using OSPSuite.DataBinding;
+using OSPSuite.DataBinding.DevExpress;
+using OSPSuite.DataBinding.DevExpress.XtraGrid;
+using OSPSuite.Presentation.Extensions;
 using OSPSuite.UI.Controls;
-using OSPSuite.UI.Extensions;
 
 namespace MoBi.UI.Views
 {

--- a/src/MoBi.UI/Views/ValidationMessagesView.cs
+++ b/src/MoBi.UI/Views/ValidationMessagesView.cs
@@ -72,7 +72,7 @@ namespace MoBi.UI.Views
          chkError.Text = AppConstants.Captions.Error;
          chkWarning.Text = AppConstants.Captions.Warning;
          btnSaveLog.Text = AppConstants.Captions.SaveLog;
-         btnSaveLog.Image = ApplicationIcons.Save.ToImage(IconSizes.Size16x16);
+         btnSaveLog.ImageOptions.SetImage(ApplicationIcons.Save, IconSizes.Size16x16);
          btnSaveLog.ImageLocation = ImageLocation.MiddleLeft;
          layoutItemSaveLog.AdjustButtonSize(layoutControl);
       }

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -57,12 +57,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.109" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-bRFfL" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -57,12 +57,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.0-bRFfL" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.110" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -57,12 +57,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.108" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.109" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.R.Tests/MoBi.R.Tests.csproj
+++ b/tests/MoBi.R.Tests/MoBi.R.Tests.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <!--
+      Temporary: tracks the TFM of MoBi.R. See note in src/Mobi.R/MoBi.R.csproj and
+      https://github.com/Open-Systems-Pharmacology/MoBi/issues/2388.
+    -->
+    <TargetFramework>net10.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.109" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-bRFfL" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.110" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.0-bRFfL" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.108" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.108" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.109" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.109" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.0-bRFfL" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.0-bRFfL" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.110" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.110" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
## Summary

Bumps OSPSuite.* references to **13.0.110**, which ships both [Open-Systems-Pharmacology/OSPSuite.Core#2858](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/issues/2858) (ApplicationIcon is a pure cross-platform resource library; Windows rendering relocated) and [Open-Systems-Pharmacology/OSPSuite.Core#2864](https://github.com/Open-Systems-Pharmacology/OSPSuite.Core/issues/2864) (ApplicationIcon rendering extensions moved from `OSPSuite.UI` to `OSPSuite.Presentation`).

### Mechanical consumption changes

All `(Image)icon` / `(SvgImage)icon` / `(System.Drawing.Size)iconSize` implicit-cast call sites in `MoBi.UI` rewritten to explicit `.ToSvgImage()` / `.ToImage()` / `.SetImage(icon, size)`. No behaviour change — same DevExpress render parameters as before.

### Notification grid

`MoBi.Presentation.Presenter.Main.NotificationMessageDTO` exposes:

```csharp
public Image Image => Icon.ToImage();
```

`Image` materializes via the upstream `OSPSuite.Presentation.Extensions.ApplicationIconExtensions.ToImage()` from #2864. The notification view continues to use the existing `_gridViewBinder.Bind(x => x.Image)` pattern.

### Cleanups enabled by #2864

- `MoBi.Presentation/IconImageRenderer.cs` — **deleted**. No longer needed; rendering is supplied by `OSPSuite.Presentation.Extensions.ApplicationIconExtensions`.
- `MoBi.Presentation.csproj` — `<PackageReference Include="DevExpress.Utils" />` and its explanatory comment block **dropped**. `DevExpress.Utils` is now inherited transitively from `OSPSuite.Presentation`.

### TFM changes

`net10.0-windows` is forced on `MoBi.Presentation` and `MoBi.CLI.Core` by their transitive `OSPSuite.Presentation` dependency (honestly Windows-only).

`MoBi.R` and `MoBi.R.Tests` are **temporarily** `net10.0-windows` with explanatory comments pointing at [#2388](https://github.com/Open-Systems-Pharmacology/MoBi/issues/2388). Honest cross-platform R needs both (a) the Presentation transitive pull removed from `MoBi.R` and (b) the System.Drawing surface in `MoBi.Core` (`IDiagramModelToImageTask` returning `Bitmap`, `ChartOptions.Color` properties, `PointF` in commands — see [the issue comment](https://github.com/Open-Systems-Pharmacology/MoBi/issues/2388#issuecomment-4430728163) for the audit) refactored. Out of scope for this PR.

### `MoBi.Core` System.Drawing pin

`MoBi.Core` gets an explicit `<PackageReference Include="System.Drawing.Common" Version="9.0.0" />`. It previously came in transitively via `OSPSuite.Assets.Images`'s DevExpress dependency, which was removed upstream in #2858. The comment in the csproj notes that the long-term fix is the [#2388](https://github.com/Open-Systems-Pharmacology/MoBi/issues/2388) refactor (interface returns `byte[]`/`Stream` instead of `Bitmap`).


## Related

- OSPSuite.Core PRs: #2863 (#2858) and #2865 (#2864), both merged into V13 and published as 13.0.110.
- Tracking issue: #2385.
- Follow-up: #2388 (R cross-platform via service decoupling + Core System.Drawing refactor) — out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core and supporting library dependencies to latest stable versions across multiple projects
  * Updated Windows framework targeting for improved platform support

* **Tests**
  * Updated test project dependencies to align with main release

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/MoBi/pull/2394)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->