### PR TITLE
Fixes #608 Show where a parameter is used

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1870,6 +1870,12 @@ namespace MoBi.Assets
          public static readonly string SelectOutputFolder = "Select output folder";
          public static readonly string SelectParameter = "Select parameter";
          public static readonly string ExpressionParameters = "Expression Parameters";
+         public static readonly string FindReferences = "Find References...";
+         public static readonly string UsedBy = "Used By";
+         public static readonly string UsedAs = "Used As";
+         public static readonly string Alias = "Alias";
+         public static readonly string Back = "Back";
+         public static string ReferencesTo(string path) => $"References to '{path}'";
          public static string AddBuildingBlocksToModule(string moduleName) => $"Add Building Blocks to Module:  {moduleName}";
          public static string LoadBuildingBlockToModule(string moduleName) => $"Load Building Block to Module:  {moduleName}";
 

--- a/src/MoBi.Presentation/DTO/ParameterReferenceDTO.cs
+++ b/src/MoBi.Presentation/DTO/ParameterReferenceDTO.cs
@@ -1,0 +1,36 @@
+using OSPSuite.Core.Domain;
+
+namespace MoBi.Presentation.DTO
+{
+   public class ParameterReferenceDTO
+   {
+      /// <summary>
+      ///    The object whose formula references the parameter
+      /// </summary>
+      public IUsingFormula UsedByObject { get; set; }
+
+      /// <summary>
+      ///    Path of the object whose formula references the parameter
+      /// </summary>
+      public string UsedBy { get; set; }
+
+      /// <summary>
+      ///    Type of the object whose formula references the parameter (Parameter, Observer etc.)
+      /// </summary>
+      public string Type { get; set; }
+
+      /// <summary>
+      ///    Indicates whether the parameter is referenced in the formula or in the right hand side formula
+      /// </summary>
+      public string UsedAs { get; set; }
+
+      /// <summary>
+      ///    Alias under which the parameter is used in the formula
+      /// </summary>
+      public string Alias { get; set; }
+
+      public string FormulaName { get; set; }
+
+      public string Formula { get; set; }
+   }
+}

--- a/src/MoBi.Presentation/Mappers/FormulaUsableToParameterReferenceDTOMapper.cs
+++ b/src/MoBi.Presentation/Mappers/FormulaUsableToParameterReferenceDTOMapper.cs
@@ -47,14 +47,14 @@ namespace MoBi.Presentation.Mappers
          if (formula == null)
             return;
 
-         var referencingPaths = formula.ObjectPaths.Where(path => Equals(path.TryResolve<IEntity>(usingFormula), target));
-         referencingPaths.Each(path => references.Add(new ParameterReferenceDTO
+         var referencesToTarget = formula.ObjectReferences.Where(x => Equals(x.Object, target));
+         referencesToTarget.Each(objectReference => references.Add(new ParameterReferenceDTO
          {
             UsedByObject = usingFormula,
             UsedBy = _entityPathResolver.PathFor(usingFormula),
             Type = _objectTypeResolver.TypeFor(usingFormula),
             UsedAs = usedAs,
-            Alias = path.Alias,
+            Alias = objectReference.Alias,
             FormulaName = formula.Name,
             Formula = formulaDisplayFor(formula)
          }));

--- a/src/MoBi.Presentation/Mappers/FormulaUsableToParameterReferenceDTOMapper.cs
+++ b/src/MoBi.Presentation/Mappers/FormulaUsableToParameterReferenceDTOMapper.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using MoBi.Assets;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.DTO;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Extensions;
+
+namespace MoBi.Presentation.Mappers
+{
+   public interface IFormulaUsableToParameterReferenceDTOMapper
+   {
+      /// <summary>
+      ///    Returns a reference for each formula in the model of <paramref name="simulation" /> where
+      ///    <paramref name="target" /> is referenced
+      /// </summary>
+      IReadOnlyList<ParameterReferenceDTO> MapFrom(IFormulaUsable target, IMoBiSimulation simulation);
+   }
+
+   public class FormulaUsableToParameterReferenceDTOMapper : IFormulaUsableToParameterReferenceDTOMapper
+   {
+      private readonly IEntityPathResolver _entityPathResolver;
+      private readonly IObjectTypeResolver _objectTypeResolver;
+
+      public FormulaUsableToParameterReferenceDTOMapper(IEntityPathResolver entityPathResolver, IObjectTypeResolver objectTypeResolver)
+      {
+         _entityPathResolver = entityPathResolver;
+         _objectTypeResolver = objectTypeResolver;
+      }
+
+      public IReadOnlyList<ParameterReferenceDTO> MapFrom(IFormulaUsable target, IMoBiSimulation simulation)
+      {
+         var references = new List<ParameterReferenceDTO>();
+         simulation.Model.Root.GetAllChildren<IUsingFormula>().Each(usingFormula =>
+         {
+            addReferencesFrom(usingFormula, usingFormula.Formula, AppConstants.Captions.Formula, target, references);
+            if (usingFormula is IParameter usingParameter)
+               addReferencesFrom(usingFormula, usingParameter.RHSFormula, AppConstants.Captions.RHSFormula, target, references);
+         });
+         return references.OrderBy(x => x.UsedBy).ToList();
+      }
+
+      private void addReferencesFrom(IUsingFormula usingFormula, IFormula formula, string usedAs, IFormulaUsable target, List<ParameterReferenceDTO> references)
+      {
+         if (formula == null)
+            return;
+
+         var referencingPaths = formula.ObjectPaths.Where(path => Equals(path.TryResolve<IEntity>(usingFormula), target));
+         referencingPaths.Each(path => references.Add(new ParameterReferenceDTO
+         {
+            UsedByObject = usingFormula,
+            UsedBy = _entityPathResolver.PathFor(usingFormula),
+            Type = _objectTypeResolver.TypeFor(usingFormula),
+            UsedAs = usedAs,
+            Alias = path.Alias,
+            FormulaName = formula.Name,
+            Formula = formulaDisplayFor(formula)
+         }));
+      }
+
+      private string formulaDisplayFor(IFormula formula)
+      {
+         if (formula is FormulaWithFormulaString formulaWithFormulaString)
+            return formulaWithFormulaString.FormulaString;
+
+         return _objectTypeResolver.TypeFor(formula);
+      }
+   }
+}

--- a/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditParametersInContainerPresenter.cs
@@ -69,6 +69,16 @@ namespace MoBi.Presentation.Presenter
       bool HasModules();
       bool HasBuildingBlocks();
       void NavigateToParameter(ParameterDTO parameterDTO);
+
+      /// <summary>
+      ///    Returns <c>true</c> if parameter references can be searched for, i.e. when editing a simulation
+      /// </summary>
+      bool CanFindReferences { get; }
+
+      /// <summary>
+      ///    Shows all formulas in the simulation where <paramref name="parameterDTO" /> is referenced
+      /// </summary>
+      void FindReferencesFor(ParameterDTO parameterDTO);
    }
 
    public class EditParametersInContainerPresenter : AbstractParameterBasePresenter<IEditParametersInContainerView, IEditParametersInContainerPresenter>, IEditParametersInContainerPresenter
@@ -492,6 +502,16 @@ namespace MoBi.Presentation.Presenter
       }
 
       public void EnableSimulationTracking(TrackableSimulation trackableSimulation) => _trackableSimulation = trackableSimulation;
+
+      public bool CanFindReferences => _trackableSimulation != null;
+
+      public void FindReferencesFor(ParameterDTO parameterDTO)
+      {
+         using (var referencesPresenter = _interactionTaskContext.ApplicationController.Start<IParameterReferencesPresenter>())
+         {
+            referencesPresenter.ShowReferencesTo(ParameterFrom(parameterDTO), _trackableSimulation.Simulation);
+         }
+      }
 
       public bool HasBuildingBlocks() => _allParametersDTO.Any(parameterDTO => !string.IsNullOrEmpty(parameterDTO.BuildingBlockName));
 

