### PR TITLE
Fixes #2404 Route headless PK-Sim-module snapshot loading through PKSim.R.Exchange

### DIFF
--- a/src/MoBi.CLI.Core/ApplicationStartup.cs
+++ b/src/MoBi.CLI.Core/ApplicationStartup.cs
@@ -8,6 +8,7 @@ using MoBi.Core.Extensions;
 using MoBi.Core.Serialization.Xml;
 using MoBi.Core.Serialization.Xml.Serializer;
 using MoBi.Core.Serialization.Xml.Services;
+using MoBi.Core.Services;
 using OSPSuite.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
@@ -69,6 +70,8 @@ namespace MoBi.CLI.Core
          container.Register<IMoBiXmlSerializerRepository, MoBiCoreXmlSerializerRepository>(LifeStyle.Singleton);
          container.Register<ICoreUserSettings, OSPSuite.Core.ICoreUserSettings, CoreUserSettings>(LifeStyle.Singleton);
          container.Register<IApplicationSettings, OSPSuite.Core.IApplicationSettings, ApplicationSettings>(LifeStyle.Singleton);
+         // Desktop CLI uses the installed PK-Sim (PKSim.Starter.dll) for snapshot conversion.
+         container.Register<IPKSimStarter, IPKSimSnapshotConverter, PKSimStarter>(LifeStyle.Singleton);
          container.Register<ISpatialStructureDiagramManager, SpatialStructureDiagramManager>();
          container.Register<IMoBiReactionDiagramManager, MoBiReactionDiagramManager>();
          container.Register<ISimulationDiagramManager, SimulationDiagramManager>();

--- a/src/MoBi.Core/CoreRegister.cs
+++ b/src/MoBi.Core/CoreRegister.cs
@@ -51,6 +51,9 @@ namespace MoBi.Core
             scan.ExcludeType<GroupRepository>();
             scan.ExcludeType<ClipboardManager>();
             scan.ExcludeType<ApplicationSettings>();
+            // The PK-Sim snapshot converter is registered explicitly per host (PKSimStarter for the
+            // desktop app/CLI, PKSimSnapshotConverter for MoBi.R), so it is not auto-registered here.
+            scan.ExcludeType<PKSimStarter>();
             scan.ExcludeNamespaceContainingType<IMoBiObjectConverter>();
             scan.ExcludeNamespaceContainingType<MoBiSimulationDiffBuilder>();
             scan.ExcludeNamespaceContainingType<ProjectMapper>();

--- a/src/MoBi.Core/Services/PKSimSnapshotConverterBase.cs
+++ b/src/MoBi.Core/Services/PKSimSnapshotConverterBase.cs
@@ -1,0 +1,107 @@
+﻿using MoBi.Core.Serialization.Xml.Services;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Qualification;
+
+namespace MoBi.Core.Services;
+
+public interface IPKSimSnapshotConverter
+{
+   Module LoadModuleFromSnapshot(string serializedSnapshot);
+   /// <summary>
+   ///    Recreates the PKSim module from the snapshot.
+   ///    If any of the PK-Sim building blocks should have markdown exported it will be done during the module rebuild.
+   /// </summary>
+   /// <param name="serializedSnapshot">The PK-Sim project snapshot</param>
+   /// <param name="qualificationConfiguration">
+   ///    The configuration containing any building block inputs that should have report
+   ///    markdown exported while the module is rebuilt in PK-Sim
+   /// </param>
+   /// <returns>A module and any input mappings that were exported</returns>
+   (Module module, InputMapping[] inputMappings) LoadModuleFromSnapshotAndExportInputs(string serializedSnapshot, QualificationConfiguration qualificationConfiguration);
+
+   /// <summary>
+   ///    Recreates a PK-Sim expression profile from the base64 encoded <paramref name="serializedSnapshot" />.
+   /// </summary>
+   /// <returns>The expression profile building block, as created in Pk-Sim</returns>
+   ExpressionProfileBuildingBlock LoadExpressionProfileFromSnapshot(string serializedSnapshot);
+
+   /// <summary>
+   ///    Recreates a PK-Sim individual from the base64 encoded <paramref name="serializedSnapshot" />.
+   /// </summary>
+   /// <returns>The individual building block, as created in Pk-Sim</returns>
+   IndividualBuildingBlock LoadIndividualFromSnapshot(string serializedSnapshot);
+}
+
+/// <summary>
+///    Shared implementation of the PK-Sim snapshot exchange. All exchanges are performed by
+///    reflecting into a PK-Sim assembly via <see cref="IPKSimAssemblyLoader" /> and recreating the
+///    returned objects in MoBi through serialization. Concrete subclasses differ only in:
+///    <list type="bullet">
+///       <item>which assembly the loader is pointed at (initialized in their constructor), and</item>
+///       <item><see cref="SnapshotExchangeType" /> - the fully-qualified name of the snapshot-exchange
+///       type that exposes the <c>Create...</c> methods.</item>
+///    </list>
+///    The desktop app uses <c>PKSim.Starter.SnapshotExchange</c> (in PKSim.Starter.dll); MoBi.R uses
+///    <c>PKSim.R.Exchange.SnapshotExchange</c> (in the shippable PKSim.R.dll).
+/// </summary>
+public abstract class PKSimSnapshotConverterBase : IPKSimSnapshotConverter
+{
+   protected const string CREATE_MODULE = "CreateModule";
+   protected const string CREATE_MODULE_AND_EXPORT_INPUTS = "CreateModuleAndExportInputs";
+   protected const string CREATE_INDIVIDUAL_BUILDING_BLOCK = "CreateIndividualBuildingBlock";
+   protected const string CREATE_EXPRESSION_PROFILE_BUILDING_BLOCK = "CreateExpressionProfileBuildingBlock";
+
+   protected readonly IPKSimAssemblyLoader _pkSimLoader;
+   private readonly IXmlSerializationService _serializationService;
+   private readonly IMoBiProjectRetriever _projectRetriever;
+
+   protected PKSimSnapshotConverterBase(IPKSimAssemblyLoader pkSimLoader, IXmlSerializationService serializationService, IMoBiProjectRetriever projectRetriever)
+   {
+      _pkSimLoader = pkSimLoader;
+      _serializationService = serializationService;
+      _projectRetriever = projectRetriever;
+   }
+
+   /// <summary>
+   ///    Fully-qualified name of the PK-Sim type exposing the <c>Create...</c> exchange methods
+   ///    (e.g. <c>PKSim.Starter.SnapshotExchange</c> or <c>PKSim.R.Exchange.SnapshotExchange</c>).
+   /// </summary>
+   protected abstract string SnapshotExchangeType { get; }
+
+   public Module LoadModuleFromSnapshot(string serializedSnapshot)
+   {
+      var element = _pkSimLoader.ExecuteMethod(SnapshotExchangeType, CREATE_MODULE, [serializedSnapshot]) as string;
+
+      // all object exchanges should be done using serialization to ensure that objects are recreated in MoBi.
+      return _serializationService.Deserialize<Module>(element, _projectRetriever.Current);
+   }
+
+   public (Module module, InputMapping[] inputMappings) LoadModuleFromSnapshotAndExportInputs(string serializedSnapshot, QualificationConfiguration qualificationConfiguration)
+   {
+      var tuple = _pkSimLoader.ExecuteMethod(SnapshotExchangeType, CREATE_MODULE_AND_EXPORT_INPUTS, [serializedSnapshot, qualificationConfiguration]);
+
+      var (element, mappings) = tuple as (string element, InputMapping[] mappings)? ?? (null, null);
+
+      // all object exchanges should be done using serialization to ensure that objects are recreated in MoBi.
+      var module = _serializationService.Deserialize<Module>(element, _projectRetriever.Current);
+
+      return (module, mappings);
+   }
+
+   public ExpressionProfileBuildingBlock LoadExpressionProfileFromSnapshot(string serializedSnapshot)
+   {
+      var pkml = _pkSimLoader.ExecuteMethod(SnapshotExchangeType, CREATE_EXPRESSION_PROFILE_BUILDING_BLOCK, [serializedSnapshot]) as string;
+
+      // all object exchanges should be done using serialization to ensure that objects are recreated in MoBi.
+      return _serializationService.Deserialize<ExpressionProfileBuildingBlock>(pkml, _projectRetriever.Current);
+   }
+
+   public IndividualBuildingBlock LoadIndividualFromSnapshot(string serializedSnapshot)
+   {
+      var pkml = _pkSimLoader.ExecuteMethod(SnapshotExchangeType, CREATE_INDIVIDUAL_BUILDING_BLOCK, [serializedSnapshot]) as string;
+
+      // all object exchanges should be done using serialization to ensure that objects are recreated in MoBi.
+      return _serializationService.Deserialize<IndividualBuildingBlock>(pkml, _projectRetriever.Current);
+   }
+}

