### PR TITLE
Fixes #2466 Restore the application molecule builder editor

### DIFF
--- a/src/MoBi.Presentation/Presenter/EditApplicationMoleculeBuilderPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditApplicationMoleculeBuilderPresenter.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Linq;
+using OSPSuite.Utility.Container;
+using OSPSuite.Utility.Extensions;
+using MoBi.Core.Commands;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Extensions;
+using MoBi.Core.Helper;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Mappers;
+using MoBi.Presentation.Presenter.BasePresenter;
+using MoBi.Presentation.Tasks.Edit;
+using MoBi.Presentation.Views;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Formulas;
+using OSPSuite.Presentation.Presenters;
+
+namespace MoBi.Presentation.Presenter
+{
+   public interface IEditApplicationMoleculeBuilderPresenter : IPresenterWithFormulaCache, ICanEditPropertiesPresenter, IEditPresenter<ApplicationMoleculeBuilder>, ICreatePresenter<ApplicationMoleculeBuilder>
+   {
+      ObjectPath SetObjectPath();
+   }
+
+   public class EditApplicationMoleculeBuilderPresenter : AbstractEntityEditPresenter<IEditApplicationMoleculeBuilderView, IEditApplicationMoleculeBuilderPresenter, ApplicationMoleculeBuilder>, IEditApplicationMoleculeBuilderPresenter
+   {
+      private ApplicationMoleculeBuilder _applicationMoleculeBuilder;
+      private readonly IEditTaskFor<ApplicationMoleculeBuilder> _editTask;
+      private readonly IApplicationMoleculeBuilderToApplicationMoleculeBuilderDTOMapper _applicationMoleculeMapper;
+      private readonly IEditFormulaInContainerPresenter _editFormulaPresenter;
+      private readonly IFormulaToFormulaBuilderDTOMapper _formulaToDTOFormulaMapper;
+      private readonly IMoBiContext _context;
+      private readonly ISelectReferencePresenterAtApplicationBuilder _selectItemPresenter;
+
+      public EditApplicationMoleculeBuilderPresenter(IEditApplicationMoleculeBuilderView view, IEditTaskFor<ApplicationMoleculeBuilder> editTask,
+         IApplicationMoleculeBuilderToApplicationMoleculeBuilderDTOMapper applicationMoleculeMapper, IFormulaToFormulaBuilderDTOMapper formulaToDTOFormulaMapper,
+         IEditFormulaInContainerPresenter editFormulaPresenter, IMoBiContext context, ISelectReferencePresenterAtApplicationBuilder selectItemPresenter)
+         : base(view)
+      {
+         _editTask = editTask;
+         _context = context;
+         _selectItemPresenter = selectItemPresenter;
+         _editFormulaPresenter = editFormulaPresenter;
+         _editFormulaPresenter.ReferencePresenter = _selectItemPresenter;
+         _view.SetFormulaView(_editFormulaPresenter.BaseView);
+         _formulaToDTOFormulaMapper = formulaToDTOFormulaMapper;
+         _applicationMoleculeMapper = applicationMoleculeMapper;
+         AddSubPresenters(_editFormulaPresenter, _selectItemPresenter);
+      }
+
+      private EventGroupBuildingBlock getEventGroupBuilding(IBuildingBlock buildingBlockWithFormulaCache)
+      {
+         return buildingBlockWithFormulaCache.DowncastTo<EventGroupBuildingBlock>();
+      }
+
+      public override object Subject => _applicationMoleculeBuilder;
+
+      public override void Edit(ApplicationMoleculeBuilder applicationMoleculeBuilder, IReadOnlyList<IObjectBase> existingObjectsInParent)
+      {
+         _applicationMoleculeBuilder = applicationMoleculeBuilder;
+         _editFormulaPresenter.Init(_applicationMoleculeBuilder, BuildingBlock);
+         _selectItemPresenter.Init(_applicationMoleculeBuilder.ParentContainer, getEventGroupBuilding(BuildingBlock).ToList(), applicationMoleculeBuilder);
+         var dto = _applicationMoleculeMapper.MapFrom(_applicationMoleculeBuilder);
+         _view.Show(dto);
+      }
+
+      public void SetPropertyValueFromView<T>(string propertyName, T newValue, T oldValue)
+      {
+         AddCommand(new EditObjectBasePropertyInBuildingBlockCommand(propertyName, newValue, oldValue, _applicationMoleculeBuilder, BuildingBlock).RunCommand(_context));
+      }
+
+      public void RenameSubject()
+      {
+         _editTask.Rename(_applicationMoleculeBuilder, BuildingBlock);
+      }
+
+      public IEnumerable<FormulaBuilderDTO> GetFormulas()
+      {
+         return FormulaCache.MapAllUsing(_formulaToDTOFormulaMapper);
+      }
+
+      public IBuildingBlock BuildingBlock { get; set; }
+
+      public IFormulaCache FormulaCache => BuildingBlock.FormulaCache;
+
+      public ObjectPath SetObjectPath()
+      {
+         using (var modalPresenter = IoC.Resolve<IModalPresenter>())
+         {
+            modalPresenter.Encapsulate(_selectItemPresenter);
+            _selectItemPresenter.Init(_applicationMoleculeBuilder.ParentContainer, new[] {_applicationMoleculeBuilder.RootContainer}, _applicationMoleculeBuilder);
+
+            if (modalPresenter.Show())
+            {
+               var path = _selectItemPresenter.GetSelection();
+               SetPropertyValueFromView(MoBiReflectionHelper.PropertyName<ApplicationMoleculeBuilder>(x => x.RelativeContainerPath), path, _applicationMoleculeBuilder.RelativeContainerPath);
+               return path;
+            }
+         }
+         return _applicationMoleculeBuilder.RelativeContainerPath ?? new ObjectPath();
+      }
+   }
+}

