### PR TITLE
Fixes #2447 CLI qualification ignores --pksim for projects with PK-Sim modules

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -40,9 +40,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
-    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/src/MoBi.CLI.Core/CLIRegister.cs
+++ b/src/MoBi.CLI.Core/CLIRegister.cs
@@ -1,6 +1,5 @@
 ﻿using MoBi.CLI.Core.RunOptions;
 using MoBi.CLI.Core.Services;
-using OSPSuite.CLI.Core.RunOptions;
 using OSPSuite.CLI.Core.Services;
 using OSPSuite.Core;
 using OSPSuite.Core.Domain.Mappers;

--- a/src/MoBi.CLI.Core/CLIRegister.cs
+++ b/src/MoBi.CLI.Core/CLIRegister.cs
@@ -21,7 +21,7 @@ namespace MoBi.CLI.Core
             x.WithConvention<OSPSuiteRegistrationConvention>();
          });
 
-         container.Register<IBatchRunner<SnapshotRunOptions>, SnapshotRunner>();
+         container.Register<IBatchRunner<MoBiSnapshotRunOptions>, SnapshotRunner>();
          container.Register<IBatchRunner<MoBiQualificationRunOptions>, QualificationRunner>();
          container.Register<IPathToPathElementsMapper, PathToPathElementsMapper>();
          container.Register<IDataColumnToPathElementsMapper, DataColumnToPathElementsMapper>();

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,13 +16,13 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.134" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.136" />
       <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.134" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.134" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.134" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.136" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.136" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI.Core/RunOptions/IProvidePKSimPath.cs
+++ b/src/MoBi.CLI.Core/RunOptions/IProvidePKSimPath.cs
@@ -1,0 +1,7 @@
+namespace MoBi.CLI.Core.RunOptions
+{
+   public interface IProvidePKSimPath
+   {
+      string PKSimPath { get; }
+   }
+}

--- a/src/MoBi.CLI.Core/RunOptions/MoBiQualificationRunOptions.cs
+++ b/src/MoBi.CLI.Core/RunOptions/MoBiQualificationRunOptions.cs
@@ -2,7 +2,7 @@
 
 namespace MoBi.CLI.Core.RunOptions
 {
-   public class MoBiQualificationRunOptions : QualificationRunOptions
+   public class MoBiQualificationRunOptions : QualificationRunOptions, IProvidePKSimPath
    {
       public string PKSimPath { get; set; }
    }

--- a/src/MoBi.CLI.Core/RunOptions/MoBiSnapshotRunOptions.cs
+++ b/src/MoBi.CLI.Core/RunOptions/MoBiSnapshotRunOptions.cs
@@ -1,0 +1,9 @@
+using OSPSuite.CLI.Core.RunOptions;
+
+namespace MoBi.CLI.Core.RunOptions
+{
+   public class MoBiSnapshotRunOptions : SnapshotRunOptions, IProvidePKSimPath
+   {
+      public string PKSimPath { get; set; }
+   }
+}

--- a/src/MoBi.CLI.Core/Services/QualificationRunner.cs
+++ b/src/MoBi.CLI.Core/Services/QualificationRunner.cs
@@ -34,7 +34,6 @@ namespace MoBi.CLI.Core.Services
       private readonly IProjectPersistor _projectPersistor;
       private readonly ISimulationPersistor _simulationPersistor;
       private readonly ISessionManager _sessionManager;
-      private readonly IApplicationSettings _applicationSettings;
       private readonly ISnapshotTask _moBiSnapshotTask;
 
       public QualificationRunner(IMoBiContext context,
@@ -44,29 +43,18 @@ namespace MoBi.CLI.Core.Services
          IJsonSerializer jsonSerializer,
          ISnapshotTask snapshotTask,
          ISimulationPersistor simulationPersistor,
-         ISessionManager sessionManager,
-         IApplicationSettings applicationSettings) : base(logger, dataRepositoryExportTask, jsonSerializer, snapshotTask)
+         ISessionManager sessionManager) : base(logger, dataRepositoryExportTask, jsonSerializer, snapshotTask)
       {
          _context = context;
          _projectPersistor = projectPersistor;
          _simulationPersistor = simulationPersistor;
          _sessionManager = sessionManager;
-         _applicationSettings = applicationSettings;
          _moBiSnapshotTask = snapshotTask;
       }
 
       protected override void LoadProjectContext(ModelProject project)
       {
          _context.LoadFrom(project);
-      }
-
-      public override Task RunBatchAsync(MoBiQualificationRunOptions runOptions)
-      {
-         // For any process that will access PK-Sim services, use the path from the command line if specified
-         if (!string.IsNullOrEmpty(runOptions.PKSimPath))
-            _applicationSettings.PKSimPath = runOptions.PKSimPath;
-
-         return base.RunBatchAsync(runOptions);
       }
 
       protected override IEnumerable<PlotMapping> RetrievePlotDefinitionsForSimulation(SimulationPlot simulationPlot, SnapshotProject snapshotProject)

