### PR TITLE
Fixes #2420 Override SQLitePCLRaw.bundle_e_sqlite3 to 3.0.3 to clear CVE-2025-6965

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.123" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MoBi.Core\MoBi.Core.csproj" />

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,13 +16,13 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.123" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.123" />
-      <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.123" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.123" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.123" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.130" />
+      <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.130" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.130" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.130" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -21,15 +21,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.123" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.130" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -30,13 +30,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.123" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.130" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.123" />
     <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.123" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.123" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.130" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -20,10 +20,10 @@
 
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.123" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.130" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -24,12 +24,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.7" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -62,6 +62,7 @@
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="OSPSuite.Presentation" Version="13.0.123" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -57,13 +57,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.123" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.130" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.123" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.130" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.123" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.123" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.130" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.130" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Clears **NU1903** for **CVE-2025-6965 / [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q)** (High, CVSS 9.8): SQLite before 3.50.2 can suffer memory corruption when aggregate terms exceed available columns. The vulnerable `SQLitePCLRaw.lib.e_sqlite3 2.1.11` enters via the direct `Microsoft.Data.Sqlite 10.0.7` references in `MoBi.Core`, `MoBi`, `MoBi.BatchTool` and `MoBi.Tests`.

## Fix
Add a direct override so the patched native ships:
```xml
<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
```
Even the latest `Microsoft.Data.Sqlite` (10.0.9) still depends on `SQLitePCLRaw.core 2.1.11`, so bumping it does not help. `SQLitePCLRaw.bundle_e_sqlite3 3.0.3` pulls in `SourceGear.sqlite3 3.50.4.5` (SQLite **3.50.4**) and drops `SQLitePCLRaw.lib.e_sqlite3` from the graph entirely. SQLitePCLRaw v3 has "no code changes in SQLitePCLRaw.core", so it stays compatible with `Microsoft.Data.Sqlite 10.0.7`. (The package version is `3.0.3`; the `3.50.x` in the issue is the SQLite native version.)

## Verification
`dotnet restore` + `dotnet list package --vulnerable --include-transitive` → **no vulnerable packages**; `--include-transitive` shows `SourceGear.sqlite3 3.50.4.5` / `SQLitePCLRaw.core 3.0.3` and no `lib.e_sqlite3`.

Sibling fixes: Open-Systems-Pharmacology/OSPSuite.Core#2894, Open-Systems-Pharmacology/PK-Sim#3585

Fixes #2420