--- a/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
@@ -33,7 +33,7 @@ namespace MoBi.Presentation.Presenter
    {
       void LoadDiagram();
       void LoadChanges();
-      void RemoveAnalysis(ISimulationAnalysisPresenter analysisPresenter);
+      void RemoveAnalysis(ISimulationAnalysis analysis);
    }
 
    public class EditSimulationPresenter : SingleStartPresenter<IEditSimulationView, IEditSimulationPresenter>, IEditSimulationPresenter, IListener<ObservedDataRemovedFromAnalysableEvent>
@@ -130,13 +130,24 @@ namespace MoBi.Presentation.Presenter
       private void removeAndReleaseAnalysisPresenter(ISimulationAnalysisPresenter presenter)
       {
          unRegisterObservedDataEvent(presenter);
-         _view.RemoveAnalysis(presenter);
+         _view.RemoveAnalysis(presenter.Analysis);
          presenter.Clear();
          presenter.ReleaseFrom(_eventPublisher);
          _analysisPresenters.Remove(presenter);
       }
 
       public void Edit(IMoBiSimulation simulation)
+      {
+         if (Equals(_simulation, simulation))
+         {
+            _view.Display();
+            return;
+         }
+
+         edit(simulation);
+      }
+
+      private void edit(IMoBiSimulation simulation)
       {
          _simulation = simulation;
          _hierarchicalPresenter.Edit(simulation);
@@ -162,7 +173,7 @@ namespace MoBi.Presentation.Presenter
          var presenter = _simulationAnalysisPresenterFactory.PresenterFor(simulationAnalysis);
          _analysisPresenters.Add(presenter);
          registerObservedDataEvent(presenter);
-         _view.AddAnalysis(presenter);
+         _view.AddAnalysis(simulationAnalysis, presenter.BaseView);
          presenter.InitializeAnalysis(simulationAnalysis, _simulation);
       }
 
@@ -178,11 +189,17 @@ namespace MoBi.Presentation.Presenter
             chartPresenter.OnObservedDataAddedToChart += onObservedDataAddedToChart;
       }
 
-      public void RemoveAnalysis(ISimulationAnalysisPresenter analysisPresenter)
+      public void RemoveAnalysis(ISimulationAnalysis analysis)
       {
-         _simulation.RemoveAnalysis(analysisPresenter.Analysis);
+         var analysisPresenter = analysisPresenterFor(analysis);
+         if (analysisPresenter == null)
+            return;
+
+         _simulation.RemoveAnalysis(analysis);
          removeAndReleaseAnalysisPresenter(analysisPresenter);
       }
+
+      private ISimulationAnalysisPresenter analysisPresenterFor(ISimulationAnalysis analysis) => _analysisPresenters.FirstOrDefault(x => Equals(x.Analysis, analysis));
 
       public override void Edit(object subject) => Edit(subject.DowncastTo<IMoBiSimulation>());
 
@@ -277,7 +294,7 @@ namespace MoBi.Presentation.Presenter
       {
          _hierarchicalPresenter.Clear();
          _diagramLoaded = false;
-         Edit(_simulation);
+         edit(_simulation);
       }
 
       public void Handle(FavoritesSelectedEvent eventToHandle)
@@ -329,6 +346,7 @@ namespace MoBi.Presentation.Presenter
             return;
 
          addAnalysis(eventToHandle.SimulationAnalysis);
+         _view.SelectAnalysis(eventToHandle.SimulationAnalysis);
       }
 
       private bool canHandle(IObjectBaseEvent objectBaseEvent) => Equals(_simulation, objectBaseEvent.ObjectBase);

--- a/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
@@ -130,9 +130,10 @@ namespace MoBi.Presentation.Presenter
       private void removeAndReleaseAnalysisPresenter(ISimulationAnalysisPresenter presenter)
       {
          unRegisterObservedDataEvent(presenter);
-         _view.RemoveAnalysis(presenter.Analysis);
+         //the presenter needs to be cleared before the view removes and disposes the analysis tab
          presenter.Clear();
          presenter.ReleaseFrom(_eventPublisher);
+         _view.RemoveAnalysis(presenter.Analysis);
          _analysisPresenters.Remove(presenter);
       }
 

--- a/src/MoBi.Presentation/Presenter/ParameterReferencesPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/ParameterReferencesPresenter.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using System.Linq;
+using MoBi.Assets;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Views;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Utility.Extensions;
+
+namespace MoBi.Presentation.Presenter
+{
+   public interface IParameterReferencesPresenter : IDisposablePresenter
+   {
+      /// <summary>
+      ///    Shows all formulas (with the objects using them) in the model of <paramref name="simulation" /> where
+      ///    <paramref name="target" /> is referenced
+      /// </summary>
+      void ShowReferencesTo(IFormulaUsable target, IMoBiSimulation simulation);
+
+      /// <summary>
+      ///    Returns <c>true</c> if the object referenced by <paramref name="reference" /> can itself be the target of a
+      ///    reference search
+      /// </summary>
+      bool CanFindReferencesFor(ParameterReferenceDTO reference);
+
+      /// <summary>
+      ///    Drills into the references: shows all formulas referencing the object of <paramref name="reference" />
+      /// </summary>
+      void FindReferencesFor(ParameterReferenceDTO reference);
+
+      /// <summary>
+      ///    Closes the view and navigates to the object of <paramref name="reference" /> in the simulation
+      /// </summary>
+      void GoTo(ParameterReferenceDTO reference);
+
+      /// <summary>
+      ///    Shows the references to the previous target in the drill-in trail
+      /// </summary>
+      void GoBack();
+   }
+
+   public class ParameterReferencesPresenter : AbstractDisposablePresenter<IParameterReferencesView, IParameterReferencesPresenter>, IParameterReferencesPresenter
+   {
+      private readonly IEntityPathResolver _entityPathResolver;
+      private readonly IFormulaUsableToParameterReferenceDTOMapper _parameterReferenceMapper;
+      private readonly IMoBiApplicationController _applicationController;
+      private readonly IMoBiContext _context;
+      private IMoBiSimulation _simulation;
+      private IEntity _entityToNavigateTo;
+      private readonly Stack<IFormulaUsable> _targetTrail = new Stack<IFormulaUsable>();
+
+      public ParameterReferencesPresenter(
+         IParameterReferencesView view,
+         IEntityPathResolver entityPathResolver,
+         IFormulaUsableToParameterReferenceDTOMapper parameterReferenceMapper,
+         IMoBiApplicationController applicationController,
+         IMoBiContext context)
+         : base(view)
+      {
+         _entityPathResolver = entityPathResolver;
+         _parameterReferenceMapper = parameterReferenceMapper;
+         _applicationController = applicationController;
+         _context = context;
+      }
+
+      public void ShowReferencesTo(IFormulaUsable target, IMoBiSimulation simulation)
+      {
+         _simulation = simulation;
+         _targetTrail.Clear();
+         _targetTrail.Push(target);
+         showCurrentTarget();
+         _view.Display();
+
+         if (_entityToNavigateTo != null)
+            _applicationController.Select(_entityToNavigateTo, _simulation, _context.HistoryManager);
+      }
+
+      public bool CanFindReferencesFor(ParameterReferenceDTO reference) => reference.UsedByObject is IFormulaUsable;
+
+      public void FindReferencesFor(ParameterReferenceDTO reference)
+      {
+         if (!CanFindReferencesFor(reference))
+            return;
+
+         _targetTrail.Push(reference.UsedByObject.DowncastTo<IFormulaUsable>());
+         showCurrentTarget();
+      }
+
+      public void GoBack()
+      {
+         if (_targetTrail.Count <= 1)
+            return;
+
+         _targetTrail.Pop();
+         showCurrentTarget();
+      }
+
+      public void GoTo(ParameterReferenceDTO reference)
+      {
+         _entityToNavigateTo = reference.UsedByObject;
+         _view.CloseView();
+      }
+
+      private void showCurrentTarget()
+      {
+         var target = _targetTrail.Peek();
+         _view.Caption = AppConstants.Captions.ReferencesTo(_entityPathResolver.PathFor(target));
+         _view.BindTo(_parameterReferenceMapper.MapFrom(target, _simulation));
+         _view.UpdateNavigation(breadcrumb(), canGoBack: _targetTrail.Count > 1);
+      }
+
+      private string breadcrumb() => string.Join(" → ", _targetTrail.Reverse().Select(x => x.Name));
+   }
+}