--- a/src/MoBi.Core/Services/PKSimStarter.cs
+++ b/src/MoBi.Core/Services/PKSimStarter.cs
@@ -1,63 +1,36 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using MoBi.Assets;
 using MoBi.Core.Exceptions;
 using MoBi.Core.Serialization.Xml.Services;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
-using OSPSuite.Core.Qualification;
 using OSPSuite.Core.Services;
 using OSPSuite.Utility;
 using OSPSuite.Utility.Extensions;
-using Module = OSPSuite.Core.Domain.Module;
 
 namespace MoBi.Core.Services
 {
-   public interface IPKSimStarter
+   public interface IPKSimStarter : IPKSimSnapshotConverter
    {
       void StartPopulationSimulationWithSimulationFile(string simulationFilePath);
       void StartWithWorkingJournalFile(string journalFilePath);
       IBuildingBlock CreateProfileExpression(ExpressionType expressionType);
       IBuildingBlock CreateIndividual();
       IReadOnlyList<ExpressionParameterValueUpdate> UpdateExpressionProfileFromDatabase(ExpressionProfileBuildingBlock expressionProfile);
-      Module LoadModuleFromSnapshot(string serializedSnapshot);
-
-      /// <summary>
-      ///    Recreates the PKSim module from the snapshot.
-      ///    If any of the PK-Sim building blocks should have markdown exported it will be done during the module rebuild.
-      /// </summary>
-      /// <param name="serializedSnapshot">The PK-Sim project snapshot</param>
-      /// <param name="qualificationConfiguration">
-      ///    The configuration containing any building block inputs that should have report
-      ///    markdown exported while the module is rebuilt in PK-Sim
-      /// </param>
-      /// <returns>A module and any input mappings that were exported</returns>
-      (Module module, InputMapping[] inputMappings) LoadModuleFromSnapshotAndExportInputs(string serializedSnapshot, QualificationConfiguration qualificationConfiguration);
-
-      /// <summary>
-      ///    Recreates a PK-Sim expression profile from the base64 encoded <paramref name="serializedSnapshot" />.
-      /// </summary>
-      /// <returns>The expression profile building block, as created in Pk-Sim</returns>
-      ExpressionProfileBuildingBlock LoadExpressionProfileFromSnapshot(string serializedSnapshot);
-
-      /// <summary>
-      ///    Recreates a PK-Sim individual from the base64 encoded <paramref name="serializedSnapshot" />.
-      /// </summary>
-      /// <returns>The individual building block, as created in Pk-Sim</returns>
-      IndividualBuildingBlock LoadIndividualFromSnapshot(string serializedSnapshot);
    }
 
-   public class PKSimStarter : IPKSimStarter
+   /// <summary>
+   ///    Desktop PK-Sim integration. In addition to the snapshot exchange (reflecting into
+   ///    <c>PKSim.Starter.SnapshotExchange</c> in the installed PK-Sim's PKSim.Starter.dll) it can launch
+   ///    the PK-Sim executable and create building blocks through the PK-Sim UI starter.
+   /// </summary>
+   public class PKSimStarter : PKSimSnapshotConverterBase, IPKSimStarter
    {
       private const string CREATE_INDIVIDUAL_ENZYME_EXPRESSION_PROFILE = "CreateIndividualEnzymeExpressionProfile";
       private const string CREATE_BINDING_PARTNER_EXPRESSION_PROFILE = "CreateBindingPartnerExpressionProfile";
       private const string CREATE_TRANSPORTER_EXPRESSION_PROFILE = "CreateTransporterExpressionProfile";
       private const string CREATE_INDIVIDUAL = "CreateIndividual";
-      private const string CREATE_MODULE = "CreateModule";
-      private const string CREATE_MODULE_AND_EXPORT_INPUTS = "CreateModuleAndExportInputs";
-      private const string CREATE_INDIVIDUAL_BUILDING_BLOCK = "CreateIndividualBuildingBlock";
-      private const string CREATE_EXPRESSION_PROFILE_BUILDING_BLOCK = "CreateExpressionProfileBuildingBlock";
       private const string GET_EXPRESSION_DATABASE_QUERY = "GetExpressionDatabaseQuery";
       private const string PKSIM_UI_STARTER_EXPRESSION_PROFILE_CREATOR = "PKSim.Starter.ExpressionProfileCreator";
       private const string PKSIM_UI_STARTER_INDIVIDUAL_CREATOR = "PKSim.Starter.IndividualCreator";
@@ -68,9 +41,6 @@ namespace MoBi.Core.Services
       private readonly IApplicationSettings _applicationSettings;
       private readonly IStartableProcessFactory _startableProcessFactory;
       private readonly ICloneManagerForBuildingBlock _cloneManager;
-      private readonly IMoBiProjectRetriever _projectRetriever;
-      private readonly IXmlSerializationService _serializationService;
-      private readonly IPKSimAssemblyLoader _pkSimLoader;
 
       public PKSimStarter(IMoBiConfiguration configuration,
          IApplicationSettings applicationSettings,
@@ -79,16 +49,16 @@ namespace MoBi.Core.Services
          IXmlSerializationService serializationService,
          IMoBiProjectRetriever projectRetriever,
          IPKSimAssemblyLoader pkSimLoader)
+         : base(pkSimLoader, serializationService, projectRetriever)
       {
          _configuration = configuration;
          _applicationSettings = applicationSettings;
          _startableProcessFactory = startableProcessFactory;
          _cloneManager = cloneManager;
-         _serializationService = serializationService;
-         _projectRetriever = projectRetriever;
-         _pkSimLoader = pkSimLoader;
          _pkSimLoader.InitializePath(retrievePKSimAssemblyPath());
       }
+
+      protected override string SnapshotExchangeType => PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE;
 
       public void StartPopulationSimulationWithSimulationFile(string simulationFilePath)
       {
@@ -138,42 +108,6 @@ namespace MoBi.Core.Services
          return _pkSimLoader.ExecuteMethod(PKSIM_UI_STARTER_EXPRESSION_PROFILE_CREATOR, GET_EXPRESSION_DATABASE_QUERY, [expressionProfile]) as List<ExpressionParameterValueUpdate>;
       }
 
-      public Module LoadModuleFromSnapshot(string serializedSnapshot)
-      {
-         var element = _pkSimLoader.ExecuteMethod(PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE, CREATE_MODULE, [serializedSnapshot]) as string;
-
-         // all object exchanges should be done using serialization to ensure that objects are recreated in MoBi.
-         return _serializationService.Deserialize<Module>(element, _projectRetriever.Current);
-      }
-
-      public (Module module, InputMapping[] inputMappings) LoadModuleFromSnapshotAndExportInputs(string serializedSnapshot, QualificationConfiguration qualificationConfiguration)
-      {
-         var tuple = _pkSimLoader.ExecuteMethod(PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE, CREATE_MODULE_AND_EXPORT_INPUTS, [serializedSnapshot, qualificationConfiguration]);
-
-         var (element, mappings) = tuple as (string element, InputMapping[] mappings)? ?? (null, null);
-
-         // all object exchanges should be done using serialization to ensure that objects are recreated in MoBi.
-         var module = _serializationService.Deserialize<Module>(element, _projectRetriever.Current);
-
-         return (module, mappings);
-      }
-
-      public ExpressionProfileBuildingBlock LoadExpressionProfileFromSnapshot(string serializedSnapshot)
-      {
-         var pkml = _pkSimLoader.ExecuteMethod(PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE, CREATE_EXPRESSION_PROFILE_BUILDING_BLOCK, [serializedSnapshot]) as string;
-
-         // all object exchanges should be done using serialization to ensure that objects are recreated in MoBi.
-         return _serializationService.Deserialize<ExpressionProfileBuildingBlock>(pkml, _projectRetriever.Current);
-      }
-
-      public IndividualBuildingBlock LoadIndividualFromSnapshot(string serializedSnapshot)
-      {
-         var pkml = _pkSimLoader.ExecuteMethod(PKSIM_UI_STARTER_SNAPSHOT_EXCHANGE, CREATE_INDIVIDUAL_BUILDING_BLOCK, [serializedSnapshot]) as string;
-
-         // all object exchanges should be done using serialization to ensure that objects are recreated in MoBi.
-         return _serializationService.Deserialize<IndividualBuildingBlock>(pkml, _projectRetriever.Current);
-      }
-
       private void startPKSimWithFile(string filePathToStart, string option)
       {
          var pkSimPath = retrievePKSimExecutablePath();
@@ -198,7 +132,7 @@ namespace MoBi.Core.Services
       {
          var prioritizedPath = prioritizedPKSimPath();
 
-         if(!FileHelper.FileExists(prioritizedPath))
+         if (!FileHelper.FileExists(prioritizedPath))
             throw new MoBiException(AppConstants.PKSim.NotInstalled);
 
          return prioritizedPath;

--- a/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
+++ b/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
@@ -28,7 +28,7 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
 {
    private readonly IXmlSerializationService _xmlSerializationService;
    private readonly SimulationMapper _simulationMapper;
-   private readonly IPKSimStarter _pkSimStarter;
+   private readonly IPKSimSnapshotConverter _pkSimSnapshotConverter;
    private readonly ISimulationSettingsFactory _simulationSettingsFactory;
    private readonly ICoreSimulationRunner _simulationRunner;
    private readonly ICoreUserSettings _userSettings;
@@ -41,7 +41,7 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
       IOSPSuiteLogger logger,
       ParameterIdentificationMapper parameterIdentificationMapper,
       SimulationMapper simulationMapper,
-      IPKSimStarter pkSimStarter,
+      IPKSimSnapshotConverter pkSimSnapshotConverter,
       ISimulationSettingsFactory simulationSettingsFactory,
       ICoreSimulationRunner simulationRunner,
       ICoreUserSettings userSettings,
@@ -49,7 +49,7 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
    {
       _xmlSerializationService = xmlSerializationService;
       _simulationMapper = simulationMapper;
-      _pkSimStarter = pkSimStarter;
+      _pkSimSnapshotConverter = pkSimSnapshotConverter;
       _simulationSettingsFactory = simulationSettingsFactory;
       _simulationRunner = simulationRunner;
       _userSettings = userSettings;
@@ -154,14 +154,14 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
 
    private ExpressionProfileBuildingBlock loadExpressionProfileFromSnapshotAndUpdateValues(ExpressionProfileSnapshot expressionProfileSnapshot, ModelProject project)
    {
-      var buildingBlock = _pkSimStarter.LoadExpressionProfileFromSnapshot(pkSimSnapshotToBase64String(expressionProfileSnapshot.PKSimSnapshot));
+      var buildingBlock = _pkSimSnapshotConverter.LoadExpressionProfileFromSnapshot(pkSimSnapshotToBase64String(expressionProfileSnapshot.PKSimSnapshot));
       expressionProfileSnapshot.UpdatedValues?.Each(x => _parameterValueUpdateManager.UpdateParameterValueIn<ExpressionProfileBuildingBlock, ExpressionParameter>(buildingBlock, x, formulaCacheFrom(expressionProfileSnapshot, project)));
       return buildingBlock;
    }
 
    private IndividualBuildingBlock loadIndividualFromSnapshotAndUpdateValues(IndividualSnapshot individualSnapshot, ModelProject project)
    {
-      var buildingBlock = _pkSimStarter.LoadIndividualFromSnapshot(pkSimSnapshotToBase64String(individualSnapshot.PKSimSnapshot));
+      var buildingBlock = _pkSimSnapshotConverter.LoadIndividualFromSnapshot(pkSimSnapshotToBase64String(individualSnapshot.PKSimSnapshot));
       individualSnapshot.UpdatedValues?.Each(x => _parameterValueUpdateManager.UpdateParameterValueIn<IndividualBuildingBlock, IndividualParameter>(buildingBlock, x, formulaCacheFrom(individualSnapshot, project)));
       return buildingBlock;
    }
@@ -204,7 +204,7 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
 
    private void loadModulesFromPKSimSnapshot(string snapshot, ModelProject project)
    {
-      var module = _pkSimStarter.LoadModuleFromSnapshot(snapshot);
+      var module = _pkSimSnapshotConverter.LoadModuleFromSnapshot(snapshot);
 
       loadModuleToProject(project, module);
    }
@@ -216,7 +216,7 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
 
    private InputMapping[] loadModulesAndExportInputsFromPKSimSnapshot(string snapshot, ModelProject project, QualificationConfiguration config)
    {
-      var (module, inputMappings) = _pkSimStarter.LoadModuleFromSnapshotAndExportInputs(snapshot, config);
+      var (module, inputMappings) = _pkSimSnapshotConverter.LoadModuleFromSnapshotAndExportInputs(snapshot, config);
 
       loadModuleToProject(project, module);
 

--- a/src/MoBi.Presentation/PresentationRegister.cs
+++ b/src/MoBi.Presentation/PresentationRegister.cs
@@ -90,7 +90,7 @@ namespace MoBi.Presentation
             scan.WithConvention<OSPSuiteRegistrationConvention>();
          });
 
-         container.Register<IPKSimStarter, PKSimStarter>(LifeStyle.Singleton);
+         container.Register<IPKSimStarter, IPKSimSnapshotConverter, PKSimStarter>(LifeStyle.Singleton);
          container.Register<IMenuBarItemRepository, MenuBarItemRepository>(LifeStyle.Singleton);
          container.Register<ISimulationRunner, SimulationRunner>(LifeStyle.Singleton);
          container.Register<IMoBiApplicationController, IApplicationController, MoBiApplicationController>(LifeStyle.Singleton);

--- a/src/MoBi.R/RRegister.cs
+++ b/src/MoBi.R/RRegister.cs
@@ -33,8 +33,13 @@ namespace MoBi.R
          {
             scan.AssemblyContainingType<RRegister>();
             scan.IncludeNamespaceContainingType<IModuleTask>();
+            // Registered explicitly below so MoBi.R uses the headless PK-Sim snapshot converter.
+            scan.ExcludeType<PKSimSnapshotConverter>();
             scan.WithConvention<OSPSuiteRegistrationConvention>();
          });
+
+         // Headless snapshot conversion via PKSim.R.dll (no PK-Sim desktop install / PKSim.Starter.dll).
+         container.Register<IPKSimSnapshotConverter, PKSimSnapshotConverter>(LifeStyle.Singleton);
 
          registerMinimalTypes(container);
       }

--- a/src/MoBi.R/Services/PKSimSnapshotConverter.cs
+++ b/src/MoBi.R/Services/PKSimSnapshotConverter.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using System.Reflection;
+using MoBi.Core.Serialization.Xml.Services;
+using MoBi.Core.Services;
+
+namespace MoBi.R.Services
+{
+   /// <summary>
+   ///    Headless PK-Sim snapshot converter used by MoBi.R. It reflects into
+   ///    <c>PKSim.R.Exchange.SnapshotExchange</c> shipped in the co-located <c>PKSim.R.dll</c>, so it
+   ///    works without a PK-Sim desktop installation and without the UI/Presentation assemblies that
+   ///    <c>PKSim.Starter.dll</c> depends on.
+   /// </summary>
+   public class PKSimSnapshotConverter : PKSimSnapshotConverterBase
+   {
+      private const string PKSIM_R_DLL = "PKSim.R.dll";
+      private const string PKSIM_R_SNAPSHOT_EXCHANGE = "PKSim.R.Exchange.SnapshotExchange";
+
+      public PKSimSnapshotConverter(IXmlSerializationService serializationService, IMoBiProjectRetriever projectRetriever, IPKSimAssemblyLoader pkSimLoader)
+         : base(pkSimLoader, serializationService, projectRetriever)
+      {
+         _pkSimLoader.InitializePath(pkSimAssemblyPath());
+      }
+
+      protected override string SnapshotExchangeType => PKSIM_R_SNAPSHOT_EXCHANGE;
+
+      // PKSim.R.dll is shipped next to the MoBi.R assembly (e.g. the R package's inst/lib folder).
+      private static string pkSimAssemblyPath() =>
+         Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty, PKSIM_R_DLL);
+   }
+}

--- a/src/MoBi.R/Services/SnapshotTask.cs
+++ b/src/MoBi.R/Services/SnapshotTask.cs
@@ -40,7 +40,7 @@ namespace MoBi.R.Services
 
       public MoBiSimulation[] LoadSimulationsFromSnapshot(string snapshotFile, params string[] simulationNames)
       {
-         var project = _snapshotTask.LoadProjectFromSnapshotFileAsync(snapshotFile).GetAwaiter().GetResult();
+         var project = _snapshotTask.LoadProjectFromSnapshotFileAsync(snapshotFile, runSimulations: false).GetAwaiter().GetResult();
          if (project == null)
             return Array.Empty<MoBiSimulation>();
 

--- a/tests/MoBi.Tests/IntegrationTests/ContextForIntegration.cs
+++ b/tests/MoBi.Tests/IntegrationTests/ContextForIntegration.cs
@@ -85,7 +85,9 @@ namespace MoBi.IntegrationTests
             container.RegisterImplementationOf(A.Fake<ILayerLayouter>());
             container.RegisterImplementationOf(A.Fake<IEntityValidationTask>());
             container.RegisterImplementationOf(A.Fake<IDiagramLayoutTask>());
-            container.RegisterImplementationOf(A.Fake<IPKSimStarter>());
+            var pkSimStarter = A.Fake<IPKSimStarter>();
+            container.RegisterImplementationOf(pkSimStarter);
+            container.RegisterImplementationOf<IPKSimSnapshotConverter>(pkSimStarter);
 
             container.Register<IDiagramModelToXmlMapper, DiagramModelToXmlMapperForSpecs>();
             container.Register<IMoBiConfiguration, MoBiConfiguration>(LifeStyle.Singleton);

--- a/tests/MoBi.Tests/TestFiles/snapshot.json
+++ b/tests/MoBi.Tests/TestFiles/snapshot.json
@@ -4,6 +4,38 @@
     {
       "Name": "Henrist oral Hot stage extrusion as table",
       "Version": 81,
+      "ExpressionProfiles": [
+        {
+          "Type": "Enzyme",
+          "Species": "Human",
+          "Molecule": "CYP3A4",
+          "Category": "Healthy",
+          "Parameters": [
+            {
+              "Path": "CYP3A4|Reference concentration",
+              "Value": 4.32,
+              "Unit": "µmol/l",
+              "ValueOrigin": {}
+            },
+            {
+              "Path": "CYP3A4|t1/2 (intestine)",
+              "Value": 1380.0,
+              "Unit": "min",
+              "ValueOrigin": {}
+            },
+            {
+              "Path": "CYP3A4|t1/2 (liver)",
+              "Value": 2220.0,
+              "Unit": "min",
+              "ValueOrigin": {}
+            }
+          ],
+          "Localization": "Intracellular",
+          "Ontogeny": {
+            "Name": "CYP3A4"
+          }
+        }
+      ],
       "Individuals": [
         {
           "Name": "Man",
@@ -21,7 +53,9 @@
               "Unit": "year(s)"
             }
           },
-          "ExpressionProfiles": []
+          "ExpressionProfiles": [
+            "CYP3A4|Human|Healthy"
+          ]
         }
       ],
       "Compounds": [
@@ -315,6 +349,9 @@
                 "Cellular permeability - PK-Sim Standard"
               ],
               "Processes": [
+                {
+                  "MoleculeName": "CYP3A4"
+                },
                 {
                   "Name": "Glomerular Filtration-GFR",
                   "SystemicProcessType": "GFR"
@@ -1226,9 +1263,35 @@
       ]
     }
   ],
-  "ExtensionModules": [],
+  "ExtensionModules": [
+    "PE1vZHVsZSBpZD0iay1PWWxZX0hnMGFYUDN4RjJGT0V6ZyIgbmFtZT0idGVzdCIgaWNvbj0iTW9kdWxlIiBtb2R1bGVJbXBvcnRWZXJzaW9uPSI1OTQ0MzM2ODciIG1lcmdlQmVoYXZpb3I9IkV4dGVuZCIgaXNQS1NpbU1vZHVsZT0iMCIgdmVyc2lvbj0iMTkiPjxTbmFwc2hvdD48L1NuYXBzaG90PjwvTW9kdWxlPg=="
+  ],
   "ExpressionProfileBuildingBlocks": [],
   "IndividualBuildingBlocks": [],
+  "ObservedDataClassifications": [
+    {
+      "Name": "observed data folder",
+      "Classifiables": [
+        "Hot stage extrusion"
+      ]
+    }
+  ],
+  "ParameterIdentificationClassifications": [
+    {
+      "Name": "pi folder",
+      "Classifiables": [
+        "Parameter Identification 1"
+      ]
+    }
+  ],
+  "ModuleClassifications": [
+    {
+      "Name": "module folder",
+      "Classifiables": [
+        "test"
+      ]
+    }
+  ],
   "ObservedData": [
     {
       "Name": "Hot stage extrusion",
@@ -1325,797 +1388,56 @@
         "Dimension": "Time",
         "Unit": "h"
       }
-    },
+    }
+  ],
+  "ParameterIdentifications": [
     {
-      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 1",
-      "ExtendedProperties": [
-        {
-          "Name": "Source",
-          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "File",
-          "Value": "Data",
-          "Type": "String"
-        },
-        {
-          "Name": "Sheet",
-          "Value": "Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "Molecule",
-          "Value": "Theophylline",
-          "Type": "String"
-        },
-        {
-          "Name": "Species",
-          "Value": "Human",
-          "Type": "String"
-        },
-        {
-          "Name": "Organ",
-          "Value": "Peripheral Venous Blood",
-          "Type": "String"
-        },
-        {
-          "Name": "Compartment",
-          "Value": "Plasma",
-          "Type": "String"
-        },
-        {
-          "Name": "Study Id",
-          "Value": "Henrist 1999",
-          "Type": "String"
-        },
-        {
-          "Name": "Dose",
-          "Value": "300 mg",
-          "Type": "String"
-        },
-        {
-          "Name": "Route",
-          "Value": "Hot stage extrusion oral",
-          "Type": "String"
-        },
-        {
-          "Name": "Patient Id",
-          "Value": "Subj 1",
-          "Type": "String"
+      "Name": "Parameter Identification 1",
+      "Simulations": [],
+      "Configuration": {
+        "LLOQMode": "SimulationOutputAsObservedDataLLOQ",
+        "RemoveLLOQMode": "Never",
+        "CalculateJacobian": false,
+        "Algorithm": {
+          "Name": "Levenberg - Marquardt (MPFit)",
+          "Properties": [
+            {
+              "Name": "ftol",
+              "Value": 0.001,
+              "Type": "Double"
+            },
+            {
+              "Name": "xtol",
+              "Value": 1E-06,
+              "Type": "Double"
+            },
+            {
+              "Name": "gtol",
+              "Value": 1E-10,
+              "Type": "Double"
+            },
+            {
+              "Name": "stepfactor",
+              "Value": 100.0,
+              "Type": "Double"
+            },
+            {
+              "Name": "maxiter",
+              "Value": 200,
+              "Type": "Integer"
+            },
+            {
+              "Name": "maxfev",
+              "Value": 0,
+              "Type": "Integer"
+            },
+            {
+              "Name": "epsfcn",
+              "Value": 1E-09,
+              "Type": "Double"
+            }
+          ]
         }
-      ],
-      "Columns": [
-        {
-          "Name": "conc ",
-          "QuantityInfo": {
-            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 1|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc "
-          },
-          "DataInfo": {
-            "Origin": "Observation",
-            "AuxiliaryType": "Undefined",
-            "MolWeight": 180.17
-          },
-          "Values": [
-            1.762712,
-            2.59887,
-            3.8870063,
-            4.745763,
-            6.666667,
-            7.073446,
-            6.305085,
-            5.378531,
-            4.79096,
-            4.248588,
-            2.621469
-          ],
-          "Dimension": "Concentration (mass)",
-          "Unit": "mg/l"
-        }
-      ],
-      "BaseGrid": {
-        "Name": "Time ",
-        "QuantityInfo": {
-          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 1|Time ",
-          "Type": "Time"
-        },
-        "DataInfo": {
-          "Origin": "BaseGrid",
-          "AuxiliaryType": "Undefined"
-        },
-        "Values": [
-          1.0,
-          2.0,
-          3.0,
-          4.0,
-          5.0,
-          6.0,
-          8.0,
-          10.0,
-          12.0,
-          14.0,
-          24.0
-        ],
-        "Dimension": "Time",
-        "Unit": "h"
-      }
-    },
-    {
-      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 2",
-      "ExtendedProperties": [
-        {
-          "Name": "Source",
-          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "File",
-          "Value": "Data",
-          "Type": "String"
-        },
-        {
-          "Name": "Sheet",
-          "Value": "Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "Molecule",
-          "Value": "Theophylline",
-          "Type": "String"
-        },
-        {
-          "Name": "Species",
-          "Value": "Human",
-          "Type": "String"
-        },
-        {
-          "Name": "Organ",
-          "Value": "Peripheral Venous Blood",
-          "Type": "String"
-        },
-        {
-          "Name": "Compartment",
-          "Value": "Plasma",
-          "Type": "String"
-        },
-        {
-          "Name": "Study Id",
-          "Value": "Henrist 1999",
-          "Type": "String"
-        },
-        {
-          "Name": "Dose",
-          "Value": "300 mg",
-          "Type": "String"
-        },
-        {
-          "Name": "Route",
-          "Value": "Hot stage extrusion oral",
-          "Type": "String"
-        },
-        {
-          "Name": "Patient Id",
-          "Value": "Subj 2",
-          "Type": "String"
-        }
-      ],
-      "Columns": [
-        {
-          "Name": "conc (1)",
-          "QuantityInfo": {
-            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 2|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (1)"
-          },
-          "DataInfo": {
-            "Origin": "Observation",
-            "AuxiliaryType": "Undefined",
-            "MolWeight": 180.17
-          },
-          "Values": [
-            0.38418078,
-            1.514124,
-            3.502825,
-            4.81356,
-            6.711864,
-            6.711864,
-            6.282486,
-            5.468926,
-            4.4971747,
-            4.022599,
-            1.9435031
-          ],
-          "Dimension": "Concentration (mass)",
-          "Unit": "mg/l"
-        }
-      ],
-      "BaseGrid": {
-        "Name": "Time ",
-        "QuantityInfo": {
-          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 2|Time ",
-          "Type": "Time"
-        },
-        "DataInfo": {
-          "Origin": "BaseGrid",
-          "AuxiliaryType": "Undefined"
-        },
-        "Values": [
-          1.0,
-          2.0,
-          3.0,
-          4.0,
-          5.0,
-          6.0,
-          8.0,
-          10.0,
-          12.0,
-          14.0,
-          24.0
-        ],
-        "Dimension": "Time",
-        "Unit": "h"
-      }
-    },
-    {
-      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 3",
-      "ExtendedProperties": [
-        {
-          "Name": "Source",
-          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "File",
-          "Value": "Data",
-          "Type": "String"
-        },
-        {
-          "Name": "Sheet",
-          "Value": "Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "Molecule",
-          "Value": "Theophylline",
-          "Type": "String"
-        },
-        {
-          "Name": "Species",
-          "Value": "Human",
-          "Type": "String"
-        },
-        {
-          "Name": "Organ",
-          "Value": "Peripheral Venous Blood",
-          "Type": "String"
-        },
-        {
-          "Name": "Compartment",
-          "Value": "Plasma",
-          "Type": "String"
-        },
-        {
-          "Name": "Study Id",
-          "Value": "Henrist 1999",
-          "Type": "String"
-        },
-        {
-          "Name": "Dose",
-          "Value": "300 mg",
-          "Type": "String"
-        },
-        {
-          "Name": "Route",
-          "Value": "Hot stage extrusion oral",
-          "Type": "String"
-        },
-        {
-          "Name": "Patient Id",
-          "Value": "Subj 3",
-          "Type": "String"
-        }
-      ],
-      "Columns": [
-        {
-          "Name": "conc (2)",
-          "QuantityInfo": {
-            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 3|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (2)"
-          },
-          "DataInfo": {
-            "Origin": "Observation",
-            "AuxiliaryType": "Undefined",
-            "MolWeight": 180.17
-          },
-          "Values": [
-            2.124294,
-            4.429379,
-            5.853107,
-            6.870057,
-            7.322034,
-            6.644068,
-            5.672317,
-            4.926554,
-            4.2033896,
-            3.59322,
-            1.694915
-          ],
-          "Dimension": "Concentration (mass)",
-          "Unit": "mg/l"
-        }
-      ],
-      "BaseGrid": {
-        "Name": "Time ",
-        "QuantityInfo": {
-          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 3|Time ",
-          "Type": "Time"
-        },
-        "DataInfo": {
-          "Origin": "BaseGrid",
-          "AuxiliaryType": "Undefined"
-        },
-        "Values": [
-          1.0,
-          2.0,
-          3.0,
-          4.0,
-          5.0,
-          6.0,
-          8.0,
-          10.0,
-          12.0,
-          14.0,
-          24.0
-        ],
-        "Dimension": "Time",
-        "Unit": "h"
-      }
-    },
-    {
-      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 4",
-      "ExtendedProperties": [
-        {
-          "Name": "Source",
-          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "File",
-          "Value": "Data",
-          "Type": "String"
-        },
-        {
-          "Name": "Sheet",
-          "Value": "Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "Molecule",
-          "Value": "Theophylline",
-          "Type": "String"
-        },
-        {
-          "Name": "Species",
-          "Value": "Human",
-          "Type": "String"
-        },
-        {
-          "Name": "Organ",
-          "Value": "Peripheral Venous Blood",
-          "Type": "String"
-        },
-        {
-          "Name": "Compartment",
-          "Value": "Plasma",
-          "Type": "String"
-        },
-        {
-          "Name": "Study Id",
-          "Value": "Henrist 1999",
-          "Type": "String"
-        },
-        {
-          "Name": "Dose",
-          "Value": "300 mg",
-          "Type": "String"
-        },
-        {
-          "Name": "Route",
-          "Value": "Hot stage extrusion oral",
-          "Type": "String"
-        },
-        {
-          "Name": "Patient Id",
-          "Value": "Subj 4",
-          "Type": "String"
-        }
-      ],
-      "Columns": [
-        {
-          "Name": "conc (3)",
-          "QuantityInfo": {
-            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 4|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (3)"
-          },
-          "DataInfo": {
-            "Origin": "Observation",
-            "AuxiliaryType": "Undefined",
-            "MolWeight": 180.17
-          },
-          "Values": [
-            2.508475,
-            4.0677967,
-            5.920904,
-            6.6892657,
-            6.531074,
-            6.033898,
-            4.745763,
-            3.9774008,
-            3.0056498,
-            1.19774
-          ],
-          "Dimension": "Concentration (mass)",
-          "Unit": "mg/l"
-        }
-      ],
-      "BaseGrid": {
-        "Name": "Time ",
-        "QuantityInfo": {
-          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 4|Time ",
-          "Type": "Time"
-        },
-        "DataInfo": {
-          "Origin": "BaseGrid",
-          "AuxiliaryType": "Undefined"
-        },
-        "Values": [
-          1.0,
-          2.0,
-          3.0,
-          4.0,
-          5.0,
-          6.0,
-          8.0,
-          10.0,
-          12.0,
-          24.0
-        ],
-        "Dimension": "Time",
-        "Unit": "h"
-      }
-    },
-    {
-      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 5",
-      "ExtendedProperties": [
-        {
-          "Name": "Source",
-          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "File",
-          "Value": "Data",
-          "Type": "String"
-        },
-        {
-          "Name": "Sheet",
-          "Value": "Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "Molecule",
-          "Value": "Theophylline",
-          "Type": "String"
-        },
-        {
-          "Name": "Species",
-          "Value": "Human",
-          "Type": "String"
-        },
-        {
-          "Name": "Organ",
-          "Value": "Peripheral Venous Blood",
-          "Type": "String"
-        },
-        {
-          "Name": "Compartment",
-          "Value": "Plasma",
-          "Type": "String"
-        },
-        {
-          "Name": "Study Id",
-          "Value": "Henrist 1999",
-          "Type": "String"
-        },
-        {
-          "Name": "Dose",
-          "Value": "300 mg",
-          "Type": "String"
-        },
-        {
-          "Name": "Route",
-          "Value": "Hot stage extrusion oral",
-          "Type": "String"
-        },
-        {
-          "Name": "Patient Id",
-          "Value": "Subj 5",
-          "Type": "String"
-        }
-      ],
-      "Columns": [
-        {
-          "Name": "conc (4)",
-          "QuantityInfo": {
-            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 5|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (4)"
-          },
-          "DataInfo": {
-            "Origin": "Observation",
-            "AuxiliaryType": "Undefined",
-            "MolWeight": 180.17
-          },
-          "Values": [
-            0.7457627,
-            1.966102,
-            3.706215,
-            3.096045,
-            5.0847464,
-            5.3559318,
-            4.3163843,
-            3.7740111,
-            3.050848,
-            1.107345
-          ],
-          "Dimension": "Concentration (mass)",
-          "Unit": "mg/l"
-        }
-      ],
-      "BaseGrid": {
-        "Name": "Time ",
-        "QuantityInfo": {
-          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 5|Time ",
-          "Type": "Time"
-        },
-        "DataInfo": {
-          "Origin": "BaseGrid",
-          "AuxiliaryType": "Undefined"
-        },
-        "Values": [
-          1.0,
-          2.0,
-          3.0,
-          4.0,
-          5.0,
-          6.0,
-          8.0,
-          10.0,
-          12.0,
-          24.0
-        ],
-        "Dimension": "Time",
-        "Unit": "h"
-      }
-    },
-    {
-      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 6",
-      "ExtendedProperties": [
-        {
-          "Name": "Source",
-          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "File",
-          "Value": "Data",
-          "Type": "String"
-        },
-        {
-          "Name": "Sheet",
-          "Value": "Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "Molecule",
-          "Value": "Theophylline",
-          "Type": "String"
-        },
-        {
-          "Name": "Species",
-          "Value": "Human",
-          "Type": "String"
-        },
-        {
-          "Name": "Organ",
-          "Value": "Peripheral Venous Blood",
-          "Type": "String"
-        },
-        {
-          "Name": "Compartment",
-          "Value": "Plasma",
-          "Type": "String"
-        },
-        {
-          "Name": "Study Id",
-          "Value": "Henrist 1999",
-          "Type": "String"
-        },
-        {
-          "Name": "Dose",
-          "Value": "300 mg",
-          "Type": "String"
-        },
-        {
-          "Name": "Route",
-          "Value": "Hot stage extrusion oral",
-          "Type": "String"
-        },
-        {
-          "Name": "Patient Id",
-          "Value": "Subj 6",
-          "Type": "String"
-        }
-      ],
-      "Columns": [
-        {
-          "Name": "conc (5)",
-          "QuantityInfo": {
-            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 6|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (5)"
-          },
-          "DataInfo": {
-            "Origin": "Observation",
-            "AuxiliaryType": "Undefined",
-            "MolWeight": 180.17
-          },
-          "Values": [
-            3.141243,
-            4.1807914,
-            5.7853107,
-            6.124294,
-            5.423729,
-            4.903955,
-            3.9548023,
-            3.3898308,
-            2.621469,
-            2.214689,
-            0.8813559
-          ],
-          "Dimension": "Concentration (mass)",
-          "Unit": "mg/l"
-        }
-      ],
-      "BaseGrid": {
-        "Name": "Time ",
-        "QuantityInfo": {
-          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 6|Time ",
-          "Type": "Time"
-        },
-        "DataInfo": {
-          "Origin": "BaseGrid",
-          "AuxiliaryType": "Undefined"
-        },
-        "Values": [
-          1.0,
-          2.0,
-          3.0,
-          4.0,
-          5.0,
-          6.0,
-          8.0,
-          10.0,
-          12.0,
-          14.0,
-          24.0
-        ],
-        "Dimension": "Time",
-        "Unit": "h"
-      }
-    },
-    {
-      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 7",
-      "ExtendedProperties": [
-        {
-          "Name": "Source",
-          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "File",
-          "Value": "Data",
-          "Type": "String"
-        },
-        {
-          "Name": "Sheet",
-          "Value": "Henrist1999 Exp 300mg ",
-          "Type": "String"
-        },
-        {
-          "Name": "Molecule",
-          "Value": "Theophylline",
-          "Type": "String"
-        },
-        {
-          "Name": "Species",
-          "Value": "Human",
-          "Type": "String"
-        },
-        {
-          "Name": "Organ",
-          "Value": "Peripheral Venous Blood",
-          "Type": "String"
-        },
-        {
-          "Name": "Compartment",
-          "Value": "Plasma",
-          "Type": "String"
-        },
-        {
-          "Name": "Study Id",
-          "Value": "Henrist 1999",
-          "Type": "String"
-        },
-        {
-          "Name": "Dose",
-          "Value": "300 mg",
-          "Type": "String"
-        },
-        {
-          "Name": "Route",
-          "Value": "Hot stage extrusion oral",
-          "Type": "String"
-        },
-        {
-          "Name": "Patient Id",
-          "Value": "Subj 7",
-          "Type": "String"
-        }
-      ],
-      "Columns": [
-        {
-          "Name": "conc (6)",
-          "QuantityInfo": {
-            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 7|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (6)"
-          },
-          "DataInfo": {
-            "Origin": "Observation",
-            "AuxiliaryType": "Undefined",
-            "MolWeight": 180.17
-          },
-          "Values": [
-            2.2824862,
-            3.9548023,
-            5.7853107,
-            6.101695,
-            5.242938,
-            3.7740111,
-            3.209039,
-            2.508475,
-            2.033898,
-            0.7457627
-          ],
-          "Dimension": "Concentration (mass)",
-          "Unit": "mg/l"
-        }
-      ],
-      "BaseGrid": {
-        "Name": "Time ",
-        "QuantityInfo": {
-          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 7|Time ",
-          "Type": "Time"
-        },
-        "DataInfo": {
-          "Origin": "BaseGrid",
-          "AuxiliaryType": "Undefined"
-        },
-        "Values": [
-          1.0,
-          2.0,
-          3.0,
-          4.0,
-          5.0,
-          8.0,
-          10.0,
-          12.0,
-          14.0,
-          24.0
-        ],
-        "Dimension": "Time",
-        "Unit": "h"
       }
     }
   ],
@@ -2155,10 +1477,12 @@
               ]
             }
           ],
