### PR TITLE
Reduce MoBi startup time

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,13 +16,13 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.131" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.132" />
       <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.131" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.131" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.131" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.132" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.132" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.132" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -21,15 +21,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.132" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,12 +31,12 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.132" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.132" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/Core/JournalPageEditorActivator.cs
+++ b/src/MoBi.Presentation/Core/JournalPageEditorActivator.cs
@@ -1,0 +1,38 @@
+using OSPSuite.Core.Journal;
+using OSPSuite.Presentation.Presenters.Journal;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Events;
+
+namespace MoBi.Presentation.Core
+{
+   public interface IJournalPageEditorActivator : IListener<EditJournalPageStartedEvent>
+   {
+   }
+
+   /// <summary>
+   ///    Creates the journal page editor on first use because it constructs expensive DevExpress components.
+   /// </summary>
+   public class JournalPageEditorActivator : IJournalPageEditorActivator
+   {
+      private readonly IContainer _container;
+      private readonly IEventPublisher _eventPublisher;
+      private bool _activated;
+
+      public JournalPageEditorActivator(IContainer container, IEventPublisher eventPublisher)
+      {
+         _container = container;
+         _eventPublisher = eventPublisher;
+      }
+
+      public void Handle(EditJournalPageStartedEvent eventToHandle)
+      {
+         if (_activated) return;
+         _activated = true;
+
+         _container.Resolve<IJournalPageEditorFormPresenter>();
+         //re-publish because the presenters created above were not yet subscribed when this event was published
+         _eventPublisher.PublishEvent(eventToHandle);
+         _eventPublisher.RemoveListener(this);
+      }
+   }
+}