--- a/src/MoBi.Presentation/Views/IEditSimulationView.cs
+++ b/src/MoBi.Presentation/Views/IEditSimulationView.cs
@@ -1,6 +1,6 @@
 ﻿using MoBi.Presentation.Presenter;
 using MoBi.Presentation.Views.BaseDiagram;
-using OSPSuite.Presentation.Presenters;
+using OSPSuite.Core.Domain;
 using OSPSuite.Presentation.Views;
 
 namespace MoBi.Presentation.Views
@@ -31,13 +31,18 @@ namespace MoBi.Presentation.Views
       void SetParametersTabEnabled(bool enabled);
 
       /// <summary>
-      ///    Adds a new analysis tab for the given presenter
+      ///    Adds a new tab for the given analysis showing <paramref name="analysisView" />
       /// </summary>
-      void AddAnalysis(ISimulationAnalysisPresenter analysisPresenter);
+      void AddAnalysis(ISimulationAnalysis analysis, IView analysisView);
 
       /// <summary>
-      ///    Removes the analysis tab for the given presenter
+      ///    Removes the tab of the given analysis
       /// </summary>
-      void RemoveAnalysis(ISimulationAnalysisPresenter analysisPresenter);
+      void RemoveAnalysis(ISimulationAnalysis analysis);
+
+      /// <summary>
+      ///    Selects the tab of the given analysis
+      /// </summary>
+      void SelectAnalysis(ISimulationAnalysis analysis);
    }
 }

--- a/src/MoBi.Presentation/Views/IParameterReferencesView.cs
+++ b/src/MoBi.Presentation/Views/IParameterReferencesView.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+using OSPSuite.Presentation.Views;
+
+namespace MoBi.Presentation.Views
+{
+   public interface IParameterReferencesView : IModalView<IParameterReferencesPresenter>
+   {
+      void BindTo(IReadOnlyList<ParameterReferenceDTO> references);
+
+      /// <summary>
+      ///    Updates the breadcrumb showing the trail of drilled-in targets and the enabled state of the back button
+      /// </summary>
+      void UpdateNavigation(string breadcrumb, bool canGoBack);
+   }
+}

--- a/src/MoBi.UI/Views/EditParametersInContainerView.cs
+++ b/src/MoBi.UI/Views/EditParametersInContainerView.cs
@@ -100,6 +100,9 @@ namespace MoBi.UI.Views
             return;
 
          e.Menu.Items.Add(copyPathMenuItem());
+
+         if (_presenter.CanFindReferences)
+            e.Menu.Items.Add(findReferencesMenuItem());
       }
 
       private DXMenuItem copyPathMenuItem()
@@ -111,7 +114,18 @@ namespace MoBi.UI.Views
          );
       }
 
+      private DXMenuItem findReferencesMenuItem()
+      {
+         return new DXMenuItem(
+            AppConstants.Captions.FindReferences,
+            (s, args) => findReferences(),
+            ApplicationIcons.Search.ToImage()
+         );
+      }
+
       private void copyPath() => _presenter.CopyPathForParameter(_gridViewBinder.FocusedElement);
+
+      private void findReferences() => _presenter.FindReferencesFor(_gridViewBinder.FocusedElement);
 
       private void hideEditor() => _unitControl.Hide();
 