-          "RandomSeed": 1261891593.0
+          "RandomSeed": 144540453.0
         },
         "IndividualBuildingBlock": "Man",
-        "ExpressionProfiles": [],
+        "ExpressionProfiles": [
+          "CYP3A4|Human|Healthy"
+        ],
         "ModuleConfigurations": [
           {
             "Module": "Henrist oral Hot stage extrusion as table",
@@ -2175,7 +1499,53 @@
     }
   ],
   "ReactionDimensionMode": "AmountBased",
-  "ExpressionProfileSnapshots": [],
+  "ExpressionProfileSnapshots": [
+    {
+      "PKSimSnapshot": {
+        "Type": "Enzyme",
+        "Species": "Human",
+        "Molecule": "CYP3A4",
+        "Category": "Healthy",
+        "Parameters": [
+          {
+            "Path": "CYP3A4|Reference concentration",
+            "Value": 4.32,
+            "Unit": "µmol/l",
+            "ValueOrigin": {}
+          },
+          {
+            "Path": "CYP3A4|t1/2 (intestine)",
+            "Value": 1380.0,
+            "Unit": "min",
+            "ValueOrigin": {}
+          },
+          {
+            "Path": "CYP3A4|t1/2 (liver)",
+            "Value": 2220.0,
+            "Unit": "min",
+            "ValueOrigin": {}
+          }
+        ],
+        "Localization": "Intracellular",
+        "Ontogeny": {
+          "Name": "CYP3A4"
+        }
+      },
+      "UpdatedValues": [
+        {
+          "Path": "Organism|VenousBlood|Plasma|CYP3A4|Initial concentration",
+          "NewUnit": "µmol/l",
+          "NewFormulaId": "ConcFormula"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|CYP3A4|Fraction expressed intracellular",
+          "NewValue": 0.9,
+          "NewUnit": ""
+        }
+      ],
+      "FormulaCache": "PEZvcm11bGFDYWNoZSB2ZXJzaW9uPSIxOSI+PEZvcm11bGFzPjxGb3JtdWxhIGlkPSJDb25jRm9ybXVsYSIgbmFtZT0iQ29uY0Zvcm11bGEiIGRpbT0iQ29uY2VudHJhdGlvbiAobW9sYXIpIiBmb3JtdWxhPSJWJmd0OzAgPyBNL1YgOiAwIj48UGF0aHM+PFBhdGggcGF0aD0iMCIgYXM9IjEiIGRpbT0iMiIgLz48UGF0aCBwYXRoPSIzIiBhcz0iNCIgZGltPSI1IiAvPjwvUGF0aHM+PC9Gb3JtdWxhPjwvRm9ybXVsYXM+PFN0cmluZ01hcD48TWFwIHM9Ii4uIiBpZD0iMCIgLz48TWFwIHM9Ik0iIGlkPSIxIiAvPjxNYXAgcz0iQW1vdW50IiBpZD0iMiIgLz48TWFwIHM9Ii4ufC4ufFZvbHVtZSIgaWQ9IjMiIC8+PE1hcCBzPSJWIiBpZD0iNCIgLz48TWFwIHM9IlZvbHVtZSIgaWQ9IjUiIC8+PC9TdHJpbmdNYXA+PC9Gb3JtdWxhQ2FjaGU+"
+    }
+  ],
   "IndividualBuildingBlockSnapshots": [
     {
       "PKSimSnapshot": {
@@ -2195,7 +1565,24 @@
           }
         }
       },
