### PR TITLE
Fixes #2428 Cannot select Global parameter type for a molecule parameter

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -111,7 +111,7 @@ def copy_templates_files(source_dir)
 end
 
 def relative_src_dir_for(configuration)
-   File.join('src', 'MoBi', 'bin', configuration, 'net8.0-windows')
+   File.join('src', 'MoBi', 'bin', configuration, 'net10.0-windows')
 end
 
 def src_dir_for(configuration)

--- a/src/MoBi.Presentation/Presenter/EditParameterPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditParameterPresenter.cs
@@ -341,7 +341,7 @@ namespace MoBi.Presentation.Presenter
       public void Handle(ParameterChangedEvent eventToHandle)
       {
          if(canHandle(eventToHandle))
-            _view.Show(_parameterDTO);
+            _view.RefreshData();
       }
 
       private bool canHandle(ParameterChangedEvent eventToHandle)

--- a/src/MoBi.Presentation/Views/IEditParameterView.cs
+++ b/src/MoBi.Presentation/Views/IEditParameterView.cs
@@ -7,6 +7,7 @@ namespace MoBi.Presentation.Views
    public interface IEditParameterView : IView<IEditParameterPresenter>, IViewWithFormula, IActivatableView
    {
       void Show(ParameterDTO parameterDTO);
+      void RefreshData();
       void AddRHSView(IView rhsView);
       bool ShowBuildMode { set; }
       void AddValueOriginView(IView view);

--- a/src/MoBi.UI/Views/EditParameterView.cs
+++ b/src/MoBi.UI/Views/EditParameterView.cs
@@ -22,6 +22,7 @@ namespace MoBi.UI.Views
    {
       private IEditParameterPresenter _presenter;
       private readonly ScreenBinder<ParameterDTO> _screenBinder;
+      private ParameterDTO _parameterDTO;
 
       public EditParameterView()
       {
@@ -156,9 +157,17 @@ namespace MoBi.UI.Views
 
       public void Show(ParameterDTO parameterDTO)
       {
+         _parameterDTO = parameterDTO;
          _screenBinder.BindToSource(parameterDTO);
          initNameControl(parameterDTO);
          initRHSControl(parameterDTO);
+      }
+
+      public void RefreshData()
+      {
+         _screenBinder.Update();
+         initNameControl(_parameterDTO);
+         initRHSControl(_parameterDTO);
       }
 
       private void initRHSControl(ParameterDTO parameterDTO)

--- a/tests/MoBi.Tests/Presentation/EditParameterPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditParameterPresenterSpecs.cs
@@ -285,9 +285,10 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void the_view_should_be_refreshed()
+      public void the_view_should_be_refreshed_without_rebinding_the_lists()
       {
-         A.CallTo(() => _view.Show(_parameterDTO)).MustHaveHappened(2, Times.Exactly);
+         A.CallTo(() => _view.RefreshData()).MustHaveHappened();
+         A.CallTo(() => _view.Show(_parameterDTO)).MustHaveHappened(1, Times.Exactly);
       }
    }
 
@@ -307,7 +308,7 @@ namespace MoBi.Presentation
       [Observation]
       public void the_view_should_not_be_refreshed()
       {
-         A.CallTo(() => _view.Show(_parameterDTO)).MustHaveHappened(1, Times.Exactly);
+         A.CallTo(() => _view.RefreshData()).MustNotHaveHappened();
       }
    }
 }


### PR DESCRIPTION
## Problem

When creating a new parameter in a Molecule (or Reaction) building block and changing **Parameter type** from `Local` to `Global`, the combo box goes blank instead of showing `Global`. The parameter is still created correctly as `Global` on OK — the defect is purely in the UI display.

Fixes #2428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Editing a parameter now refreshes the existing view content rather than fully re-rendering it, avoiding unnecessary list rebinding.
  * Changes to other parameters no longer trigger an unintended refresh while editing is in progress.
* **Tests**
  * Updated presenter specs to validate the new refresh behavior and to ensure refresh is not called when the edited parameter is not the one that changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->