--- a/src/MoBi.UI/Views/ParameterReferencesView.Designer.cs
+++ b/src/MoBi.UI/Views/ParameterReferencesView.Designer.cs
@@ -1,0 +1,184 @@
+namespace MoBi.UI.Views
+{
+   partial class ParameterReferencesView
+   {
+      /// <summary>
+      /// Required designer variable.
+      /// </summary>
+      private System.ComponentModel.IContainer components = null;
+
+      /// <summary>
+      /// Clean up any resources being used.
+      /// </summary>
+      /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+      protected override void Dispose(bool disposing)
+      {
+         if (disposing && (components != null))
+         {
+            components.Dispose();
+         }
+         _gridViewBinder.Dispose();
+         base.Dispose(disposing);
+      }
+
+      #region Component Designer generated code
+
+      /// <summary>
+      /// Required method for Designer support - do not modify
+      /// the contents of this method with the code editor.
+      /// </summary>
+      private void InitializeComponent()
+      {
+         this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.gridControl = new OSPSuite.UI.Controls.UxGridControl();
+         this.gridView = new MoBi.UI.Views.UxGridView();
+         this.btnBack = new DevExpress.XtraEditors.SimpleButton();
+         this.lblBreadcrumb = new DevExpress.XtraEditors.LabelControl();
+         this.layoutControlGroup = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.layoutControlItemBack = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutControlItemBreadcrumb = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutControlItemReferences = new DevExpress.XtraLayout.LayoutControlItem();
+         ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
+         this.layoutControl.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.gridControl)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.gridView)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemBack)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemBreadcrumb)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemReferences)).BeginInit();
+         this.SuspendLayout();
+         //
+         // layoutControl
+         //
+         this.layoutControl.Controls.Add(this.btnBack);
+         this.layoutControl.Controls.Add(this.lblBreadcrumb);
+         this.layoutControl.Controls.Add(this.gridControl);
+         this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.layoutControl.Location = new System.Drawing.Point(0, 0);
+         this.layoutControl.Name = "layoutControl";
+         this.layoutControl.Root = this.layoutControlGroup;
+         this.layoutControl.Size = new System.Drawing.Size(984, 515);
+         this.layoutControl.TabIndex = 1;
+         this.layoutControl.Text = "layoutControl";
+         //
+         // btnBack
+         //
+         this.btnBack.Location = new System.Drawing.Point(12, 12);
+         this.btnBack.Name = "btnBack";
+         this.btnBack.Size = new System.Drawing.Size(96, 22);
+         this.btnBack.StyleController = this.layoutControl;
+         this.btnBack.TabIndex = 5;
+         this.btnBack.Text = "btnBack";
+         //
+         // lblBreadcrumb
+         //
+         this.lblBreadcrumb.Location = new System.Drawing.Point(112, 17);
+         this.lblBreadcrumb.Name = "lblBreadcrumb";
+         this.lblBreadcrumb.Size = new System.Drawing.Size(860, 13);
+         this.lblBreadcrumb.StyleController = this.layoutControl;
+         this.lblBreadcrumb.TabIndex = 6;
+         this.lblBreadcrumb.Text = "lblBreadcrumb";
+         //
+         // gridControl
+         //
+         this.gridControl.Location = new System.Drawing.Point(12, 38);
+         this.gridControl.MainView = this.gridView;
+         this.gridControl.Name = "gridControl";
+         this.gridControl.Size = new System.Drawing.Size(960, 465);
+         this.gridControl.TabIndex = 4;
+         this.gridControl.ViewCollection.AddRange(new DevExpress.XtraGrid.Views.Base.BaseView[] {
+            this.gridView});
+         //
+         // gridView
+         //
+         this.gridView.GridControl = this.gridControl;
+         this.gridView.Name = "gridView";
+         this.gridView.RowsInsertable = false;
+         //
+         // layoutControlGroup
+         //
+         this.layoutControlGroup.CustomizationFormText = "layoutControlGroup";
+         this.layoutControlGroup.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
+         this.layoutControlGroup.GroupBordersVisible = false;
+         this.layoutControlGroup.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutControlItemBack,
+            this.layoutControlItemBreadcrumb,
+            this.layoutControlItemReferences});
+         this.layoutControlGroup.Location = new System.Drawing.Point(0, 0);
+         this.layoutControlGroup.Name = "layoutControlGroup";
+         this.layoutControlGroup.Size = new System.Drawing.Size(984, 515);
+         this.layoutControlGroup.Text = "layoutControlGroup";
+         this.layoutControlGroup.TextVisible = false;
+         //
+         // layoutControlItemBack
+         //
+         this.layoutControlItemBack.Control = this.btnBack;
+         this.layoutControlItemBack.CustomizationFormText = "layoutControlItemBack";
+         this.layoutControlItemBack.Location = new System.Drawing.Point(0, 0);
+         this.layoutControlItemBack.Name = "layoutControlItemBack";
+         this.layoutControlItemBack.Size = new System.Drawing.Size(100, 26);
+         this.layoutControlItemBack.SizeConstraintsType = DevExpress.XtraLayout.SizeConstraintsType.Custom;
+         this.layoutControlItemBack.Text = "layoutControlItemBack";
+         this.layoutControlItemBack.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutControlItemBack.TextToControlDistance = 0;
+         this.layoutControlItemBack.TextVisible = false;
+         //
+         // layoutControlItemBreadcrumb
+         //
+         this.layoutControlItemBreadcrumb.Control = this.lblBreadcrumb;
+         this.layoutControlItemBreadcrumb.CustomizationFormText = "layoutControlItemBreadcrumb";
+         this.layoutControlItemBreadcrumb.Location = new System.Drawing.Point(100, 0);
+         this.layoutControlItemBreadcrumb.Name = "layoutControlItemBreadcrumb";
+         this.layoutControlItemBreadcrumb.Size = new System.Drawing.Size(864, 26);
+         this.layoutControlItemBreadcrumb.Text = "layoutControlItemBreadcrumb";
+         this.layoutControlItemBreadcrumb.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutControlItemBreadcrumb.TextToControlDistance = 0;
+         this.layoutControlItemBreadcrumb.TextVisible = false;
+         //
+         // layoutControlItemReferences
+         //
+         this.layoutControlItemReferences.Control = this.gridControl;
+         this.layoutControlItemReferences.CustomizationFormText = "layoutControlItemReferences";
+         this.layoutControlItemReferences.Location = new System.Drawing.Point(0, 26);
+         this.layoutControlItemReferences.Name = "layoutControlItemReferences";
+         this.layoutControlItemReferences.Size = new System.Drawing.Size(964, 469);
+         this.layoutControlItemReferences.Text = "layoutControlItemReferences";
+         this.layoutControlItemReferences.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutControlItemReferences.TextToControlDistance = 0;
+         this.layoutControlItemReferences.TextVisible = false;
+         //
+         // ParameterReferencesView
+         //
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.ClientSize = new System.Drawing.Size(984, 561);
+         this.Controls.Add(this.layoutControl);
+         this.Name = "ParameterReferencesView";
+         this.Controls.SetChildIndex(this.layoutControl, 0);
+         ((System.ComponentModel.ISupportInitialize)(this._errorProvider)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
+         this.layoutControl.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.gridControl)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.gridView)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemBack)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemBreadcrumb)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlItemReferences)).EndInit();
+         this.ResumeLayout(false);
+
+      }
+
+      #endregion
+
+      private OSPSuite.UI.Controls.UxLayoutControl layoutControl;
+      private DevExpress.XtraLayout.LayoutControlGroup layoutControlGroup;
+      private OSPSuite.UI.Controls.UxGridControl gridControl;
+      private UxGridView gridView;
+      private DevExpress.XtraEditors.SimpleButton btnBack;
+      private DevExpress.XtraEditors.LabelControl lblBreadcrumb;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlItemBack;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlItemBreadcrumb;
+      private DevExpress.XtraLayout.LayoutControlItem layoutControlItemReferences;
+   }
+}

--- a/src/MoBi.UI/Views/ParameterReferencesView.cs
+++ b/src/MoBi.UI/Views/ParameterReferencesView.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using DevExpress.Utils;
+using DevExpress.Utils.Menu;
+using DevExpress.XtraGrid.Views.Grid;
+using DevExpress.XtraGrid.Views.Grid.ViewInfo;
+using MoBi.Assets;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+using OSPSuite.Assets;
+using OSPSuite.DataBinding.DevExpress;
+using OSPSuite.DataBinding.DevExpress.XtraGrid;
+using OSPSuite.Presentation.Extensions;
+using OSPSuite.UI.Extensions;
+using OSPSuite.UI.Views;
+
+namespace MoBi.UI.Views
+{
+   public partial class ParameterReferencesView : BaseModalView, IParameterReferencesView
+   {
+      private readonly GridViewBinder<ParameterReferenceDTO> _gridViewBinder;
+      private IParameterReferencesPresenter _presenter;
+
+      public ParameterReferencesView()
+      {
+         InitializeComponent();
+         _gridViewBinder = new GridViewBinder<ParameterReferenceDTO>(gridView);
+         gridView.OptionsBehavior.Editable = false;
+         gridView.OptionsView.ShowGroupPanel = false;
+         gridView.PopupMenuShowing += OnPopupMenuShowing;
+         gridControl.MouseDoubleClick += (o, e) => OnEvent(() => onDoubleClick(e));
+         btnBack.Click += (o, e) => OnEvent(() => _presenter.GoBack());
+      }
+
+      public void AttachPresenter(IParameterReferencesPresenter presenter) => _presenter = presenter;
+
+      public override void InitializeBinding()
+      {
+         base.InitializeBinding();
+
+         _gridViewBinder.Bind(x => x.UsedBy)
+            .WithCaption(AppConstants.Captions.UsedBy)
+            .AsReadOnly();
+
+         _gridViewBinder.Bind(x => x.Type)
+            .WithCaption(AppConstants.Captions.Type)
+            .AsReadOnly();
+
+         _gridViewBinder.Bind(x => x.UsedAs)
+            .WithCaption(AppConstants.Captions.UsedAs)
+            .AsReadOnly();
+
+         _gridViewBinder.Bind(x => x.Alias)
+            .WithCaption(AppConstants.Captions.Alias)
+            .AsReadOnly();
+
+         _gridViewBinder.Bind(x => x.FormulaName)
+            .WithCaption(AppConstants.Captions.FormulaName)
+            .AsReadOnly();
+
+         _gridViewBinder.Bind(x => x.Formula)
+            .WithCaption(AppConstants.Captions.Formula)
+            .AsReadOnly();
+      }
+
+      public override void InitializeResources()
+      {
+         base.InitializeResources();
+         CancelVisible = false;
+         ExtraVisible = true;
+         ExtraCaption = AppConstants.MenuNames.GoTo;
+         btnBack.InitWithImage(ApplicationIcons.Back, AppConstants.Captions.Back);
+         layoutControlItemBack.AdjustButtonSize(layoutControl);
+
+         // This aligns the breadcrumb text with the taller back button in the same row
+         layoutControlItemBack.ContentVertAlignment = VertAlignment.Center;
+         layoutControlItemBreadcrumb.ContentVertAlignment = VertAlignment.Center;
+      }
+
+      protected override void ExtraClicked() => _presenter.GoTo(_gridViewBinder.FocusedElement);
+
+      private void onDoubleClick(MouseEventArgs e)
+      {
+         var reference = _gridViewBinder.ElementAt(gridView.RowHandleAt(e));
+         if (reference == null)
+            return;
+
+         _presenter.FindReferencesFor(reference);
+      }
+
+      public void UpdateNavigation(string breadcrumb, bool canGoBack)
+      {
+         lblBreadcrumb.Text = breadcrumb;
+         btnBack.Enabled = canGoBack;
+      }
+
+      private void OnPopupMenuShowing(object sender, PopupMenuShowingEventArgs e)
+      {
+         if (e.HitInfo.HitTest != GridHitTest.RowIndicator || !e.Menu.Items.Any() || gridView.GetSelectedRows().Length != 1)
+            return;
+
+         //first menu entry: by convention this is the action also triggered by double click
+         if (_presenter.CanFindReferencesFor(_gridViewBinder.FocusedElement))
+            e.Menu.Items.Insert(0, findReferencesMenuItem());
+      }
+
+      private DXMenuItem findReferencesMenuItem()
+      {
+         return new DXMenuItem(
+            AppConstants.Captions.FindReferences,
+            (s, args) => findReferences(),
+            ApplicationIcons.Search.ToImage()
+         );
+      }
+
+      private void findReferences() => _presenter.FindReferencesFor(_gridViewBinder.FocusedElement);
+
+      public void BindTo(IReadOnlyList<ParameterReferenceDTO> references)
+      {
+         _gridViewBinder.BindToSource(references);
+         ExtraEnabled = references.Any();
+         gridView.BestFitColumns();
+      }
+   }
+}