-      "UpdatedValues": []
+      "UpdatedValues": [
+        {
+          "Path": "Organism|Ontogeny factor (albumin)",
+          "NewUnit": "",
+          "NewFormulaId": "_SZxHCxS90OL8x2QoHgyWg"
+        },
+        {
+          "Path": "Organism|pH (blood cells)",
+          "NewValue": 7.0,
+          "NewUnit": ""
+        },
+        {
+          "Path": "Organism|Age",
+          "NewValue": 31.0,
+          "NewUnit": "year(s)"
+        }
+      ],
+      "FormulaCache": "PEZvcm11bGFDYWNoZSB2ZXJzaW9uPSIxOSI+PEZvcm11bGFzPjxUYWJsZUZvcm11bGFXaXRoWEFyZ3VtZW50IGlkPSJfU1p4SEN4UzkwT0w4eDJRb0hneVdnIiBuYW1lPSJDbG9uZWRUYWJsZUZvcm11bGFXaXRoWEFyZ3VtZW50X09udG9nZW55RmFjdG9yQWxidW1pbiIgdGFibGVPYmplY3RBbGlhcz0iVGFibGUiIHhBcmd1bWVudEFsaWFzPSJYQXJnIj48UGF0aHM+PFBhdGggcGF0aD0iMCIgYXM9IjEiIC8+PFBhdGggcGF0aD0iMiIgYXM9IjMiIGRpbT0iNCIgLz48L1BhdGhzPjwvVGFibGVGb3JtdWxhV2l0aFhBcmd1bWVudD48L0Zvcm11bGFzPjxTdHJpbmdNYXA+PE1hcCBzPSIuLnxPbnRvZ2VueSBmYWN0b3IgKGFsYnVtaW4pIHRhYmxlIiBpZD0iMCIgLz48TWFwIHM9IlRhYmxlIiBpZD0iMSIgLz48TWFwIHM9Ik9yZ2FuaXNtfFBvc3QgbWVuc3RydWFsIGFnZSIgaWQ9IjIiIC8+PE1hcCBzPSJYQXJnIiBpZD0iMyIgLz48TWFwIHM9IkFnZSBpbiB5ZWFycyIgaWQ9IjQiIC8+PC9TdHJpbmdNYXA+PC9Gb3JtdWxhQ2FjaGU+"
     }
   ]
 }

