### PR TITLE
Fixes #2443 Restore simulation association on PI snapshot import

### DIFF
--- a/src/MoBi.Core/Domain/Model/MoBiProject.cs
+++ b/src/MoBi.Core/Domain/Model/MoBiProject.cs
@@ -39,6 +39,9 @@ public class MoBiProject : Project
       parameterIdentification.IsLoaded = true;
    }
 
+   /// <summary>
+   /// Returns all simulations or building blocks matching <typeparamref name="T"/>
+   /// </summary>
    public override IReadOnlyCollection<T> All<T>() => get<T>();
 
    public IEnumerable<CurveChart> Charts => _charts;
@@ -57,7 +60,7 @@ public class MoBiProject : Project
 
    public IReadOnlyList<IMoBiSimulation> Simulations => _allSimulations;
 
-   private IReadOnlyList<T> get<T>() => _buildingBlocks.OfType<T>().ToList();
+   private IReadOnlyList<T> get<T>() => _buildingBlocks.OfType<T>().Concat(_allSimulations.OfType<T>()).ToList();
 
    public IReadOnlyList<ExpressionProfileBuildingBlock> ExpressionProfileCollection => get<ExpressionProfileBuildingBlock>();
 
@@ -104,7 +107,7 @@ public class MoBiProject : Project
 
    public IReadOnlyList<IMoBiSimulation> SimulationsUsing(IBuildingBlock templateBuildingBlock) => Simulations.Where(simulation => simulation.Uses(templateBuildingBlock)).ToList();
 
-   public IEnumerable<IObjectBase> All() => All<IObjectBase>().Union(Simulations);
+   public IEnumerable<IObjectBase> All() => All<IObjectBase>();
 
    /// <summary>
    ///    Returns a list of simulations that have a module where the name matches <paramref name="module" />

--- a/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
+++ b/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
@@ -116,9 +116,6 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
       var observedData = await ObservedDataFrom(projectSnapshot.ObservedData, snapshotContext);
       observedData?.Each(repository => AddObservedDataToProject(project, repository));
 
-      var parameterIdentifications = await AllParameterIdentificationsFrom(projectSnapshot.ParameterIdentifications, snapshotContext);
-      parameterIdentifications?.Each(pi => AddParameterIdentificationToProject(project, pi));
-
       var simulationContext = new SimulationContext(context.RunSimulations, snapshotContext)
       {
          NumberOfSimulationsToLoad = projectSnapshot.Simulations?.Length ?? 0,
@@ -141,6 +138,9 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
             }
          }
       }
+
+      var parameterIdentifications = await AllParameterIdentificationsFrom(projectSnapshot.ParameterIdentifications, snapshotContext);
+      parameterIdentifications?.Each(pi => AddParameterIdentificationToProject(project, pi));
 
       if (simulationContext.Run && project.Simulations.Any())
       {

--- a/tests/MoBi.Tests/IntegrationTests/Snapshots/ParameterIdentificationSnapshotSpecs.cs
+++ b/tests/MoBi.Tests/IntegrationTests/Snapshots/ParameterIdentificationSnapshotSpecs.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Container;
+
+namespace MoBi.IntegrationTests.Snapshots
+{
+   public class When_loading_a_snapshot_with_a_parameter_identification_referencing_a_simulation : ContextWithLoadedSnapshot
+   {
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+
+         var validationTask = IoC.Resolve<IEntityValidationTask>();
+         A.CallTo(() => validationTask.Validate(A<MoBiSimulation>._)).Returns(true);
+
+         LoadSnapshot("snapshot_no_pksim_modules");
+      }
+
+      [Observation]
+      public void the_simulation_is_loaded()
+      {
+         _project.Simulations.Count.ShouldBeEqualTo(1);
+         _project.Simulations[0].Name.ShouldBeEqualTo("test");
+      }
+
+      [Observation]
+      public void the_parameter_identification_retains_its_simulation()
+      {
+         var parameterIdentification = _project.AllParameterIdentifications.Single();
+         parameterIdentification.AllSimulations.Select(x => x.Name).ShouldContain("test");
+      }
+
+      [Observation]
+      public void the_identification_parameter_is_linked_to_the_simulation_parameter()
+      {
+         var parameterIdentification = _project.AllParameterIdentifications.Single();
+         parameterIdentification.AllIdentificationParameters.Count.ShouldBeEqualTo(1);
+      }
+   }
+}

--- a/tests/MoBi.Tests/TestFiles/snapshot_no_pksim_modules.json
+++ b/tests/MoBi.Tests/TestFiles/snapshot_no_pksim_modules.json
@@ -149,7 +149,42 @@
   "ParameterIdentifications": [
     {
       "Name": "Parameter Identification 1",
-      "Simulations": [],
+      "Simulations": [
+        "test"
+      ],
+      "OutputMappings": [
+        {
+          "Scaling": "Log",
+          "Path": "test|Organism|PeripheralVenousBlood|Theophylline|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Human.Plasma.IV.Subj 1.Human.Plasma.IV.Subj 1"
+        }
+      ],
+      "IdentificationParameters": [
+        {
+          "Name": "Fraction vascular",
+          "Scaling": "Linear",
+          "LinkedParameters": [
+            "test|Organism|ArterialBlood|Fraction vascular"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 1.0,
+              "ValueOrigin": {}
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.0,
+              "ValueOrigin": {}
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 1.0,
+              "ValueOrigin": {}
+            }
+          ]
+        }
+      ],
       "Configuration": {
         "LLOQMode": "SimulationOutputAsObservedDataLLOQ",
         "RemoveLLOQMode": "Never",


### PR DESCRIPTION
Fixes #2443

Loading a project snapshot containing a parameter identification dropped the PI's simulation association (and threw a `NullReferenceException`).

Two causes, both fixed here:
- **`ProjectMapper`** mapped parameter identifications *before* simulations were added to the project, so name lookups failed. PIs are now mapped after simulations load, matching PK-Sim.
- **`MoBiProject.All<T>()`** only enumerated building blocks, but simulations live in a separate list. The Core PI mapper resolves the PI's `Simulations` via `project.All<ISimulation>()`, which was always empty in MoBi. `All<T>()` now includes simulations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project item retrieval so simulations are included consistently alongside other project components.
  * Adjusted project loading so parameter identifications are restored after simulation setup, improving snapshot loading consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->