### PR TITLE
Fixes #2389 Rename tag conditions in dynamic formulas when a molecule is renamed

### DIFF
--- a/src/MoBi.Core/Commands/EditTargetCriteriaTagCommand.cs
+++ b/src/MoBi.Core/Commands/EditTargetCriteriaTagCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Domain.Model;
+using MoBi.Core.Events;
 using OSPSuite.Assets;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
@@ -27,6 +28,7 @@ namespace MoBi.Core.Commands
       {
          base.ExecuteWith(context);
          editTagInCriteria(getCriteria());
+         context.PublishEvent(new TagChangedEvent(_taggedObject));
       }
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)

--- a/src/MoBi.Core/Events/Events.cs
+++ b/src/MoBi.Core/Events/Events.cs
@@ -289,6 +289,13 @@ namespace MoBi.Core.Events
       }
    }
 
+   public class TagChangedEvent : TagConditionEvent
+   {
+      public TagChangedEvent(IObjectBase taggedObject) : base(taggedObject)
+      {
+      }
+   }
+
    public class ChartAddedEvent
    {
       public CurveChart Chart { get; }

--- a/src/MoBi.Presentation/Presenter/EditSumFormulaPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditSumFormulaPresenter.cs
@@ -12,7 +12,8 @@ namespace MoBi.Presentation.Presenter
 {
    public interface IEditSumFormulaPresenter :
       IEditTypedFormulaPresenter,
-      IListener<FormulaChangedEvent>
+      IListener<FormulaChangedEvent>,
+      IListener<TagChangedEvent>
    {
       void ChangeVariableName(string newVariableName);
       void Validate(string formula);
@@ -79,6 +80,14 @@ namespace MoBi.Presentation.Presenter
       public void Handle(FormulaChangedEvent eventToHandle)
       {
          if (!canHandle(eventToHandle))
+            return;
+
+         refreshView();
+      }
+
+      public void Handle(TagChangedEvent eventToHandle)
+      {
+         if (!Equals(eventToHandle.TaggedObject, _formula))
             return;
 
          refreshView();

--- a/src/MoBi.Presentation/Tasks/CheckNameVisitor.cs
+++ b/src/MoBi.Presentation/Tasks/CheckNameVisitor.cs
@@ -138,6 +138,9 @@ namespace MoBi.Presentation.Tasks
             }
          }
 
+         if (formula is DynamicFormula dynamicFormula)
+            checkDescriptorCriteria(dynamicFormula, x => x.Criteria);
+
          var explicitFormula = formula as ExplicitFormula;
          if (explicitFormula == null)
             return;

--- a/tests/MoBi.Tests/Core/CheckNameVisitorSpecs.cs
+++ b/tests/MoBi.Tests/Core/CheckNameVisitorSpecs.cs
@@ -695,4 +695,41 @@ namespace MoBi.Core
          _resultChanges.Count.ShouldBeEqualTo(3);
       }
    }
+
+   internal class When_visiting_a_dynamic_formula_with_a_tag_condition_matching_the_renamed_molecule : concern_for_CheckNameVisitor
+   {
+      private SumFormula _sumFormula;
+      private MoBiReactionBuildingBlock _reactionBuildingBlock;
+      private IEnumerable<IStringChange> _changes;
+      private MatchTagCondition _tagCondition;
+
+      protected override void Context()
+      {
+         base.Context();
+         _sumFormula = new SumFormula().WithName("drugSum");
+         _tagCondition = new MatchTagCondition(_changedName);
+         _sumFormula.Criteria.Add(_tagCondition);
+         _reactionBuildingBlock = new MoBiReactionBuildingBlock().WithName("R").WithId("R");
+         _reactionBuildingBlock.AddFormula(_sumFormula);
+      }
+
+      protected override void Because()
+      {
+         _changes = sut.GetPossibleChangesFrom(_changedObject, _newName, _reactionBuildingBlock, _changedName);
+      }
+
+      [Observation]
+      public void should_emit_an_EditTagCommand_for_the_dynamic_formula_criteria()
+      {
+         _changes.Count(x => x.ChangeCommand.IsAnImplementationOf<EditTagCommand<DynamicFormula>>()).ShouldBeEqualTo(1);
+      }
+
+      [Observation]
+      public void executing_the_emitted_command_should_replace_the_tag_on_the_dynamic_formula()
+      {
+         var change = _changes.First(x => x.ChangeCommand.IsAnImplementationOf<EditTagCommand<DynamicFormula>>());
+         change.ChangeCommand.Execute(_context);
+         _sumFormula.Criteria.OfType<ITagCondition>().Single().Tag.ShouldBeEqualTo(_newName);
+      }
+   }
 }