--- a/src/MoBi.Presentation/Core/JournalPageEditorActivator.cs
+++ b/src/MoBi.Presentation/Core/JournalPageEditorActivator.cs
@@ -27,9 +27,11 @@ namespace MoBi.Presentation.Core
       public void Handle(EditJournalPageStartedEvent eventToHandle)
       {
          if (_activated) return;
-         _activated = true;
 
          _container.Resolve<IJournalPageEditorFormPresenter>();
+         //set only after a successful resolve (so a failed resolve retries on the next edit), but before
+         //re-publishing so the re-dispatched event does not re-enter this activator
+         _activated = true;
          //re-publish because the presenters created above were not yet subscribed when this event was published
          _eventPublisher.PublishEvent(eventToHandle);
          _eventPublisher.RemoveListener(this);

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -21,9 +21,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/PresentationRegister.cs
+++ b/src/MoBi.Presentation/PresentationRegister.cs
@@ -82,6 +82,7 @@ namespace MoBi.Presentation
             scan.ExcludeType<MoBiApplicationController>();
             scan.ExcludeType<MoBiXmlSerializerRepository>();
             scan.ExcludeType<MoBiMainViewPresenter>();
+            scan.ExcludeType<JournalPageEditorActivator>();
             scan.Exclude(t => t.IsAnImplementationOf<IMoBiBaseDiagramPresenter>());
 
             //exclude presenter already registered at startup
@@ -92,6 +93,7 @@ namespace MoBi.Presentation
 
          container.Register<IPKSimStarter, IPKSimSnapshotConverter, PKSimStarter>(LifeStyle.Singleton);
          container.Register<IMenuBarItemRepository, MenuBarItemRepository>(LifeStyle.Singleton);
+         container.Register<IJournalPageEditorActivator, JournalPageEditorActivator>(LifeStyle.Singleton);
          container.Register<ISimulationRunner, SimulationRunner>(LifeStyle.Singleton);
          container.Register<IMoBiApplicationController, IApplicationController, MoBiApplicationController>(LifeStyle.Singleton);
 
@@ -128,6 +130,8 @@ namespace MoBi.Presentation
          //Create one instance of the invoker so that the object is available
          //since it is not created anywhere and is only used as event listener
          container.RegisterImplementationOf(container.Resolve<ICloseSubjectPresenterInvoker>());
+         //Activates the journal page editor on first use
+         container.Resolve<IJournalPageEditorActivator>();
          container.Register<IWithWorkspaceLayout, Workspace>(LifeStyle.Singleton);
 
          container.Register<IQuantityPathToQuantityDisplayPathMapper, MoBiQuantityPathToQuantityDisplayPathMapper>();

--- a/src/MoBi.Presentation/Repositories/MenuBarItemRepository.cs
+++ b/src/MoBi.Presentation/Repositories/MenuBarItemRepository.cs
@@ -501,7 +501,13 @@ namespace MoBi.Presentation.Repositories
          yield return JournalMenuBarButtons.JournalView(MenuBarItemIds.JournalView, _container);
          yield return JournalMenuBarButtons.CreateJournalPage(MenuBarItemIds.CreateJournalPage, _container);
          yield return JournalMenuBarButtons.SelectJournal(MenuBarItemIds.SelectJournal, _container);
-         yield return JournalMenuBarButtons.JournalEditorView(MenuBarItemIds.JournalEditorView, _container);
+         //Initialize JournalEditorVisibiliyUICommand on demand because it constructs expensive DevExpress components
+         yield return CreateMenuButton.WithCaption(OSPSuite.Assets.Captions.Journal.JournalEditorView)
+            .WithId(MenuBarItemIds.JournalEditorView)
+            .WithDescription(OSPSuite.Assets.Captions.Journal.JournalEditorViewDescription)
+            .WithActionCommand(() => _container.Resolve<JournalEditorVisibiliyUICommand>().Execute())
+            .WithIcon(ApplicationIcons.PageEdit);
+
          yield return CommonMenuBarButtons.JournalDiagramView(MenuBarItemIds.JournalDiagramView, _container);
          yield return JournalMenuBarButtons.SearchJournal(MenuBarItemIds.SearchJournal, _container);
          yield return JournalMenuBarButtons.ExportJournal(MenuBarItemIds.ExportJournal, _container);

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.132" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -25,11 +25,11 @@
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -57,13 +57,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.131" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.132" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.132" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/MoBi.Tests/Presentation/JournalPageEditorActivatorSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/JournalPageEditorActivatorSpecs.cs
@@ -1,0 +1,79 @@
+using FakeItEasy;
+using MoBi.Presentation.Core;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Journal;
+using OSPSuite.Presentation.Presenters.Journal;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Events;
+
+namespace MoBi.Presentation
+{
+   public abstract class concern_for_JournalPageEditorActivator : ContextSpecification<IJournalPageEditorActivator>
+   {
+      protected IContainer _container;
+      protected IEventPublisher _eventPublisher;
+      protected EditJournalPageStartedEvent _event;
+
+      protected override void Context()
+      {
+         _container = A.Fake<IContainer>();
+         _eventPublisher = A.Fake<IEventPublisher>();
+         _event = new EditJournalPageStartedEvent(new JournalPage(), showEditor: true);
+         sut = new JournalPageEditorActivator(_container, _eventPublisher);
+      }
+   }
+
+   public class When_the_journal_page_editor_activator_handles_the_first_edit_journal_page_started_event : concern_for_JournalPageEditorActivator
+   {
+      protected override void Because()
+      {
+         sut.Handle(_event);
+      }
+
+      [Observation]
+      public void should_create_the_journal_page_editor_form_presenter()
+      {
+         A.CallTo(() => _container.Resolve<IJournalPageEditorFormPresenter>()).MustHaveHappenedOnceExactly();
+      }
+
+      [Observation]
+      public void should_republish_the_event_so_that_the_newly_subscribed_presenters_can_handle_it()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(_event)).MustHaveHappenedOnceExactly();
+      }
+
+      [Observation]
+      public void should_unsubscribe_itself_from_the_event_publisher()
+      {
+         A.CallTo(() => _eventPublisher.RemoveListener(sut)).MustHaveHappened();
+      }
+   }
+
+   public class When_the_journal_page_editor_activator_handles_a_subsequent_edit_journal_page_started_event : concern_for_JournalPageEditorActivator
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.Handle(_event);
+         Fake.ClearRecordedCalls(_container);
+         Fake.ClearRecordedCalls(_eventPublisher);
+      }
+
+      protected override void Because()
+      {
+         sut.Handle(new EditJournalPageStartedEvent(new JournalPage(), showEditor: false));
+      }
+
+      [Observation]
+      public void should_not_create_the_editor_form_presenter_again()
+      {
+         A.CallTo(() => _container.Resolve<IJournalPageEditorFormPresenter>()).MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void should_not_republish_the_event()
+      {
+         A.CallTo(() => _eventPublisher.PublishEvent(A<EditJournalPageStartedEvent>._)).MustNotHaveHappened();
+      }
+   }
+}

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.131" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.131" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.132" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.132" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #2430

Reduces MoBi startup time (cold-Debug main-window build ~5.0 s → ~1.9 s, ~3 s off total):

| Fix | In this PR | Saving |
|---|---|---|
| Journal page editor built on first use instead of at startup | yes | ~1.5 s |
| Skin gallery populated on demand (via OSPSuite.Core 13.0.132, #2902) | package bump | ~1.7 s |

MoBi has no system database (only the project file), so the repository warm-up / value-origin work done for PK-Sim does not apply here — these two shared deferrals are the whole win.

Draft — opened alongside PK-Sim (Open-Systems-Pharmacology/PK-Sim#3596) and depends on the published OSPSuite.Core 13.0.132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lazy initialization for the journal page editor, improving responsiveness when opening the editor.
  * Updated the Journal menu item to launch the editor on demand.

* **Chores**
  * Bumped several app and test dependencies to the latest patch version across the solution.

* **Tests**
  * Added coverage for first-time and repeated journal editor activation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->