### PR TITLE
Fixes #2459 Open exported files and hyperlinks again

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,13 +16,13 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.136" />
-      <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.136" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.136" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.141" />
+      <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.141" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.141" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.141" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -21,15 +21,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.141" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -30,13 +30,13 @@
     <PackageReference Include="FluentNHibernate" Version="3.4.0" />
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.141" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.141" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -20,10 +20,10 @@
 
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.141" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -24,12 +24,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.2" />
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
-    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.10" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/Views/BaseModuleContentView.cs
+++ b/src/MoBi.UI/Views/BaseModuleContentView.cs
@@ -1,4 +1,5 @@
-﻿using DevExpress.Utils;
+﻿using System.Diagnostics;
+using DevExpress.Utils;
 using DevExpress.XtraLayout;
 using DevExpress.XtraLayout.Utils;
 using MoBi.Assets;
@@ -59,7 +60,7 @@ namespace MoBi.UI.Views
 
       private void handleLink(HyperlinkClickEventArgs e)
       {
-         System.Diagnostics.Process.Start(e.Link);
+         Process.Start(new ProcessStartInfo(e.Link) {UseShellExecute = true});
       }
 
       public void SetBehaviorDescription(string description)

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -57,13 +57,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.136" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.141" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.141" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.136" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.136" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.141" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.141" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #2459

- `OSPSuite.Core` family 13.0.136 -> 13.0.141 and `OSPSuite.Utility` 5.0.0.10 -> 5.0.0.11. The Utility build carries the `FileHelper.TryOpenFile` fix (Open-Systems-Pharmacology/OSPSuite.Utility#58): since .NET Core, `Process.Start(path)` no longer shell-executes, so `TryOpenFile` threw `Win32Exception` and swallowed it. That restores *Export Simulation Model to File*, *Export Results to Excel* and *Export Model Parts to Excel*, none of which needed a MoBi code change. `OSPSuite.Utility` has to move too, otherwise MoBi's direct reference would downgrade what Core 13.0.141 pulls in.
- `BaseModuleContentView.handleLink` opens the merge behavior documentation link with its own `Process.Start` call, which the Utility fix does not cover. It now passes an explicit `ProcessStartInfo` with `UseShellExecute = true`.

`dotnet build` + `dotnet test` green: 2769 passed, 0 failed across MoBi.Tests, MoBi.UI.Tests and MoBi.R.Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