--- a/tests/MoBi.Tests/TestFiles/snapshot.json
+++ b/tests/MoBi.Tests/TestFiles/snapshot.json
@@ -4,38 +4,6 @@
     {
       "Name": "Henrist oral Hot stage extrusion as table",
       "Version": 81,
-      "ExpressionProfiles": [
-        {
-          "Type": "Enzyme",
-          "Species": "Human",
-          "Molecule": "CYP3A4",
-          "Category": "Healthy",
-          "Parameters": [
-            {
-              "Path": "CYP3A4|Reference concentration",
-              "Value": 4.32,
-              "Unit": "µmol/l",
-              "ValueOrigin": {}
-            },
-            {
-              "Path": "CYP3A4|t1/2 (intestine)",
-              "Value": 1380.0,
-              "Unit": "min",
-              "ValueOrigin": {}
-            },
-            {
-              "Path": "CYP3A4|t1/2 (liver)",
-              "Value": 2220.0,
-              "Unit": "min",
-              "ValueOrigin": {}
-            }
-          ],
-          "Localization": "Intracellular",
-          "Ontogeny": {
-            "Name": "CYP3A4"
-          }
-        }
-      ],
       "Individuals": [
         {
           "Name": "Man",
@@ -53,9 +21,7 @@
               "Unit": "year(s)"
             }
           },
-          "ExpressionProfiles": [
-            "CYP3A4|Human|Healthy"
-          ]
+          "ExpressionProfiles": []
         }
       ],
       "Compounds": [
@@ -349,9 +315,6 @@
                 "Cellular permeability - PK-Sim Standard"
               ],
               "Processes": [
-                {
-                  "MoleculeName": "CYP3A4"
-                },
                 {
                   "Name": "Glomerular Filtration-GFR",
                   "SystemicProcessType": "GFR"
@@ -1263,35 +1226,9 @@
       ]
     }
   ],