--- a/src/MoBi.UI/Views/ParameterReferencesView.resx
+++ b/src/MoBi.UI/Views/ParameterReferencesView.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/MoBi.UI/Views/SimulationView/EditSimulationView.cs
+++ b/src/MoBi.UI/Views/SimulationView/EditSimulationView.cs
@@ -105,7 +105,9 @@ namespace MoBi.UI.Views.SimulationView
          page.Tag = analysis;
          page.ShowCloseButton = DefaultBoolean.True;
          page.InitializeFrom(analysisView);
-         analysisView.CaptionChanged += (o, e) => page.Text = analysisView.Caption;
+         EventHandler captionChanged = (o, e) => page.Text = analysisView.Caption;
+         analysisView.CaptionChanged += captionChanged;
+         page.Disposed += (o, e) => analysisView.CaptionChanged -= captionChanged;
 
          var changesIndex = tabs.TabPages.IndexOf(tabChanges);
          tabs.TabPages.Insert(changesIndex, page);
@@ -118,6 +120,7 @@ namespace MoBi.UI.Views.SimulationView
             return;
 
          tabs.TabPages.Remove(tab);
+         tab.Dispose();
       }
 
       public void SelectAnalysis(ISimulationAnalysis analysis)

--- a/src/MoBi.UI/Views/SimulationView/EditSimulationView.cs
+++ b/src/MoBi.UI/Views/SimulationView/EditSimulationView.cs
@@ -10,7 +10,7 @@ using MoBi.Presentation.Views;
 using MoBi.Presentation.Views.BaseDiagram;
 using MoBi.UI.Extensions;
 using OSPSuite.Assets;
-using OSPSuite.Presentation.Presenters;
+using OSPSuite.Core.Domain;
 using OSPSuite.Presentation.Views;
 using OSPSuite.UI.Extensions;
 using OSPSuite.UI.Views;
@@ -64,10 +64,10 @@ namespace MoBi.UI.Views.SimulationView
       private void closeButtonClick(ClosePageButtonEventArgs e)
       {
          var closingTab = e.Page as XtraTabPage;
-         if (closingTab?.Tag is not ISimulationAnalysisPresenter analysisPresenter)
+         if (closingTab?.Tag is not ISimulationAnalysis analysis)
             return;
 
-         simulationPresenter.RemoveAnalysis(analysisPresenter);
+         simulationPresenter.RemoveAnalysis(analysis);
       }
 
       public void SetEditView(IView view)
@@ -90,36 +90,46 @@ namespace MoBi.UI.Views.SimulationView
          spliterDiagram.Panel2.FillWith(subView);
       }
 
-      public bool ShowsResults => tabs.SelectedTabPage?.Tag is ISimulationAnalysisPresenter;
+      public bool ShowsResults => tabs.SelectedTabPage?.Tag is ISimulationAnalysis;
 
       public void ShowResultsTab()
       {
-         var firstAnalysisTab = tabs.TabPages.FirstOrDefault(x => x.Tag is ISimulationAnalysisPresenter);
+         var firstAnalysisTab = tabs.TabPages.FirstOrDefault(x => x.Tag is ISimulationAnalysis);
          if (firstAnalysisTab != null)
             tabs.SelectedTabPage = firstAnalysisTab;
       }
 
-      public void AddAnalysis(ISimulationAnalysisPresenter analysisPresenter)
+      public void AddAnalysis(ISimulationAnalysis analysis, IView analysisView)
       {
          var page = new XtraTabPage();
-         page.Tag = analysisPresenter;
+         page.Tag = analysis;
          page.ShowCloseButton = DefaultBoolean.True;
-         page.InitializeFrom(analysisPresenter.BaseView);
-         analysisPresenter.BaseView.CaptionChanged += (o, e) => page.Text = analysisPresenter.BaseView.Caption;
+         page.InitializeFrom(analysisView);
+         analysisView.CaptionChanged += (o, e) => page.Text = analysisView.Caption;
 
          var changesIndex = tabs.TabPages.IndexOf(tabChanges);
          tabs.TabPages.Insert(changesIndex, page);
-         tabs.SelectedTabPage = page;
       }
 
-      public void RemoveAnalysis(ISimulationAnalysisPresenter analysisPresenter)
+      public void RemoveAnalysis(ISimulationAnalysis analysis)
       {
-         var tab = tabs.TabPages.FirstOrDefault(x => Equals(x.Tag, analysisPresenter));
+         var tab = tabPageFor(analysis);
          if (tab == null)
             return;
 
          tabs.TabPages.Remove(tab);
       }
+
+      public void SelectAnalysis(ISimulationAnalysis analysis)
+      {
+         var tab = tabPageFor(analysis);
+         if (tab == null)
+            return;
+
+         tabs.SelectedTabPage = tab;
+      }
+
+      private XtraTabPage tabPageFor(ISimulationAnalysis analysis) => tabs.TabPages.FirstOrDefault(x => Equals(x.Tag, analysis));
 
       public void ShowChangesTab()
       {

--- a/tests/MoBi.Tests/Presentation/EditParametersInContainerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditParametersInContainerPresenterSpecs.cs
@@ -661,4 +661,48 @@ namespace MoBi.Presentation
          A.CallTo(() => _sourceReferenceNavigator.GoTo(_parameterDTO.SourceReference)).MustHaveHappened();
       }
    }
+
+   public class When_checking_if_references_can_be_found : concern_for_EditParametersInContainerPresenter
+   {
+      [Observation]
+      public void should_not_allow_the_reference_search_when_not_editing_a_simulation()
+      {
+         sut.CanFindReferences.ShouldBeFalse();
+      }
+
+      [Observation]
+      public void should_allow_the_reference_search_when_editing_a_simulation()
+      {
+         sut.EnableSimulationTracking(new TrackableSimulation(A.Fake<IMoBiSimulation>(), new SimulationEntitySourceReferenceCache()));
+         sut.CanFindReferences.ShouldBeTrue();
+      }
+   }
+
+   public class When_finding_the_references_for_a_parameter : concern_for_EditParametersInContainerPresenter
+   {
+      private ParameterDTO _parameterDTO;
+      private IParameterReferencesPresenter _referencesPresenter;
+      private TrackableSimulation _trackableSimulation;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameterDTO = new ParameterDTO(_parameter);
+         _referencesPresenter = A.Fake<IParameterReferencesPresenter>();
+         A.CallTo(() => _interactionTaskContext.ApplicationController.Start<IParameterReferencesPresenter>()).Returns(_referencesPresenter);
+         _trackableSimulation = new TrackableSimulation(A.Fake<IMoBiSimulation>(), new SimulationEntitySourceReferenceCache());
+         sut.EnableSimulationTracking(_trackableSimulation);
+      }
+
+      protected override void Because()
+      {
+         sut.FindReferencesFor(_parameterDTO);
+      }
+
+      [Observation]
+      public void should_show_the_references_to_the_parameter_in_the_simulation()
+      {
+         A.CallTo(() => _referencesPresenter.ShowReferencesTo(_parameter, _trackableSimulation.Simulation)).MustHaveHappened();
+      }
+   }
 }