--- a/tests/MoBi.Tests/Core/Commands/EditParameterTagCommandAtSumFormulaSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/EditParameterTagCommandAtSumFormulaSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using FakeItEasy;
 using MoBi.Core.Domain.Model;
+using MoBi.Core.Events;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain.Builder;
@@ -49,6 +50,12 @@ namespace MoBi.Core.Commands
       public void should_should_have_changed_Tag_at_condition()
       {
          _tagCondition.Tag.ShouldBeEqualTo(_newTag);
+      }
+
+      [Observation]
+      public void should_publish_a_TagChangedEvent_for_the_tagged_object()
+      {
+         A.CallTo(() => _context.PublishEvent(A<TagChangedEvent>.That.Matches(x => x.TaggedObject == _sumFormula))).MustHaveHappened();
       }
    }
 }

--- a/tests/MoBi.Tests/Presentation/EditSumFormulaPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditSumFormulaPresenterSpecs.cs
@@ -1,0 +1,78 @@
+using FakeItEasy;
+using MoBi.Core.Domain.Services;
+using MoBi.Core.Events;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Core.Services;
+
+namespace MoBi.Presentation
+{
+   public abstract class concern_for_EditSumFormulaPresenter : ContextSpecification<IEditSumFormulaPresenter>
+   {
+      protected IEditSumFormulaView _view;
+      protected ISumFormulaToDTOSumFormulaMapper _sumFormulaDTOMapper;
+      protected IDescriptorConditionListPresenter<SumFormula> _descriptorConditionListPresenter;
+      protected IMoBiFormulaTask _moBiFormulaTask;
+      protected IDisplayUnitRetriever _displayUnitRetriever;
+      protected IEditFormulaPathListPresenter _editFormulaPathListPresenter;
+      protected SumFormula _sumFormula;
+
+      protected override void Context()
+      {
+         _view = A.Fake<IEditSumFormulaView>();
+         _sumFormulaDTOMapper = A.Fake<ISumFormulaToDTOSumFormulaMapper>();
+         _descriptorConditionListPresenter = A.Fake<IDescriptorConditionListPresenter<SumFormula>>();
+         _moBiFormulaTask = A.Fake<IMoBiFormulaTask>();
+         _displayUnitRetriever = A.Fake<IDisplayUnitRetriever>();
+         _editFormulaPathListPresenter = A.Fake<IEditFormulaPathListPresenter>();
+         _sumFormula = new SumFormula();
+         A.CallTo(() => _sumFormulaDTOMapper.MapFrom(_sumFormula)).Returns(new SumFormulaDTO(_sumFormula));
+         A.CallTo(() => _moBiFormulaTask.Validate(A<string>._, A<SumFormula>._, A<OSPSuite.Core.Domain.Builder.IBuildingBlock>._))
+            .Returns((true, string.Empty));
+         sut = new EditSumFormulaPresenter(
+            _view, _sumFormulaDTOMapper, _descriptorConditionListPresenter, _moBiFormulaTask, _displayUnitRetriever, _editFormulaPathListPresenter);
+         sut.Edit(_sumFormula);
+         Fake.ClearRecordedCalls(_view);
+      }
+   }
+
+   public class When_handling_a_TagChangedEvent_for_the_edited_sum_formula : concern_for_EditSumFormulaPresenter
+   {
+      protected override void Because()
+      {
+         sut.Handle(new TagChangedEvent(_sumFormula));
+      }
+
+      [Observation]
+      public void should_refresh_the_view()
+      {
+         A.CallTo(() => _view.Show(A<SumFormulaDTO>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_handling_a_TagChangedEvent_for_a_different_tagged_object : concern_for_EditSumFormulaPresenter
+   {
+      private SumFormula _otherFormula;
+
+      protected override void Context()
+      {
+         base.Context();
+         _otherFormula = new SumFormula();
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new TagChangedEvent(_otherFormula));
+      }
+
+      [Observation]
+      public void should_not_refresh_the_view()
+      {
+         A.CallTo(() => _view.Show(A<SumFormulaDTO>._)).MustNotHaveHappened();
+      }
+   }
+}


### PR DESCRIPTION
## Summary

Fixes #2389.

When a molecule is renamed in a Molecule Building Block, paths referencing the old name are correctly rewritten (e.g. the FcRn-binding reaction paths in an ADC base module). However, tag-based conditions on `DynamicFormula.Criteria` (e.g. `MatchTagCondition("nAb")` inside the two SumFormula-based parameters of the endosomal FcRn binding reaction) were not updated, so the formula resolved to no drug and the reaction silently broke.

### Root cause

`CheckNameVisitor` already runs `checkDescriptorCriteria` for every entity type that carries a `DescriptorCriteria` property (`TransportBuilder.{Source,Target}Criteria`, `ObserverBuilder.ContainerCriteria`, `EventGroupBuilder.SourceCriteria`, `ReactionBuilder.ContainerCriteria`). It was missing the case for formulas: `DynamicFormula` (base class of `SumFormula`) also exposes a `Criteria` property, but `Visit(IFormula)` only handled paths/aliases/explicit-formula strings.

### Changes

- **`CheckNameVisitor.Visit(IFormula)`** — slot `DynamicFormula.Criteria` into the existing `checkDescriptorCriteria<T>` → `EditTagCommand<T>` pipeline. Targeting `DynamicFormula` rather than the concrete `SumFormula` future-proofs the visitor against any future dynamic-formula subclass added in OSPSuite.Core.
- **`TagChangedEvent`** — new event in `MoBi.Core.Events`, sibling of `AddTagConditionEvent`/`RemoveTagConditionEvent`, carrying the `TaggedObject` so listeners can self-filter.
- **`EditTagCommand<T>.ExecuteWith`** — publishes `TagChangedEvent` after editing, so currently-open editors can refresh.
- **`EditSumFormulaPresenter`** — implements `IListener<TagChangedEvent>`; refreshes the view when the event's `TaggedObject` is the formula being edited.

Cross-building-block scope is already provided by `EditTaskFor.checkUsagesInModule`, which iterates every building block in the module — so a `SumFormula` living in the Reaction BB is visited when the rename starts from the Molecule BB.

## Test plan

- [x] `dotnet build MoBi.sln` — clean, 0 errors.
- [x] New `When_visiting_a_dynamic_formula_with_a_tag_condition_matching_the_renamed_molecule` spec in `CheckNameVisitorSpecs.cs` — asserts `EditTagCommand<DynamicFormula>` is emitted and that executing it replaces the tag (2 observations).
- [x] Extended `EditParameterTagCommandAtSumFormulaSpecs` — asserts `TagChangedEvent` is published with the correct `TaggedObject`.
- [x] New `EditSumFormulaPresenterSpecs.cs` — asserts the presenter refreshes the view on matching `TagChangedEvent` and ignores non-matching ones.
- [x] All pre-existing `CheckNameVisitor` specs still pass (23 `When_visiting_*` + 3 `When_renaming_*` + 1 transport-builder spec).
- [x] Manual smoke test: open ADC base module from PK-Sim, rename `nAb` → `nAb_renamed` in the Molecule BB, confirm the "select renaming" dialog now offers an `EditTagCondition` change for the affected `SumFormula`, accept, verify parameter view shows `MatchTag = nAb_renamed` and the reaction resolves drug correctly.
- [ ] Undo/redo round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event notification for tag changes on formulas, ensuring UI updates reflect tag modifications in real-time.
  * Enhanced formula criteria handling to properly detect and update tag references when renaming objects.

* **Tests**
  * Added comprehensive test coverage for tag change events and presenter behavior when tags are updated on formulas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/MoBi/pull/2395)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->