-  "ExtensionModules": [
-    "PE1vZHVsZSBpZD0iay1PWWxZX0hnMGFYUDN4RjJGT0V6ZyIgbmFtZT0idGVzdCIgaWNvbj0iTW9kdWxlIiBtb2R1bGVJbXBvcnRWZXJzaW9uPSI1OTQ0MzM2ODciIG1lcmdlQmVoYXZpb3I9IkV4dGVuZCIgaXNQS1NpbU1vZHVsZT0iMCIgdmVyc2lvbj0iMTkiPjxTbmFwc2hvdD48L1NuYXBzaG90PjwvTW9kdWxlPg=="
-  ],
+  "ExtensionModules": [],
   "ExpressionProfileBuildingBlocks": [],
   "IndividualBuildingBlocks": [],
-  "ObservedDataClassifications": [
-    {
-      "Name": "observed data folder",
-      "Classifiables": [
-        "Hot stage extrusion"
-      ]
-    }
-  ],
-  "ParameterIdentificationClassifications": [
-    {
-      "Name": "pi folder",
-      "Classifiables": [
-        "Parameter Identification 1"
-      ]
-    }
-  ],
-  "ModuleClassifications": [
-    {
-      "Name": "module folder",
-      "Classifiables": [
-        "test"
-      ]
-    }
-  ],
   "ObservedData": [
     {
       "Name": "Hot stage extrusion",
@@ -1388,56 +1325,797 @@
         "Dimension": "Time",
         "Unit": "h"
       }
-    }
-  ],
-  "ParameterIdentifications": [
+    },
     {
-      "Name": "Parameter Identification 1",
-      "Simulations": [],
-      "Configuration": {
-        "LLOQMode": "SimulationOutputAsObservedDataLLOQ",
-        "RemoveLLOQMode": "Never",
-        "CalculateJacobian": false,
-        "Algorithm": {
-          "Name": "Levenberg - Marquardt (MPFit)",
-          "Properties": [
-            {
-              "Name": "ftol",
-              "Value": 0.001,
-              "Type": "Double"
-            },
-            {
-              "Name": "xtol",
-              "Value": 1E-06,
-              "Type": "Double"
-            },
-            {
-              "Name": "gtol",
-              "Value": 1E-10,
-              "Type": "Double"
-            },
-            {
-              "Name": "stepfactor",
-              "Value": 100.0,
-              "Type": "Double"
-            },
-            {
-              "Name": "maxiter",
-              "Value": 200,
-              "Type": "Integer"
-            },
-            {
-              "Name": "maxfev",
-              "Value": 0,
-              "Type": "Integer"
-            },
-            {
-              "Name": "epsfcn",
-              "Value": 1E-09,
-              "Type": "Double"
-            }
-          ]
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 1",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 1",
+          "Type": "String"
         }
+      ],
+      "Columns": [
+        {
+          "Name": "conc ",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 1|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc "
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            1.762712,
+            2.59887,
+            3.8870063,
+            4.745763,
+            6.666667,
+            7.073446,
+            6.305085,
+            5.378531,
+            4.79096,
+            4.248588,
+            2.621469
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 1|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          14.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 2",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 2",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc (1)",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 2|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (1)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            0.38418078,
+            1.514124,
+            3.502825,
+            4.81356,
+            6.711864,
+            6.711864,
+            6.282486,
+            5.468926,
+            4.4971747,
+            4.022599,
+            1.9435031
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 2|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          14.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 3",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 3",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc (2)",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 3|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (2)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            2.124294,
+            4.429379,
+            5.853107,
+            6.870057,
+            7.322034,
+            6.644068,
+            5.672317,
+            4.926554,
+            4.2033896,
+            3.59322,
+            1.694915
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 3|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          14.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 4",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 4",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc (3)",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 4|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (3)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            2.508475,
+            4.0677967,
+            5.920904,
+            6.6892657,
+            6.531074,
+            6.033898,
+            4.745763,
+            3.9774008,
+            3.0056498,
+            1.19774
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 4|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 5",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 5",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc (4)",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 5|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (4)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            0.7457627,
+            1.966102,
+            3.706215,
+            3.096045,
+            5.0847464,
+            5.3559318,
+            4.3163843,
+            3.7740111,
+            3.050848,
+            1.107345
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 5|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 6",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 6",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc (5)",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 6|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (5)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            3.141243,
+            4.1807914,
+            5.7853107,
+            6.124294,
+            5.423729,
+            4.903955,
+            3.9548023,
+            3.3898308,
+            2.621469,
+            2.214689,
+            0.8813559
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 6|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          6.0,
+          8.0,
+          10.0,
+          12.0,
+          14.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Henrist 1999.Hot stage extrusion oral.Subj 7",
+      "ExtendedProperties": [
+        {
+          "Name": "Source",
+          "Value": "Z:\\HOST_C\\Users\\ztcok\\Projekte\\GI tract\\TestSubstances\\Theophylline\\XML files\\Data.xlsx.Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "File",
+          "Value": "Data",
+          "Type": "String"
+        },
+        {
+          "Name": "Sheet",
+          "Value": "Henrist1999 Exp 300mg ",
+          "Type": "String"
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Theophylline",
+          "Type": "String"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human",
+          "Type": "String"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood",
+          "Type": "String"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma",
+          "Type": "String"
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Henrist 1999",
+          "Type": "String"
+        },
+        {
+          "Name": "Dose",
+          "Value": "300 mg",
+          "Type": "String"
+        },
+        {
+          "Name": "Route",
+          "Value": "Hot stage extrusion oral",
+          "Type": "String"
+        },
+        {
+          "Name": "Patient Id",
+          "Value": "Subj 7",
+          "Type": "String"
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "conc (6)",
+          "QuantityInfo": {
+            "Path": "Henrist 1999.Hot stage extrusion oral.Subj 7|ObservedData|Peripheral Venous Blood|Plasma|Theophylline|conc (6)"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "MolWeight": 180.17
+          },
+          "Values": [
+            2.2824862,
+            3.9548023,
+            5.7853107,
+            6.101695,
+            5.242938,
+            3.7740111,
+            3.209039,
+            2.508475,
+            2.033898,
+            0.7457627
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time ",
+        "QuantityInfo": {
+          "Path": "Henrist 1999.Hot stage extrusion oral.Subj 7|Time ",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined"
+        },
+        "Values": [
+          1.0,
+          2.0,
+          3.0,
+          4.0,
+          5.0,
+          8.0,
+          10.0,
+          12.0,
+          14.0,
+          24.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
       }
     }
   ],
@@ -1477,12 +2155,10 @@
               ]
             }
           ],
-          "RandomSeed": 144540453.0
+          "RandomSeed": 1261891593.0
         },
         "IndividualBuildingBlock": "Man",