--- a/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
@@ -321,9 +321,10 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void should_clear_the_presenter()
+      public void should_clear_the_presenter_before_removing_the_tab_from_the_view()
       {
-         A.CallTo(() => _analysisPresenter.Clear()).MustHaveHappened();
+         A.CallTo(() => _analysisPresenter.Clear()).MustHaveHappened()
+            .Then(A.CallTo(() => _view.RemoveAnalysis(_chart)).MustHaveHappened());
       }
 
       [Observation]

--- a/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
@@ -132,8 +132,14 @@ namespace MoBi.Presentation
       [Observation]
       public void should_add_each_analysis_to_the_view()
       {
-         A.CallTo(() => _view.AddAnalysis(_timeProfilePresenter)).MustHaveHappened();
-         A.CallTo(() => _view.AddAnalysis(_predictedVsObservedPresenter)).MustHaveHappened();
+         A.CallTo(() => _view.AddAnalysis(_timeProfileChart, _timeProfilePresenter.BaseView)).MustHaveHappened();
+         A.CallTo(() => _view.AddAnalysis(_predictedVsObservedChart, _predictedVsObservedPresenter.BaseView)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_not_select_any_analysis_tab()
+      {
+         A.CallTo(() => _view.SelectAnalysis(A<ISimulationAnalysis>._)).MustNotHaveHappened();
       }
    }
 
@@ -156,7 +162,48 @@ namespace MoBi.Presentation
       [Observation]
       public void should_not_add_any_analysis_to_the_view()
       {
-         A.CallTo(() => _view.AddAnalysis(A<ISimulationAnalysisPresenter>._)).MustNotHaveHappened();
+         A.CallTo(() => _view.AddAnalysis(A<ISimulationAnalysis>._, A<IView>._)).MustNotHaveHappened();
+      }
+   }
+
+   public class When_editing_the_simulation_that_is_already_edited : concern_for_EditSimulationPresenter
+   {
+      private IMoBiSimulation _simulation;
+      private ISimulationAnalysisPresenter _analysisPresenter;
+      private MoBiSimulationTimeProfileChart _chart;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = A.Fake<IMoBiSimulation>();
+         _chart = new MoBiSimulationTimeProfileChart();
+         A.CallTo(() => _simulation.Analyses).Returns(new ISimulationAnalysis[] { _chart });
+         _analysisPresenter = A.Fake<ISimulationAnalysisPresenter>();
+         A.CallTo(() => _simulationAnalysisPresenterFactory.PresenterFor(_chart)).Returns(_analysisPresenter);
+         sut.Edit(_simulation);
+      }
+
+      protected override void Because()
+      {
+         sut.Edit(_simulation);
+      }
+
+      [Observation]
+      public void should_not_reset_the_view_by_reloading_the_analyses()
+      {
+         A.CallTo(() => _view.AddAnalysis(_chart, _analysisPresenter.BaseView)).MustHaveHappenedOnceExactly();
+      }
+
+      [Observation]
+      public void should_not_rebuild_the_simulation_hierarchy()
+      {
+         A.CallTo(() => _hierarchicalSimulationPresenter.Edit(_simulation)).MustHaveHappenedOnceExactly();
+      }
+
+      [Observation]
+      public void should_still_display_the_view()
+      {
+         A.CallTo(() => _view.Display()).MustHaveHappenedTwiceExactly();
       }
    }
 
@@ -198,7 +245,13 @@ namespace MoBi.Presentation
       [Observation]
       public void should_add_the_analysis_to_the_view()
       {
-         A.CallTo(() => _view.AddAnalysis(_analysisPresenter)).MustHaveHappened();
+         A.CallTo(() => _view.AddAnalysis(_chart, _analysisPresenter.BaseView)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_select_the_tab_of_the_new_analysis()
+      {
+         A.CallTo(() => _view.SelectAnalysis(_chart)).MustHaveHappened();
       }
    }
 
@@ -226,7 +279,7 @@ namespace MoBi.Presentation
       [Observation]
       public void should_not_add_any_analysis_to_the_view()
       {
-         A.CallTo(() => _view.AddAnalysis(A<ISimulationAnalysisPresenter>._)).MustNotHaveHappened();
+         A.CallTo(() => _view.AddAnalysis(A<ISimulationAnalysis>._, A<IView>._)).MustNotHaveHappened();
       }
    }
 
@@ -252,7 +305,7 @@ namespace MoBi.Presentation
 
       protected override void Because()
       {
-         sut.RemoveAnalysis(_analysisPresenter);
+         sut.RemoveAnalysis(_chart);
       }
 
       [Observation]
@@ -264,7 +317,7 @@ namespace MoBi.Presentation
       [Observation]
       public void should_remove_the_analysis_from_the_view()
       {
-         A.CallTo(() => _view.RemoveAnalysis(_analysisPresenter)).MustHaveHappened();
+         A.CallTo(() => _view.RemoveAnalysis(_chart)).MustHaveHappened();
       }
 
       [Observation]