--- a/src/MoBi.CLI.Core/Services/SnapshotRunner.cs
+++ b/src/MoBi.CLI.Core/Services/SnapshotRunner.cs
@@ -67,6 +67,7 @@ namespace MoBi.CLI.Core.Services
       private async Task startSnapshotRun(IReadOnlyList<FileMap> fileMaps, Func<FileMap, Task> exportFunc)
       {
          var begin = DateTime.UtcNow;
+         var failedCount = 0;
          foreach (var fileMap in fileMaps)
          {
             try
@@ -75,6 +76,7 @@ namespace MoBi.CLI.Core.Services
             }
             catch (Exception e)
             {
+               failedCount++;
                _logger.AddException(e);
             }
             finally
@@ -87,7 +89,11 @@ namespace MoBi.CLI.Core.Services
          var end = DateTime.UtcNow;
          var timeSpent = end - begin;
 
-         _logger.AddInfo($"{fileMaps.Count} {"project".PluralizeIf(fileMaps)} loaded and exported in {timeSpent.ToDisplay()}");
+         var exportedCount = fileMaps.Count - failedCount;
+         _logger.AddInfo($"{exportedCount} {"project".PluralizeIf(exportedCount)} loaded and exported in {timeSpent.ToDisplay()}");
+
+         if (failedCount > 0)
+            throw new OSPSuiteException($"{failedCount} {"project".PluralizeIf(failedCount)} failed to load and export. See the log for details.");
       }
 
       private async Task createProjectFromSnapshotFile(FileMap file, bool runSimulations)
@@ -95,7 +101,7 @@ namespace MoBi.CLI.Core.Services
          _logger.AddInfo($"Starting project export for '{file.SnapshotFile}'");
          var project = await _snapshotTask.LoadProjectFromSnapshotFileAsync(file.SnapshotFile, runSimulations);
          if (project == null)
-            return;
+            throw new OSPSuiteException($"Failed to load snapshot '{file.SnapshotFile}'.");
 
          _logger.AddDebug($"Snapshot loaded successfully from '{file.SnapshotFile}'");
          _moBiContext.Project.FilePath = file.ProjectFile;

--- a/src/MoBi.CLI.Core/Services/SnapshotRunner.cs
+++ b/src/MoBi.CLI.Core/Services/SnapshotRunner.cs
@@ -8,7 +8,6 @@ using MoBi.Core.Domain.Model;
 using MoBi.Core.Serialization.ORM;
 using MoBi.Core.Snapshots.Services;
 using OSPSuite.Assets.Extensions;
-using OSPSuite.CLI.Core.RunOptions;
 using OSPSuite.CLI.Core.Services;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Extensions;
@@ -16,6 +15,7 @@ using OSPSuite.Core.Services;
 using OSPSuite.Utility;
 using OSPSuite.Utility.Exceptions;
 using OSPSuite.Utility.Extensions;