-        "ExpressionProfiles": [
-          "CYP3A4|Human|Healthy"
-        ],
+        "ExpressionProfiles": [],
         "ModuleConfigurations": [
           {
             "Module": "Henrist oral Hot stage extrusion as table",
@@ -1499,53 +2175,7 @@
     }
   ],
   "ReactionDimensionMode": "AmountBased",
-  "ExpressionProfileSnapshots": [
-    {
-      "PKSimSnapshot": {
-        "Type": "Enzyme",
-        "Species": "Human",
-        "Molecule": "CYP3A4",
-        "Category": "Healthy",
-        "Parameters": [
-          {
-            "Path": "CYP3A4|Reference concentration",
-            "Value": 4.32,
-            "Unit": "µmol/l",
-            "ValueOrigin": {}
-          },
-          {
-            "Path": "CYP3A4|t1/2 (intestine)",
-            "Value": 1380.0,
-            "Unit": "min",
-            "ValueOrigin": {}
-          },
-          {
-            "Path": "CYP3A4|t1/2 (liver)",
-            "Value": 2220.0,
-            "Unit": "min",
-            "ValueOrigin": {}
-          }
-        ],
-        "Localization": "Intracellular",
-        "Ontogeny": {
-          "Name": "CYP3A4"
-        }
-      },
-      "UpdatedValues": [
-        {
-          "Path": "Organism|VenousBlood|Plasma|CYP3A4|Initial concentration",
-          "NewUnit": "µmol/l",
-          "NewFormulaId": "ConcFormula"
-        },
-        {
-          "Path": "Organism|Bone|Intracellular|CYP3A4|Fraction expressed intracellular",
-          "NewValue": 0.9,
-          "NewUnit": ""
-        }
-      ],
-      "FormulaCache": "PEZvcm11bGFDYWNoZSB2ZXJzaW9uPSIxOSI+PEZvcm11bGFzPjxGb3JtdWxhIGlkPSJDb25jRm9ybXVsYSIgbmFtZT0iQ29uY0Zvcm11bGEiIGRpbT0iQ29uY2VudHJhdGlvbiAobW9sYXIpIiBmb3JtdWxhPSJWJmd0OzAgPyBNL1YgOiAwIj48UGF0aHM+PFBhdGggcGF0aD0iMCIgYXM9IjEiIGRpbT0iMiIgLz48UGF0aCBwYXRoPSIzIiBhcz0iNCIgZGltPSI1IiAvPjwvUGF0aHM+PC9Gb3JtdWxhPjwvRm9ybXVsYXM+PFN0cmluZ01hcD48TWFwIHM9Ii4uIiBpZD0iMCIgLz48TWFwIHM9Ik0iIGlkPSIxIiAvPjxNYXAgcz0iQW1vdW50IiBpZD0iMiIgLz48TWFwIHM9Ii4ufC4ufFZvbHVtZSIgaWQ9IjMiIC8+PE1hcCBzPSJWIiBpZD0iNCIgLz48TWFwIHM9IlZvbHVtZSIgaWQ9IjUiIC8+PC9TdHJpbmdNYXA+PC9Gb3JtdWxhQ2FjaGU+"
-    }
-  ],
+  "ExpressionProfileSnapshots": [],
   "IndividualBuildingBlockSnapshots": [
     {
       "PKSimSnapshot": {
@@ -1565,24 +2195,7 @@
           }
         }
       },