--- a/src/MoBi.Presentation/Views/IEditApplicationMoleculeBuilderView.cs
+++ b/src/MoBi.Presentation/Views/IEditApplicationMoleculeBuilderView.cs
@@ -1,0 +1,12 @@
+﻿using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+using OSPSuite.Presentation.Views;
+
+namespace MoBi.Presentation.Views
+{
+   public interface IEditApplicationMoleculeBuilderView : IView<IEditApplicationMoleculeBuilderPresenter>, IActivatableView
+   {
+      void Show(ApplicationMoleculeBuilderDTO dtoApplicationMoleculeBuilder);
+      void SetFormulaView(IView view);
+   }
+}

--- a/src/MoBi.UI/Views/EditApplicationMoleculeBuilderView.Designer.cs
+++ b/src/MoBi.UI/Views/EditApplicationMoleculeBuilderView.Designer.cs
@@ -1,0 +1,206 @@
+﻿namespace MoBi.UI.Views
+{
+   partial class EditApplicationMoleculeBuilderView
+   {
+      /// <summary> 
+      /// Required designer variable.
+      /// </summary>
+      private System.ComponentModel.IContainer components = null;
+
+      /// <summary> 
+      /// Clean up any resources being used.
+      /// </summary>
+      /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+      protected override void Dispose(bool disposing)
+      {
+         if (disposing && (components != null))
+         {
+            components.Dispose();
+         }
+         _screenBinder.Dispose();
+         base.Dispose(disposing);
+      }
+
+      #region Component Designer generated code
+
+      /// <summary> 
+      /// Required method for Designer support - do not modify 
+      /// the contents of this method with the code editor.
+      /// </summary>
+      private void InitializeComponent()
+      {
+         this.lblDescription = new DevExpress.XtraEditors.LabelControl();
+         this.lblName = new DevExpress.XtraEditors.LabelControl();
+         this.btContainerPath = new DevExpress.XtraEditors.ButtonEdit();
+         this.layoutControl = new OSPSuite.UI.Controls.UxLayoutControl();
+         this.htmlEditor = new DevExpress.XtraEditors.MemoExEdit();
+         this.panelFormula = new DevExpress.XtraEditors.PanelControl();
+         this.layoutControlGroup1 = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.layoutItemContainerName = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutItemDescription = new DevExpress.XtraLayout.LayoutControlItem();
+         this.layoutGroupFormula = new DevExpress.XtraLayout.LayoutControlGroup();
+         this.layoutItemPanelFormula = new DevExpress.XtraLayout.LayoutControlItem();
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.btContainerPath.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).BeginInit();
+         this.layoutControl.SuspendLayout();
+         ((System.ComponentModel.ISupportInitialize)(this.htmlEditor.Properties)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.panelFormula)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup1)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemContainerName)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDescription)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutGroupFormula)).BeginInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemPanelFormula)).BeginInit();
+         this.SuspendLayout();
+         // 
+         // lblDescription
+         // 
+         this.lblDescription.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+         this.lblDescription.Location = new System.Drawing.Point(-138, 511);
+         this.lblDescription.Name = "lblDescription";
+         this.lblDescription.Size = new System.Drawing.Size(57, 13);
+         this.lblDescription.TabIndex = 13;
+         this.lblDescription.Text = "Description:";
+         // 
+         // lblName
+         // 
+         this.lblName.Location = new System.Drawing.Point(-138, -81);
+         this.lblName.Name = "lblName";
+         this.lblName.Size = new System.Drawing.Size(31, 13);
+         this.lblName.TabIndex = 12;
+         this.lblName.Text = "Name:";
+         // 
+         // btContainerPath
+         // 
+         this.btContainerPath.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+         this.btContainerPath.Location = new System.Drawing.Point(131, 2);
+         this.btContainerPath.Name = "btContainerPath";
+         this.btContainerPath.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton()});
+         this.btContainerPath.Properties.ReadOnly = true;
+         this.btContainerPath.Size = new System.Drawing.Size(525, 20);
+         this.btContainerPath.StyleController = this.layoutControl;
+         this.btContainerPath.TabIndex = 19;
+         // 
+         // layoutControl
+         // 
+         this.layoutControl.Controls.Add(this.htmlEditor);
+         this.layoutControl.Controls.Add(this.panelFormula);
+         this.layoutControl.Controls.Add(this.btContainerPath);
+         this.layoutControl.Dock = System.Windows.Forms.DockStyle.Fill;
+         this.layoutControl.Location = new System.Drawing.Point(0, 0);
+         this.layoutControl.Name = "layoutControl";
+         this.layoutControl.Root = this.layoutControlGroup1;
+         this.layoutControl.Size = new System.Drawing.Size(658, 538);
+         this.layoutControl.TabIndex = 23;
+         this.layoutControl.Text = "layoutControl1";
+         // 
+         // htmlEditor
+         // 
+         this.htmlEditor.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+         this.htmlEditor.Location = new System.Drawing.Point(131, 516);
+         this.htmlEditor.Name = "htmlEditor";
+         this.htmlEditor.Properties.Buttons.AddRange(new DevExpress.XtraEditors.Controls.EditorButton[] {
+            new DevExpress.XtraEditors.Controls.EditorButton(DevExpress.XtraEditors.Controls.ButtonPredefines.Combo)});
+         this.htmlEditor.Properties.ShowIcon = false;
+         this.htmlEditor.Size = new System.Drawing.Size(525, 20);
+         this.htmlEditor.StyleController = this.layoutControl;
+         this.htmlEditor.TabIndex = 22;
+         // 
+         // panelFormula
+         // 
+         this.panelFormula.Location = new System.Drawing.Point(14, 56);
+         this.panelFormula.Name = "panelFormula";
+         this.panelFormula.Size = new System.Drawing.Size(630, 444);
+         this.panelFormula.TabIndex = 20;
+         // 
+         // layoutControlGroup1
+         // 
+         this.layoutControlGroup1.EnableIndentsWithoutBorders = DevExpress.Utils.DefaultBoolean.True;
+         this.layoutControlGroup1.GroupBordersVisible = false;
+         this.layoutControlGroup1.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutItemContainerName,
+            this.layoutItemDescription,
+            this.layoutGroupFormula});
+         this.layoutControlGroup1.Location = new System.Drawing.Point(0, 0);
+         this.layoutControlGroup1.Name = "layoutControlGroup1";
+         this.layoutControlGroup1.Padding = new DevExpress.XtraLayout.Utils.Padding(0, 0, 0, 0);
+         this.layoutControlGroup1.Size = new System.Drawing.Size(658, 538);
+         this.layoutControlGroup1.TextVisible = false;
+         // 
+         // layoutItemContainerName
+         // 
+         this.layoutItemContainerName.Control = this.btContainerPath;
+         this.layoutItemContainerName.Location = new System.Drawing.Point(0, 0);
+         this.layoutItemContainerName.Name = "layoutItemContainerName";
+         this.layoutItemContainerName.Size = new System.Drawing.Size(658, 24);
+         this.layoutItemContainerName.TextSize = new System.Drawing.Size(126, 13);
+         // 
+         // layoutItemDescription
+         // 
+         this.layoutItemDescription.Control = this.htmlEditor;
+         this.layoutItemDescription.Location = new System.Drawing.Point(0, 514);
+         this.layoutItemDescription.Name = "layoutItemDescription";
+         this.layoutItemDescription.Size = new System.Drawing.Size(658, 24);
+         this.layoutItemDescription.TextSize = new System.Drawing.Size(126, 13);
+         // 
+         // layoutGroupFormula
+         // 
+         this.layoutGroupFormula.Items.AddRange(new DevExpress.XtraLayout.BaseLayoutItem[] {
+            this.layoutItemPanelFormula});
+         this.layoutGroupFormula.Location = new System.Drawing.Point(0, 24);
+         this.layoutGroupFormula.Name = "layoutGroupFormula";
+         this.layoutGroupFormula.Size = new System.Drawing.Size(658, 490);
+         // 
+         // layoutItemPanelFormula
+         // 
+         this.layoutItemPanelFormula.Control = this.panelFormula;
+         this.layoutItemPanelFormula.Location = new System.Drawing.Point(0, 0);
+         this.layoutItemPanelFormula.Name = "layoutItemPanelFormula";
+         this.layoutItemPanelFormula.Size = new System.Drawing.Size(634, 448);
+         this.layoutItemPanelFormula.TextSize = new System.Drawing.Size(0, 0);
+         this.layoutItemPanelFormula.TextVisible = false;
+         // 
+         // EditApplicationMoleculeBuilderView
+         // 
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.Controls.Add(this.layoutControl);
+         this.Controls.Add(this.lblDescription);
+         this.Controls.Add(this.lblName);
+         this.Name = "EditApplicationMoleculeBuilderView";
+         this.Size = new System.Drawing.Size(658, 538);
+         ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.btContainerPath.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControl)).EndInit();
+         this.layoutControl.ResumeLayout(false);
+         ((System.ComponentModel.ISupportInitialize)(this.htmlEditor.Properties)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.panelFormula)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutControlGroup1)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemContainerName)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemDescription)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutGroupFormula)).EndInit();
+         ((System.ComponentModel.ISupportInitialize)(this.layoutItemPanelFormula)).EndInit();
+         this.ResumeLayout(false);
+         this.PerformLayout();
+
+      }
+
+      #endregion
+
+      private DevExpress.XtraEditors.LabelControl lblDescription;
+      private DevExpress.XtraEditors.LabelControl lblName;
+      private DevExpress.XtraEditors.ButtonEdit btContainerPath;
+      private DevExpress.XtraEditors.MemoExEdit htmlEditor;
+      private OSPSuite.UI.Controls.UxLayoutControl layoutControl;
+      private DevExpress.XtraEditors.PanelControl panelFormula;
+      private DevExpress.XtraLayout.LayoutControlGroup layoutControlGroup1;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemContainerName;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemPanelFormula;
+      private DevExpress.XtraLayout.LayoutControlItem layoutItemDescription;
+      private DevExpress.XtraLayout.LayoutControlGroup layoutGroupFormula;
+
+   }
+}

