### PR TITLE
Fixes #2415 Restore chart editor width when opening a Time Profile chart

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
@@ -162,8 +162,8 @@ namespace MoBi.Presentation.Presenter
          var presenter = _simulationAnalysisPresenterFactory.PresenterFor(simulationAnalysis);
          _analysisPresenters.Add(presenter);
          registerObservedDataEvent(presenter);
-         presenter.InitializeAnalysis(simulationAnalysis, _simulation);
          _view.AddAnalysis(presenter);
+         presenter.InitializeAnalysis(simulationAnalysis, _simulation);
       }
 
       private void unRegisterObservedDataEvent(ISimulationAnalysisPresenter presenter)

--- a/src/MoBi.UI/Views/SimulationView/EditSimulationView.cs
+++ b/src/MoBi.UI/Views/SimulationView/EditSimulationView.cs
@@ -105,6 +105,7 @@ namespace MoBi.UI.Views.SimulationView
          page.Tag = analysisPresenter;
          page.ShowCloseButton = DefaultBoolean.True;
          page.InitializeFrom(analysisPresenter.BaseView);
+         analysisPresenter.BaseView.CaptionChanged += (o, e) => page.Text = analysisPresenter.BaseView.Caption;
 
          var changesIndex = tabs.TabPages.IndexOf(tabChanges);
          tabs.TabPages.Insert(changesIndex, page);


### PR DESCRIPTION
Fixes #2415

## Summary

The chart editor panel opened much narrower for **Time Profile** charts than for other analysis types (e.g. Predicted vs. Observed).

## Root cause

`EditSimulationPresenter.addAnalysis` restored the chart-editor layout ("Standard View") via `InitializeAnalysis` **before** the analysis view was added to its tab. Time Profile charts are hosted in `ChartView`, a plain user control sized via `FillWith`, so the editor/display control had no real width at that point and the restored editor/display split collapsed to a sliver. MoBi's `ChartPresenter` then locked this in via its one-shot `_initialized` guard, so the layout was never recomputed once the tab was shown at full width.

Predicted-vs-Observed and Residual-vs-Time charts use a different presenter hosted in a pre-sized layout view, so the editor already had a real width when the layout was restored — which is why only Time Profile showed the problem.

## Changes

- **`EditSimulationPresenter.addAnalysis`**: add the analysis view (and select its tab) **before** calling `InitializeAnalysis`, so the editor layout is restored while the editor control already has its real size.
- **`EditSimulationView.AddAnalysis`**: keep the tab caption in sync with the view caption (which is set during `InitializeAnalysis`, now after the tab is created) by subscribing to `CaptionChanged`, mirroring the existing `BaseMdiChildTabbedView` pattern. Without this the tab caption would be blank.

## Testing

Verified in MoBi: the Time Profile chart editor now opens at the same width as other chart types, and analysis tab captions correctly show the chart name for all types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tab labels for analyses to properly update when their names change, ensuring the UI remains synchronized with current analysis information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->