--- a/tests/MoBi.Tests/Presentation/Mapper/FormulaUsableToParameterReferenceDTOMapperSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Mapper/FormulaUsableToParameterReferenceDTOMapperSpecs.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using MoBi.Assets;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Core.Domain.Services;
+
+namespace MoBi.Presentation.Mapper
+{
+   public abstract class concern_for_FormulaUsableToParameterReferenceDTOMapper : ContextSpecification<FormulaUsableToParameterReferenceDTOMapper>
+   {
+      protected IObjectTypeResolver _objectTypeResolver;
+      protected IMoBiSimulation _simulation;
+      protected IParameter _parameter;
+      protected IParameter _referencingParameter;
+      protected IReadOnlyList<ParameterReferenceDTO> _result;
+
+      protected override void Context()
+      {
+         _objectTypeResolver = A.Fake<IObjectTypeResolver>();
+         sut = new FormulaUsableToParameterReferenceDTOMapper(new EntityPathResolver(new ObjectPathFactory(new AliasCreator())), _objectTypeResolver);
+
+         var root = new Container { ContainerType = ContainerType.Simulation }.WithName("Sim");
+         var organism = new Container().WithName("Organism");
+         root.Add(organism);
+
+         _parameter = new Parameter().WithName("P");
+         organism.Add(_parameter);
+
+         //references the parameter with an absolute path
+         var referencingFormula = new ExplicitFormula("P * 2").WithName("F1");
+         referencingFormula.AddObjectPath(new FormulaUsablePath("Sim", "Organism", "P").WithAlias("P"));
+         _referencingParameter = new Parameter().WithName("P2").WithFormula(referencingFormula);
+         organism.Add(_referencingParameter);
+
+         //references the parameter in the RHS formula with a relative path
+         var rhsFormula = new ExplicitFormula("P + 1").WithName("F2");
+         rhsFormula.AddObjectPath(new FormulaUsablePath(ObjectPath.PARENT_CONTAINER, "P").WithAlias("PRel"));
+         var parameterWithRHS = new Parameter().WithName("P3").WithFormula(new ConstantFormula(1));
+         parameterWithRHS.RHSFormula = rhsFormula;
+         organism.Add(parameterWithRHS);
+
+         //references another parameter
+         var otherFormula = new ExplicitFormula("Q * 2").WithName("F3");
+         otherFormula.AddObjectPath(new FormulaUsablePath("Sim", "Organism", "Q").WithAlias("Q"));
+         organism.Add(new Parameter().WithName("P4").WithFormula(otherFormula));
+
+         _simulation = A.Fake<IMoBiSimulation>();
+         A.CallTo(() => _simulation.Model).Returns(new Model { Root = root });
+      }
+   }
+
+   public class When_mapping_the_references_to_a_parameter_used_in_a_simulation : concern_for_FormulaUsableToParameterReferenceDTOMapper
+   {
+      protected override void Because()
+      {
+         _result = sut.MapFrom(_parameter, _simulation);
+      }
+
+      [Observation]
+      public void should_map_the_object_referencing_the_parameter_in_its_formula()
+      {
+         var reference = _result.Single(x => string.Equals(x.UsedBy, "Organism|P2"));
+         reference.UsedByObject.ShouldBeEqualTo(_referencingParameter);
+         reference.UsedAs.ShouldBeEqualTo(AppConstants.Captions.Formula);
+         reference.Alias.ShouldBeEqualTo("P");
+         reference.FormulaName.ShouldBeEqualTo("F1");
+         reference.Formula.ShouldBeEqualTo("P * 2");
+      }
+
+      [Observation]
+      public void should_map_the_object_referencing_the_parameter_in_its_right_hand_side_formula()
+      {
+         var reference = _result.Single(x => string.Equals(x.UsedBy, "Organism|P3"));
+         reference.UsedAs.ShouldBeEqualTo(AppConstants.Captions.RHSFormula);
+         reference.Alias.ShouldBeEqualTo("PRel");
+         reference.FormulaName.ShouldBeEqualTo("F2");
+      }
+
+      [Observation]
+      public void should_not_map_objects_that_do_not_reference_the_parameter()
+      {
+         _result.Count.ShouldBeEqualTo(2);
+      }
+   }
+
+   public class When_mapping_the_references_to_a_parameter_that_is_not_used_anywhere : concern_for_FormulaUsableToParameterReferenceDTOMapper
+   {
+      protected override void Because()
+      {
+         _result = sut.MapFrom(_referencingParameter, _simulation);
+      }
+
+      [Observation]
+      public void should_return_an_empty_list()
+      {
+         _result.ShouldBeEmpty();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/Mapper/FormulaUsableToParameterReferenceDTOMapperSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Mapper/FormulaUsableToParameterReferenceDTOMapperSpecs.cs
@@ -30,7 +30,7 @@ namespace MoBi.Presentation.Mapper
          var organism = new Container().WithName("Organism");
          root.Add(organism);
 
-         _parameter = new Parameter().WithName("P");
+         _parameter = new Parameter().WithName("P").WithFormula(new ConstantFormula(1));
          organism.Add(_parameter);
 
          //references the parameter with an absolute path
@@ -47,9 +47,12 @@ namespace MoBi.Presentation.Mapper
          organism.Add(parameterWithRHS);
 
          //references another parameter
+         organism.Add(new Parameter().WithName("Q").WithFormula(new ConstantFormula(2)));
          var otherFormula = new ExplicitFormula("Q * 2").WithName("F3");
          otherFormula.AddObjectPath(new FormulaUsablePath("Sim", "Organism", "Q").WithAlias("Q"));
          organism.Add(new Parameter().WithName("P4").WithFormula(otherFormula));
+
+         new ReferencesResolver().ResolveReferencesIn(root);
 
          _simulation = A.Fake<IMoBiSimulation>();
          A.CallTo(() => _simulation.Model).Returns(new Model { Root = root });

--- a/tests/MoBi.Tests/Presentation/ParameterReferencesPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ParameterReferencesPresenterSpecs.cs
@@ -60,7 +60,7 @@ namespace MoBi.Presentation
          var organism = new Container().WithName("Organism");
          root.Add(organism);
 
-         _parameter = new Parameter().WithName("P");
+         _parameter = new Parameter().WithName("P").WithFormula(new ConstantFormula(1));
          organism.Add(_parameter);
 
          //references the parameter with an absolute path
@@ -80,6 +80,8 @@ namespace MoBi.Presentation
          var indirectFormula = new ExplicitFormula("P2 * 3").WithName("F4");
          indirectFormula.AddObjectPath(new FormulaUsablePath("Sim", "Organism", "P2").WithAlias("P2"));
          organism.Add(new Parameter().WithName("P5").WithFormula(indirectFormula));
+
+         new ReferencesResolver().ResolveReferencesIn(root);
 
          _simulation = A.Fake<IMoBiSimulation>();
          A.CallTo(() => _simulation.Model).Returns(new Model { Root = root });

--- a/tests/MoBi.Tests/Presentation/ParameterReferencesPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ParameterReferencesPresenterSpecs.cs
@@ -1,0 +1,231 @@
+using System.Collections.Generic;
+using System.Linq;
+using FakeItEasy;
+using MoBi.Assets;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Core.Domain.Services;
+
+namespace MoBi.Presentation
+{
+   public abstract class concern_for_ParameterReferencesPresenter : ContextSpecification<ParameterReferencesPresenter>
+   {
+      protected IParameterReferencesView _view;
+      protected IObjectTypeResolver _objectTypeResolver;
+      protected IMoBiApplicationController _applicationController;
+      protected IMoBiContext _context;
+      protected IMoBiSimulation _simulation;
+      protected IParameter _parameter;
+      protected IReadOnlyList<ParameterReferenceDTO> _boundReferences;
+      protected string _breadcrumb;
+      protected bool _canGoBack;
+
+      protected override void Context()
+      {
+         _view = A.Fake<IParameterReferencesView>();
+         _objectTypeResolver = A.Fake<IObjectTypeResolver>();
+         _applicationController = A.Fake<IMoBiApplicationController>();
+         _context = A.Fake<IMoBiContext>();
+
+         A.CallTo(() => _view.BindTo(A<IReadOnlyList<ParameterReferenceDTO>>._))
+            .Invokes(x => _boundReferences = x.GetArgument<IReadOnlyList<ParameterReferenceDTO>>(0));
+
+         A.CallTo(() => _view.UpdateNavigation(A<string>._, A<bool>._))
+            .Invokes(x =>
+            {
+               _breadcrumb = x.GetArgument<string>(0);
+               _canGoBack = x.GetArgument<bool>(1);
+            });
+
+         var entityPathResolver = new EntityPathResolver(new ObjectPathFactory(new AliasCreator()));
+         sut = new ParameterReferencesPresenter(_view, entityPathResolver, new FormulaUsableToParameterReferenceDTOMapper(entityPathResolver, _objectTypeResolver), _applicationController, _context);
+      }
+   }
+
+   public abstract class concern_for_ParameterReferencesPresenter_with_a_simulation : concern_for_ParameterReferencesPresenter
+   {
+      protected IParameter _referencingParameter;
+
+      protected override void Context()
+      {
+         base.Context();
+         var root = new Container { ContainerType = ContainerType.Simulation }.WithName("Sim");
+         var organism = new Container().WithName("Organism");
+         root.Add(organism);
+
+         _parameter = new Parameter().WithName("P");
+         organism.Add(_parameter);
+
+         //references the parameter with an absolute path
+         var referencingFormula = new ExplicitFormula("P * 2").WithName("F1");
+         referencingFormula.AddObjectPath(new FormulaUsablePath("Sim", "Organism", "P").WithAlias("P"));
+         _referencingParameter = new Parameter().WithName("P2").WithFormula(referencingFormula);
+         organism.Add(_referencingParameter);
+
+         //references the parameter in the RHS formula
+         var rhsFormula = new ExplicitFormula("P + 1").WithName("F2");
+         rhsFormula.AddObjectPath(new FormulaUsablePath(ObjectPath.PARENT_CONTAINER, "P").WithAlias("PRel"));
+         var parameterWithRHS = new Parameter().WithName("P3").WithFormula(new ConstantFormula(1));
+         parameterWithRHS.RHSFormula = rhsFormula;
+         organism.Add(parameterWithRHS);
+
+         //references the referencing parameter (indirect reference to the parameter)
+         var indirectFormula = new ExplicitFormula("P2 * 3").WithName("F4");
+         indirectFormula.AddObjectPath(new FormulaUsablePath("Sim", "Organism", "P2").WithAlias("P2"));
+         organism.Add(new Parameter().WithName("P5").WithFormula(indirectFormula));
+
+         _simulation = A.Fake<IMoBiSimulation>();
+         A.CallTo(() => _simulation.Model).Returns(new Model { Root = root });
+      }
+   }
+
+   public class When_showing_the_references_to_a_parameter_used_in_a_simulation : concern_for_ParameterReferencesPresenter_with_a_simulation
+   {
+      protected override void Because()
+      {
+         sut.ShowReferencesTo(_parameter, _simulation);
+      }
+
+      [Observation]
+      public void should_display_the_view()
+      {
+         A.CallTo(() => _view.Display()).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_bind_the_references_to_the_view()
+      {
+         _boundReferences.Select(x => x.UsedBy).ShouldOnlyContain("Organism|P2", "Organism|P3");
+      }
+
+      [Observation]
+      public void should_not_navigate_to_any_object()
+      {
+         A.CallTo(() => _applicationController.Select(A<IObjectBase>._, A<IObjectBase>._, A<OSPSuite.Core.Commands.Core.ICommandCollector>._)).MustNotHaveHappened();
+      }
+
+      [Observation]
+      public void should_show_the_target_as_breadcrumb_and_not_allow_going_back()
+      {
+         _breadcrumb.ShouldBeEqualTo("P");
+         _canGoBack.ShouldBeFalse();
+      }
+   }
+
+   public class When_drilling_into_the_references_of_a_referencing_object : concern_for_ParameterReferencesPresenter_with_a_simulation
+   {
+      protected override void Because()
+      {
+         sut.ShowReferencesTo(_parameter, _simulation);
+         sut.FindReferencesFor(_boundReferences.Single(x => string.Equals(x.UsedBy, "Organism|P2")));
+      }
+
+      [Observation]
+      public void should_show_the_references_to_the_object_of_the_selected_reference()
+      {
+         _boundReferences.Single().UsedBy.ShouldBeEqualTo("Organism|P5");
+      }
+
+      [Observation]
+      public void should_update_the_caption_to_the_new_target()
+      {
+         _view.Caption.ShouldBeEqualTo(AppConstants.Captions.ReferencesTo("Organism|P2"));
+      }
+
+      [Observation]
+      public void should_show_the_drill_in_trail_as_breadcrumb_and_allow_going_back()
+      {
+         _breadcrumb.ShouldBeEqualTo("P → P2");
+         _canGoBack.ShouldBeTrue();
+      }
+   }
+
+   public class When_going_back_after_drilling_into_a_reference : concern_for_ParameterReferencesPresenter_with_a_simulation
+   {
+      protected override void Because()
+      {
+         sut.ShowReferencesTo(_parameter, _simulation);
+         sut.FindReferencesFor(_boundReferences.Single(x => string.Equals(x.UsedBy, "Organism|P2")));
+         sut.GoBack();
+      }
+
+      [Observation]
+      public void should_show_the_references_to_the_previous_target_again()
+      {
+         _boundReferences.Select(x => x.UsedBy).ShouldOnlyContain("Organism|P2", "Organism|P3");
+         _view.Caption.ShouldBeEqualTo(AppConstants.Captions.ReferencesTo("Organism|P"));
+      }
+
+      [Observation]
+      public void should_show_the_previous_target_as_breadcrumb_and_not_allow_going_back()
+      {
+         _breadcrumb.ShouldBeEqualTo("P");
+         _canGoBack.ShouldBeFalse();
+      }
+   }
+
+   public class When_going_back_without_having_drilled_into_a_reference : concern_for_ParameterReferencesPresenter_with_a_simulation
+   {
+      protected override void Because()
+      {
+         sut.ShowReferencesTo(_parameter, _simulation);
+         sut.GoBack();
+      }
+
+      [Observation]
+      public void should_not_rebind_the_view()
+      {
+         A.CallTo(() => _view.BindTo(A<IReadOnlyList<ParameterReferenceDTO>>._)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+   public class When_going_to_the_object_of_a_reference : concern_for_ParameterReferencesPresenter_with_a_simulation
+   {
+      protected override void Context()
+      {
+         base.Context();
+         //simulates the user pressing the go to button while the modal view is open
+         A.CallTo(() => _view.Display())
+            .Invokes(x => sut.GoTo(_boundReferences.Single(dto => string.Equals(dto.UsedBy, "Organism|P2"))));
+      }
+
+      protected override void Because()
+      {
+         sut.ShowReferencesTo(_parameter, _simulation);
+      }
+
+      [Observation]
+      public void should_close_the_view()
+      {
+         A.CallTo(() => _view.CloseView()).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_navigate_to_the_object_in_the_simulation_after_the_view_was_closed()
+      {
+         A.CallTo(() => _applicationController.Select(_referencingParameter, _simulation, _context.HistoryManager)).MustHaveHappened();
+      }
+   }
+
+   public class When_checking_if_the_references_of_a_reference_can_be_searched : concern_for_ParameterReferencesPresenter
+   {
+      [Observation]
+      public void should_allow_the_search_for_an_object_that_can_be_referenced_by_formulas()
+      {
+         sut.CanFindReferencesFor(new ParameterReferenceDTO { UsedByObject = new Parameter() }).ShouldBeTrue();
+      }
+
+      [Observation]
+      public void should_not_allow_the_search_for_an_object_that_cannot_be_referenced_by_formulas()
+      {
+         sut.CanFindReferencesFor(new ParameterReferenceDTO { UsedByObject = new EventAssignment() }).ShouldBeFalse();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #608
Fixes #2463

A feature that lists all formulas (or objects that have these formulas) where a selected parameter is used.

## What's included

- **Find References...** context menu on the row indicator of the parameters list when editing a simulation
- A modal dialog lists every formula in the simulation model referencing the selected parameter: Used By (path), Type, Used As (formula / right hand side), Alias, Formula Name, Formula. The whole table can be copied via the grid's standard copy shortcuts (Ctrl+C / Ctrl+Shift+C) and row-indicator context menu
- **Drill-down**: "Find References..." on a result row (first menu entry, also triggered by double click) re-targets the search to the referencing object, so indirect references can be explored interactively. A breadcrumb trail shows the drill path and a **Back** button returns to the previous target
- **Go To...** closes the dialog and navigates to the selected referencing object in the simulation
- The reference search and DTO mapping are encapsulated in `FormulaUsableToParameterReferenceDTOMapper`; the modal presenter only orchestrates

## Bug fixes

- #2463: analyses loaded with a simulation selected their own tab while being added, so opening a simulation with charts always landed on the last chart instead of the Parameters tab (regression from #2323). Analyses are now added without taking focus; only a newly created analysis selects its tab
- Re-editing the simulation that is already shown (entity navigation, double-open from the explorer) no longer resets the view (hierarchy tree, analysis tabs); an actual refresh still goes through `SimulationReloadEvent`

<img width="1029" height="615" alt="image" src="https://github.com/user-attachments/assets/7d607455-f909-4e30-8687-86042c3e7e04" />

Double click or `Find References` to continue to drill into the next layer
Back to go back up your drilled stack
Go To to close the dialog and navigate the simulation editor to the selected item

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Find References” for parameters used in simulation formulas.
  * View references, usage details, aliases, and formulas in a dedicated window.
  * Drill into related references, navigate to referenced objects, and return using breadcrumbs.
  * Improved simulation analysis tab selection and management.

* **Tests**
  * Added coverage for reference mapping, navigation, filtering, and simulation analysis behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->