+using SnapshotRunOptions = MoBi.CLI.Core.RunOptions.MoBiSnapshotRunOptions;
 
 namespace MoBi.CLI.Core.Services
 {

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -21,15 +21,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
-    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.136" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.CLI/Program.cs
+++ b/src/MoBi.CLI/Program.cs
@@ -4,6 +4,9 @@ using CommandLine;
 using Microsoft.Extensions.Logging;
 using MoBi.Assets;
 using MoBi.CLI.Commands;
+using MoBi.CLI.Core;
+using MoBi.CLI.Core.RunOptions;
+using MoBi.Core;
 using OSPSuite.CLI.Core.Services;
 using OSPSuite.Core.Services;
 using OSPSuite.Infrastructure.Services;
@@ -24,7 +27,7 @@ namespace MoBi.CLI
 
       static int Main(string[] args)
       {
-         Core.ApplicationStartup.Initialize();
+         ApplicationStartup.Initialize();
 
          Parser.Default.ParseArguments<SnapshotRunCommand, QualificationRunCommand>(args)
             .WithParsed<SnapshotRunCommand>(startCommand)
@@ -37,20 +40,24 @@ namespace MoBi.CLI
          return (int)ExitCodes.Success;
       }
 
-      private static void startCommand<TRunOptions>(CLICommand<TRunOptions> command)
+      private static void startCommand<TRunOptions>(CLICommand<TRunOptions> command) where TRunOptions : IProvidePKSimPath
       {
-         Core.ApplicationStartup.Start();
+         ApplicationStartup.Start();
+         var runOptions = command.ToRunOptions();
+
+         if (!string.IsNullOrEmpty(runOptions.PKSimPath))
+            IoC.Resolve<IApplicationSettings>().PKSimPath = runOptions.PKSimPath;
 
          var logger = initializeLogger(command);
          if (command.LogCommandName)
             logger.AddInfo($"Starting {command.Name.ToLower()} run");
 
          logger.AddDebug($"Arguments:\n{command}");
-         
+
          var runner = IoC.Resolve<IBatchRunner<TRunOptions>>();
          try
          {
-            runner.RunBatchAsync(command.ToRunOptions()).Wait();
+            runner.RunBatchAsync(runOptions).Wait();
          }
          catch (Exception e)
          {

--- a/src/MoBi.CLI/SnapshotRunCommand.cs
+++ b/src/MoBi.CLI/SnapshotRunCommand.cs
@@ -3,6 +3,7 @@ using CommandLine;
 using CommandLine.Text;
 using Microsoft.Extensions.Logging;
 using MoBi.CLI.Commands;
+using MoBi.CLI.Core.RunOptions;
 using OSPSuite.CLI.Core.RunOptions;
 using OSPSuite.CLI.Core.Services;
 using System.Collections.Generic;
@@ -10,7 +11,7 @@ using System.Collections.Generic;
 namespace MoBi.CLI
 {
    [Verb("snap", HelpText = "Start snapshot workflow by loading a set of project (or snapshot) files and creating the corresponding snapshot (or project) file automatically.")]
-   public class SnapshotRunCommand : CLICommand<SnapshotRunOptions>, IWithInputAndOutputFolders
+   public class SnapshotRunCommand : CLICommand<MoBiSnapshotRunOptions>, IWithInputAndOutputFolders
    {
       public override string Name { get; } = "Snapshot";
 
@@ -21,6 +22,9 @@ namespace MoBi.CLI
 
       [Option('o', "output", Required = true, HelpText = "Output folder where project or snapshot files will be exported.")]
       public string OutputFolder { get; set; }
+
+      [Option("pksim", Required = false, HelpText = "The file path where PK-Sim can be found, required when loading snapshots that use PK-Sim modules. Default is to use the value from user settings in MoBi.")]
+      public string PKSimPath { get; set; }
 
       [Option('p', "project", HelpText = "Create project files from snapshot files.")]
       public bool ExportProject
@@ -62,13 +66,14 @@ namespace MoBi.CLI
          return sb.ToString();
       }
 
-      public override SnapshotRunOptions ToRunOptions()
+      public override MoBiSnapshotRunOptions ToRunOptions()
       {
-         return new SnapshotRunOptions
+         return new MoBiSnapshotRunOptions
          {
             OutputFolder = OutputFolder,
             InputFolder = InputFolder,
-            ExportMode = ExportMode
+            ExportMode = ExportMode,
+            PKSimPath = PKSimPath
          };
       }
    }

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,12 +31,12 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.136" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -21,9 +21,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.136" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.R/Services/SnapshotTask.cs
+++ b/src/MoBi.R/Services/SnapshotTask.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using MoBi.CLI.Core.RunOptions;
 using OSPSuite.CLI.Core.RunOptions;
 using OSPSuite.CLI.Core.Services;
 using MoBiSimulation = MoBi.R.Domain.MoBiSimulation;
@@ -30,9 +31,9 @@ namespace MoBi.R.Services
    public class SnapshotTask : ISnapshotTask
    {
       private readonly CoreSnapshotTask _snapshotTask;
-      private readonly IBatchRunner<SnapshotRunOptions> _snapshotRunner;
+      private readonly IBatchRunner<MoBiSnapshotRunOptions> _snapshotRunner;
 
-      public SnapshotTask(CoreSnapshotTask snapshotTask, IBatchRunner<SnapshotRunOptions> snapshotRunner)
+      public SnapshotTask(CoreSnapshotTask snapshotTask, IBatchRunner<MoBiSnapshotRunOptions> snapshotRunner)
       {
          _snapshotTask = snapshotTask;
          _snapshotRunner = snapshotRunner;
@@ -56,7 +57,7 @@ namespace MoBi.R.Services
       public void RunSnapshot(string inputFolder, string outputFolder, bool runSimulations = true,
          SnapshotExportMode exportMode = SnapshotExportMode.Snapshot, params string[] folders)
       {
-         var runOptions = new SnapshotRunOptions
+         var runOptions = new MoBiSnapshotRunOptions
          {
             InputFolder = inputFolder,
             OutputFolder = outputFolder,

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -25,11 +25,11 @@
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -57,13 +57,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
-    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.134" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.R.Tests/MoBi.R.Tests.csproj
+++ b/tests/MoBi.R.Tests/MoBi.R.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
-	 <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+	 <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
 	 <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
 
 	</ItemGroup>

--- a/tests/MoBi.Tests/CLI/QualificationRunnerSpecs.cs
+++ b/tests/MoBi.Tests/CLI/QualificationRunnerSpecs.cs
@@ -45,7 +45,6 @@ namespace MoBi.CLI
       protected readonly List<string> _createdDirectories = [];
       protected MoBiQualificationRunOptions _runOptions;
       protected QualificationConfiguration _qualificationConfiguration;
-      protected IApplicationSettings _applicationSettings;
       protected ISessionManager _sessionManager;
 
       public override async Task GlobalContext()
@@ -60,7 +59,6 @@ namespace MoBi.CLI
             _createdDirectories.Add(s);
             return s;
          };
-         _applicationSettings = new ApplicationSettings();
       }
 
       protected override Task Context()
@@ -82,7 +80,7 @@ namespace MoBi.CLI
 
          _qualificationConfiguration = new QualificationConfiguration();
 
-         sut = new QualificationRunner(_context, _projectPersistor, _logger, _dataRepositoryTask, _jsonSerializer, _snapshotTask, _simulationPersistor, _sessionManager, _applicationSettings);
+         sut = new QualificationRunner(_context, _projectPersistor, _logger, _dataRepositoryTask, _jsonSerializer, _snapshotTask, _simulationPersistor, _sessionManager);
 
          return _completed;
       }
@@ -218,12 +216,6 @@ namespace MoBi.CLI
          A.CallTo(() => _session.BeginTransaction()).MustHaveHappened();
          A.CallTo(() => _transaction.Commit()).MustHaveHappened();
          A.CallTo(() => _projectPersistor.Save(_context.CurrentProject, _context)).MustHaveHappened();
-      }
-
-      [Observation]
-      public void the_application_settings_pk_sim_path_is_overridden()
-      {
-         _applicationSettings.PKSimPath.ShouldBeEqualTo(_runOptions.PKSimPath);
       }
 
       [Observation]

--- a/tests/MoBi.Tests/CLI/SnapshotRunnerSpecs.cs
+++ b/tests/MoBi.Tests/CLI/SnapshotRunnerSpecs.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 using FakeItEasy;
 using MoBi.Assets;
+using MoBi.CLI.Core.RunOptions;
 using MoBi.CLI.Core.Services;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Serialization.ORM;
@@ -21,7 +22,7 @@ namespace MoBi.CLI
    {
       protected ISnapshotTask _snapshotTask;
       protected IOSPSuiteLogger _logger;
-      protected SnapshotRunOptions _runOptions;
+      protected MoBiSnapshotRunOptions _runOptions;
       protected string _createdDirectory;
       private Func<string, string> _oldCreateDirectory;
       protected readonly string _inputFolder = @"C:\Input\";
@@ -46,7 +47,7 @@ namespace MoBi.CLI
          _contextPersistor = A.Fake<IContextPersistor>();
          sut = new SnapshotRunner(_snapshotTask, _logger, _moBiContext, _projectTask, _contextPersistor);
 
-         _runOptions = new SnapshotRunOptions();
+         _runOptions = new MoBiSnapshotRunOptions();
          return _completed;
       }
 

--- a/tests/MoBi.Tests/IntegrationTests/SnapshotRunnerSpecs.cs
+++ b/tests/MoBi.Tests/IntegrationTests/SnapshotRunnerSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using MoBi.Core.Domain.Model;
+using MoBi.CLI.Core.RunOptions;
 using MoBi.Core.Serialization.ORM;
 using MoBi.HelpersForTests;
 using OSPSuite.BDDHelper;
@@ -10,13 +11,13 @@ using OSPSuite.Utility.Container;
 
 namespace MoBi.IntegrationTests
 {
-   public abstract class concern_for_SnapshotRunner : concern_for_BatchRunnerSpecs<SnapshotRunOptions>
+   public abstract class concern_for_SnapshotRunner : concern_for_BatchRunnerSpecs<MoBiSnapshotRunOptions>
    {
    }
 
    public class when_exporting_a_snapshot_from_project : concern_for_SnapshotRunner
    {
-      private SnapshotRunOptions _snapshotRunOptions;
+      private MoBiSnapshotRunOptions _snapshotRunOptions;
       private string _projectDirectory;
       private string _jsonDirectory;
       private readonly string _jsonFileName = "snapshot_no_pksim_modules.json";
@@ -36,7 +37,7 @@ namespace MoBi.IntegrationTests
          createProjectFromSnapshot();
 
          File.Delete(_jsonPath);
-         _snapshotRunOptions = new SnapshotRunOptions
+         _snapshotRunOptions = new MoBiSnapshotRunOptions
          {
             ExportMode = SnapshotExportMode.Snapshot,
             InputFolder = _projectDirectory,
@@ -48,7 +49,7 @@ namespace MoBi.IntegrationTests
 
       private void createProjectFromSnapshot()
       {
-         _snapshotRunOptions = new SnapshotRunOptions
+         _snapshotRunOptions = new MoBiSnapshotRunOptions
          {
             ExportMode = SnapshotExportMode.Project,
             InputFolder = _jsonDirectory,
@@ -97,7 +98,7 @@ namespace MoBi.IntegrationTests
 
    public class when_loading_a_project_from_snapshot : concern_for_SnapshotRunner
    {
-      private SnapshotRunOptions _snapshotRunOptions;
+      private MoBiSnapshotRunOptions _snapshotRunOptions;
       private string _projectDirectory;
       private string _jsonDirectory;
       private readonly string _jsonFileName = "snapshot_no_pksim_modules.json";
@@ -114,7 +115,7 @@ namespace MoBi.IntegrationTests
          _inputPath = Path.Combine(_jsonDirectory, _jsonFileName);
          _outputPath = Path.Combine(_projectDirectory, _projectFileName);
 
-         _snapshotRunOptions = new SnapshotRunOptions
+         _snapshotRunOptions = new MoBiSnapshotRunOptions
          {
             ExportMode = SnapshotExportMode.Project,
             InputFolder = _jsonDirectory,

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -28,11 +28,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.136" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
-    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.76" />
+    <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />

--- a/tests/MoBi.Tests/Presentation/ComparisonChartPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ComparisonChartPresenterSpecs.cs
@@ -109,7 +109,7 @@ public class When_dropping_historical_results_on_the_comparison_chart : concern_
    [Observation]
    public void a_curve_is_added_for_each_output_column_of_the_dropped_historical_results()
    {
-      A.CallTo(() => _chartPresenterContext.EditorPresenter.AddCurveForColumn(_outputColumn, A<CurveOptions>._, A<bool>._)).MustHaveHappened();
+      A.CallTo(() => _chartPresenterContext.EditorPresenter.AddCurveForColumn(_outputColumn, A<CurveOptions>._, A<string>._)).MustHaveHappened();
    }
 
    [Observation]

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.134" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.134" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.136" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
## Fix (#2447)
CLI qualification **and** snapshot conversion of a project whose snapshot embeds PK-Sim modules failed with `Could not find compatible PK-Sim assemblies PKSim.Starter.dll`, ignoring the supplied PK-Sim path.

The path was applied in `QualificationRunner.RunBatchAsync`, which runs *after* the runner is resolved — and resolving the runner constructs the `PKSimStarter` singleton (via `ISnapshotTask → ProjectMapper → IPKSimSnapshotConverter`), whose constructor reads the PK-Sim path from the application settings. So the setting was still empty when it mattered. Regression from the PKSim.R.Exchange refactor (#2405).

Now the path is applied in `Program.startCommand` **before** the batch runner is resolved, via an `IProvidePKSimPath` interface on the run options (a generic constraint keeps the single `startCommand<TRunOptions>`). The `snap` command gains a `--pksim` option (`MoBiSnapshotRunOptions`) so snapshots with PK-Sim modules can be converted too; the redundant `RunBatchAsync` override is removed from the MoBi `QualificationRunner`.

Verified end-to-end: the Amikacin MoBi qualification (Walker 1979, PK-Sim modules) loads both modules and produces the report; `snap --project --pksim <path>` converts the same snapshot to an `.mbp3`. The R path is unaffected (it uses the co-located `PKSim.R.dll` via `PKSimSnapshotConverter`).

## Also: update core
OSPSuite.Core family `13.0.134` → `13.0.136`, and `OSPSuite.SimModel` `5.0.0.76` → `5.0.0.80` (Core 13.0.136 raised its minimum). One test callsite adapted for the Core `AddCurveForColumn` signature change (`bool` → `string linkedOutputPath`). Full solution builds green.

## snap exit code (#2449)
`snap` now surfaces per-file load/export failures as a non-zero exit instead of swallowing them into exit 0 (it previously reported failed files as "loaded and exported"). All files are still attempted; the non-zero exit signals that at least one failed.

Fixes #2447
Fixes #2449



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a PK-Sim path option for snapshot and qualification command-line operations.
  * Improved batch snapshot exports to report failures and signal unsuccessful operations.

* **Bug Fixes**
  * Corrected snapshot runner registration and option handling for command-line and R-based workflows.

* **Chores**
  * Updated OSPSuite and SimModel package versions across application and test projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->