### PR TITLE
Fixes #2460 Reference the Windows Desktop framework in MoBi.CLI

### DIFF
--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWindowsForms>True</UseWindowsForms>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <Authors>Open-Systems-Pharmacology</Authors>


### PR DESCRIPTION
MoBi.CLI targeted plain `net10.0`, so its runtimeconfig only loaded `Microsoft.NETCore.App`. When the CLI runs from MoBi's `net10.0-windows` output folder — where it is deployed via project reference — the assemblies that `Microsoft.WindowsDesktop.App` provides (System.Configuration.ConfigurationManager, System.Diagnostics.EventLog, System.Formats.Nrbf, System.Security.Cryptography.Pkcs/ProtectedData/Xml) are neither in the folder nor in the CLI's framework closure, and the first project load fails in NHibernate's static initializer.

Targeting `net10.0-windows` with `UseWindowsForms` (as PKSim.CLI already does) adds `Microsoft.WindowsDesktop.App` to the CLI's runtimeconfig, so these assemblies resolve from the shared framework regardless of which folder the CLI runs from.

Verified locally: `MoBi.CLI.exe snap -s ...` run from `src/MoBi/bin/Debug/net10.0-windows` failed with the reported `TypeInitializationException` before this change and exports the snapshot successfully after it.

Fixes #2460

🤖 Generated with [Claude Code](https://claude.com/claude-code)