-      "UpdatedValues": [
-        {
-          "Path": "Organism|Ontogeny factor (albumin)",
-          "NewUnit": "",
-          "NewFormulaId": "_SZxHCxS90OL8x2QoHgyWg"
-        },
-        {
-          "Path": "Organism|pH (blood cells)",
-          "NewValue": 7.0,
-          "NewUnit": ""
-        },
-        {
-          "Path": "Organism|Age",
-          "NewValue": 31.0,
-          "NewUnit": "year(s)"
-        }
-      ],
-      "FormulaCache": "PEZvcm11bGFDYWNoZSB2ZXJzaW9uPSIxOSI+PEZvcm11bGFzPjxUYWJsZUZvcm11bGFXaXRoWEFyZ3VtZW50IGlkPSJfU1p4SEN4UzkwT0w4eDJRb0hneVdnIiBuYW1lPSJDbG9uZWRUYWJsZUZvcm11bGFXaXRoWEFyZ3VtZW50X09udG9nZW55RmFjdG9yQWxidW1pbiIgdGFibGVPYmplY3RBbGlhcz0iVGFibGUiIHhBcmd1bWVudEFsaWFzPSJYQXJnIj48UGF0aHM+PFBhdGggcGF0aD0iMCIgYXM9IjEiIC8+PFBhdGggcGF0aD0iMiIgYXM9IjMiIGRpbT0iNCIgLz48L1BhdGhzPjwvVGFibGVGb3JtdWxhV2l0aFhBcmd1bWVudD48L0Zvcm11bGFzPjxTdHJpbmdNYXA+PE1hcCBzPSIuLnxPbnRvZ2VueSBmYWN0b3IgKGFsYnVtaW4pIHRhYmxlIiBpZD0iMCIgLz48TWFwIHM9IlRhYmxlIiBpZD0iMSIgLz48TWFwIHM9Ik9yZ2FuaXNtfFBvc3QgbWVuc3RydWFsIGFnZSIgaWQ9IjIiIC8+PE1hcCBzPSJYQXJnIiBpZD0iMyIgLz48TWFwIHM9IkFnZSBpbiB5ZWFycyIgaWQ9IjQiIC8+PC9TdHJpbmdNYXA+PC9Gb3JtdWxhQ2FjaGU+"
+      "UpdatedValues": []
     }
   ]
 }


### PR DESCRIPTION
## Summary
Make the PK-Sim snapshot exchange host-selectable so MoBi.R (headless) no longer needs the desktop `PKSim.Starter.dll`.

- Split `IPKSimStarter` into `IPKSimSnapshotConverter` (the snapshot `Load*` methods) + `IPKSimStarter : IPKSimSnapshotConverter` (desktop-only members).
- Add abstract `PKSimSnapshotConverterBase` with the shared reflection/serialization logic; the only variation point is the exchange type name. `PKSimStarter` (desktop → `PKSim.Starter.SnapshotExchange`) and the new `PKSimSnapshotConverter` (MoBi.R → `PKSim.R.Exchange.SnapshotExchange` in the shipped `PKSim.R.dll`) derive from it.
- Register one implementation per host: `PKSimStarter` for desktop UI/BatchTool/CLI; `PKSimSnapshotConverter` for MoBi.R. `PKSimStarter` is excluded from the shared `CoreRegister` convention.
- `ProjectMapper` now depends on `IPKSimSnapshotConverter`; `ContextForIntegration` registers the fake under both interfaces.
- `LoadSimulationsFromSnapshot` passes `runSimulations: false` — load only; the caller runs.
- Replace the snapshot test fixture with a clean one (the previous one had a circular formula reference).

## Dependency
Requires PK-Sim Open-Systems-Pharmacology/PK-Sim#3563 (the headless `PKSim.R.Exchange.SnapshotExchange`) to be published before MoBi.R can convert PK-Sim-module snapshots at runtime.

## Test plan
- [x] MoBi.sln builds (0 errors); `When_loading_a_snapshot` passes with the fake-under-both-interfaces fix.
- [x] Validated end-to-end via OSPSuite-R with local builds: PK-Sim module loads headlessly, and the loaded simulation runs cleanly afterward.
- [x] CI green.

Fixes #2404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured PK-Sim snapshot conversion system to support both desktop and headless modes with better separation of concerns.
  * Updated dependency injection configuration across multiple modules for improved compatibility.

* **Tests**
  * Updated integration test fixtures and snapshot data to align with refactored conversion architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Systems-Pharmacology/MoBi/pull/2405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->