--- a/src/MoBi.UI/Views/EditApplicationMoleculeBuilderView.cs
+++ b/src/MoBi.UI/Views/EditApplicationMoleculeBuilderView.cs
@@ -1,0 +1,86 @@
+﻿using OSPSuite.DataBinding;
+using OSPSuite.DataBinding.DevExpress;
+using DevExpress.XtraEditors.Controls;
+using MoBi.Assets;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Views;
+using OSPSuite.Presentation;
+using OSPSuite.Presentation.Extensions;
+using OSPSuite.Presentation.Views;
+using OSPSuite.UI.Controls;
+using OSPSuite.UI.Extensions;
+
+namespace MoBi.UI.Views
+{
+   public partial class EditApplicationMoleculeBuilderView : BaseUserControl, IEditApplicationMoleculeBuilderView
+   {
+      private IEditApplicationMoleculeBuilderPresenter _presenter;
+      private ScreenBinder<ApplicationMoleculeBuilderDTO> _screenBinder;
+
+      public EditApplicationMoleculeBuilderView()
+      {
+         InitializeComponent();
+      }
+
+      public override void InitializeBinding()
+      {
+         base.InitializeBinding();
+         _screenBinder = new ScreenBinder<ApplicationMoleculeBuilderDTO>();
+         _screenBinder.Bind(dto => dto.Description)
+            .To(htmlEditor)
+            .OnValueUpdating += OnValueUpdating;
+
+         _screenBinder.Bind(dto => dto.RelativeContainerPath)
+            .To(btContainerPath);
+
+         RegisterValidationFor(_screenBinder, NotifyViewChanged);
+
+         btContainerPath.ButtonClick += selectContainerPath;
+      }
+
+      public void Activate()
+      {
+         ActiveControl = btContainerPath;
+      }
+
+      private void OnValueUpdating<T>(ApplicationMoleculeBuilderDTO applicationMoleculeBuilder, PropertyValueSetEventArgs<T> e)
+      {
+         OnEvent(() => _presenter.SetPropertyValueFromView(e.PropertyName, e.NewValue, e.OldValue));
+      }
+
+      public void AttachPresenter(IEditApplicationMoleculeBuilderPresenter presenter)
+      {
+         _presenter = presenter;
+      }
+
+      public void Show(ApplicationMoleculeBuilderDTO dtoApplicationMoleculeBuilder)
+      {
+         _screenBinder.BindToSource(dtoApplicationMoleculeBuilder);
+      }
+
+      public void SetFormulaView(IView view)
+      {
+         panelFormula.FillWith(view);
+      }
+
+      public override bool HasError => base.HasError || _screenBinder.HasError;
+
+      private void selectContainerPath(object sender, ButtonPressedEventArgs e)
+      {
+         OnEvent(() =>
+         {
+            var newPath = _presenter.SetObjectPath();
+            btContainerPath.Text = newPath.ToString();
+         });
+      }
+
+      public override void InitializeResources()
+      {
+         base.InitializeResources();
+         layoutItemContainerName.Text = AppConstants.Captions.ContainerPath.FormatForLabel();
+         layoutItemDescription.Text = AppConstants.Captions.Description.FormatForLabel();
+         layoutGroupFormula.Text = AppConstants.Captions.Formula;
+      }
+   }
+}

--- a/src/MoBi.UI/Views/EditApplicationMoleculeBuilderView.resx
+++ b/src/MoBi.UI/Views/EditApplicationMoleculeBuilderView.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="errorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>


### PR DESCRIPTION
This presenter/view cluster is only ever resolved through the ICreatePresenter<> registration convention, so it had no static references and #2412 removed it as dead code. Creating an application molecule builder has thrown ever since, from both the tree context menu and the application editor grid.

Fixes #2466
