### PR TITLE
Fixes #2436 Prepend the Events container to event-group parameter value paths

### DIFF
--- a/src/MoBi.Presentation/Presenter/SelectReferenceAtParameterValuePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/SelectReferenceAtParameterValuePresenter.cs
@@ -130,7 +130,22 @@ namespace MoBi.Presentation.Presenter
             return returnPath;
          }
 
-         return CreatePathFor(item);
+         var itemPath = CreatePathFor(item);
+         prependEventsContainerIfMissing(item, itemPath);
+         return itemPath;
+      }
+
+      private static void prependEventsContainerIfMissing(IEntity item, ObjectPath objectPath)
+      {
+         // Entities selected from an event group building block are rooted at their top
+         // EventGroupBuilder, but in the built model these live under the "Events" top container.
+         if (isAbsolutePathRootedAtEventGroup(item, objectPath))
+            objectPath.AddAtFront(Constants.EVENTS);
+      }
+
+      private static bool isAbsolutePathRootedAtEventGroup(IEntity item, ObjectPath objectPath)
+      {
+         return item.RootContainer is EventGroupBuilder eventGroupRoot && string.Equals(objectPath.FirstOrDefault(), eventGroupRoot.Name);
       }
 
       private bool shouldUseParameterPath(IEntity item, DummyParameterDTO matchingDto)

--- a/tests/MoBi.Tests/Presentation/SelectReferenceAtParameterValuePresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SelectReferenceAtParameterValuePresenterSpecs.cs
@@ -248,6 +248,43 @@ namespace MoBi.Presentation
       }
    }
 
+   internal class When_selecting_an_event_group_parameter : concern_for_SelectReferenceAtParameterValuePresenter
+   {
+      private ObjectBaseDTO _doseDTO;
+      private Parameter _dose;
+      private IReadOnlyList<ObjectPath> _selectedSections;
+
+      protected override void Context()
+      {
+         base.Context();
+         var eventGroup = new EventGroupBuilder().WithName("200mg iv");
+         var application = new EventGroupBuilder().WithName("Application_1");
+         var protocolSchemaItem = new Container().WithName("ProtocolSchemaItem");
+         _dose = new Parameter().WithName("Dose").WithId("doseId");
+         protocolSchemaItem.Add(_dose);
+         application.Add(protocolSchemaItem);
+         eventGroup.Add(application);
+
+         _doseDTO = new ObjectBaseDTO(_dose);
+
+         A.CallTo(() => _context.Get<IEntity>(_dose.Id)).Returns(_dose);
+         A.CallTo(() => _view.AllSelectedDTOs).Returns(new[] { _doseDTO });
+         A.CallTo(() => _objectPathFactory.CreateAbsoluteObjectPath(_dose))
+            .Returns(new ObjectPath("200mg iv", "Application_1", "ProtocolSchemaItem", "Dose"));
+      }
+
+      protected override void Because()
+      {
+         _selectedSections = sut.GetAllSelections();
+      }
+
+      [Observation]
+      public void the_path_should_be_prefixed_with_the_events_top_container()
+      {
+         _selectedSections.Single().PathAsString.ShouldBeEqualTo($"{Constants.EVENTS}|200mg iv|Application_1|ProtocolSchemaItem|Dose");
+      }
+   }
+
    internal class When_selecting_multiple_references_and_not_all_are_parameters : concern_for_SelectReferenceAtParameterValuePresenter
    {
       private ObjectBaseDTO _parameterDTO2;


### PR DESCRIPTION
## Problem

Adding a parameter value via right-click **New parameter value** and selecting a parameter from an **events** building block (e.g. the `Dose` parameter of a `ProtocolSchemaItem`) produced a path that is missing the leading `Events` element, so the parameter value did not resolve against the model.

Reproduced from the [issue's example project](https://github.com/Open-Systems-Pharmacology/MoBi/issues/2436):

Fixes #2436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reference paths for parameters selected within event groups.
  * Event-group parameter paths now include the appropriate Events container, ensuring selections resolve correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->