### PR TITLE
Fixes #516 Add a context menu to the plot tabs of a simulation

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.142" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.142-ctxmenu2928" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,13 +16,13 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.142" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.142" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.142-ctxmenu2928" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.142-ctxmenu2928" />
       <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.142" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.142" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.142" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.142-ctxmenu2928" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.142-ctxmenu2928" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.142-ctxmenu2928" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -22,15 +22,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.142-ctxmenu2928" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.142-ctxmenu2928" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,12 +31,12 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.142-ctxmenu2928" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.142-ctxmenu2928" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -21,9 +21,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditSimulationPresenter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using MoBi.Assets;
 using MoBi.Core.Domain.Model;
@@ -12,6 +13,7 @@ using OSPSuite.Core.Domain.Data;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Utility.Collections;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
@@ -29,11 +31,13 @@ namespace MoBi.Presentation.Presenter
       IListener<UserDefinedSelectedEvent>,
       IListener<ShowSimulationChangesEvent>,
       IListener<SimulationRunStartedEvent>,
-      IListener<SimulationAnalysisCreatedEvent>
+      IListener<SimulationAnalysisCreatedEvent>,
+      IPresenterWithAnalyses
    {
       void LoadDiagram();
       void LoadChanges();
       void RemoveAnalysis(ISimulationAnalysis analysis);
+      void ShowContextMenu(ISimulationAnalysis analysis, Point popupLocation);
    }
 
    public class EditSimulationPresenter : SingleStartPresenter<IEditSimulationView, IEditSimulationPresenter>, IEditSimulationPresenter, IListener<ObservedDataRemovedFromAnalysableEvent>
@@ -58,6 +62,8 @@ namespace MoBi.Presentation.Presenter
       private readonly ISimulationRunner _simulationRunner;
       private readonly ISimulationAnalysisPresenterFactory _simulationAnalysisPresenterFactory;
       private readonly IEventPublisher _eventPublisher;
+      private readonly IMoBiSimulationAnalysisCreator _simulationAnalysisCreator;
+      private readonly ISimulationAnalysisPresenterContextMenuFactory _contextMenuFactory;
       private readonly IList<ISimulationAnalysisPresenter> _analysisPresenters = new List<ISimulationAnalysisPresenter>();
 
       public EditSimulationPresenter(
@@ -77,7 +83,9 @@ namespace MoBi.Presentation.Presenter
          ISimulationEntitySourceReferenceFactory entitySourceReferenceFactory,
          ISimulationRunner simulationRunner,
          ISimulationAnalysisPresenterFactory simulationAnalysisPresenterFactory,
-         IEventPublisher eventPublisher)
+         IEventPublisher eventPublisher,
+         IMoBiSimulationAnalysisCreator simulationAnalysisCreator,
+         ISimulationAnalysisPresenterContextMenuFactory contextMenuFactory)
          : base(view)
       {
          _simulationChangesPresenter = changesPresenter;
@@ -95,6 +103,8 @@ namespace MoBi.Presentation.Presenter
          _simulationRunner = simulationRunner;
          _simulationAnalysisPresenterFactory = simulationAnalysisPresenterFactory;
          _eventPublisher = eventPublisher;
+         _simulationAnalysisCreator = simulationAnalysisCreator;
+         _contextMenuFactory = contextMenuFactory;
          _outputMappingMatchingTask = outputMappingMatchingTask;
          _view.SetTreeView(hierarchicalPresenter.BaseView);
          _view.SetModelDiagram(_simulationDiagramPresenter.View);
@@ -198,6 +208,27 @@ namespace MoBi.Presentation.Presenter
 
          _simulation.RemoveAnalysis(analysis);
          removeAndReleaseAnalysisPresenter(analysisPresenter);
+      }
+
+      public void RemoveAnalysis(ISimulationAnalysisPresenter simulationAnalysisPresenter) => RemoveAnalysis(simulationAnalysisPresenter.Analysis);
+
+      public void RemoveAllAnalyses() => _analysisPresenters.ToList().Each(RemoveAnalysis);
+
+      public void CloneAnalysis(ISimulationAnalysis analysis)
+      {
+         var clonedAnalysis = _simulationAnalysisCreator.CreateAnalysisBasedOn(analysis);
+         _simulationAnalysisCreator.AddSimulationAnalysisTo(_simulation, clonedAnalysis);
+      }
+
+      public void ShowContextMenu(ISimulationAnalysis analysis, Point popupLocation) => ShowContextMenu(analysisPresenterFor(analysis), popupLocation);
+
+      public void ShowContextMenu(ISimulationAnalysisPresenter analysisPresenter, Point popupLocation)
+      {
+         if (analysisPresenter == null)
+            return;
+
+         var contextMenu = _contextMenuFactory.CreateFor(analysisPresenter, this);
+         contextMenu.Show(_view, popupLocation);
       }
 
       private ISimulationAnalysisPresenter analysisPresenterFor(ISimulationAnalysis analysis) => _analysisPresenters.FirstOrDefault(x => Equals(x.Analysis, analysis));

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.142-ctxmenu2928" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -25,11 +25,11 @@
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.UI/Views/SimulationView/EditSimulationView.cs
+++ b/src/MoBi.UI/Views/SimulationView/EditSimulationView.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
+using System.Windows.Forms;
 using DevExpress.Utils;
+using DevExpress.XtraBars;
 using DevExpress.XtraEditors;
 using DevExpress.XtraTab;
 using DevExpress.XtraTab.ViewInfo;
@@ -13,20 +15,25 @@ using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Presentation.Views;
 using OSPSuite.UI.Extensions;
+using OSPSuite.UI.Services;
 using OSPSuite.UI.Views;
 using OSPSuite.Utility.Extensions;
 
 namespace MoBi.UI.Views.SimulationView
 {
-   public partial class EditSimulationView : BaseMdiChildView, IEditSimulationView
+   public partial class EditSimulationView : BaseMdiChildView, IEditSimulationView, IViewWithPopup
    {
-      public EditSimulationView(IMainView mainView) : base(mainView)
+      public BarManager PopupBarManager { get; }
+
+      public EditSimulationView(IMainView mainView, IImageListRetriever imageListRetriever) : base(mainView)
       {
          InitializeComponent();
          spliterDiagram.CollapsePanel = SplitCollapsePanel.Panel1;
          splitSimulationParameters.CollapsePanel = SplitCollapsePanel.Panel1;
          tabs.ClosePageButtonShowMode = ClosePageButtonShowMode.InActiveTabPageHeader;
          tabs.CloseButtonClick += (o, e) => OnEvent(closeButtonClick, e as ClosePageButtonEventArgs);
+         tabs.MouseDown += (o, e) => OnEvent(onTabsMouseDown, e);
+         PopupBarManager = new BarManager { Form = this, Images = imageListRetriever.AllImagesForContextMenu };
       }
 
       public void AttachPresenter(IEditSimulationPresenter presenter)
@@ -68,6 +75,21 @@ namespace MoBi.UI.Views.SimulationView
             return;
 
          simulationPresenter.RemoveAnalysis(analysis);
+      }
+
+      private void onTabsMouseDown(MouseEventArgs e)
+      {
+         if (e.Button != MouseButtons.Right)
+            return;
+
+         var hitInfo = tabs.CalcHitInfo(e.Location);
+         if (hitInfo == null || hitInfo.HitTest != XtraTabHitTest.PageHeader)
+            return;
+
+         if (hitInfo.Page?.Tag is not ISimulationAnalysis analysis)
+            return;
+
+         simulationPresenter.ShowContextMenu(analysis, PointToClient(Cursor.Position));
       }
 
       public void SetEditView(IView view)

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -57,13 +57,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.142" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.142-ctxmenu2928" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.142-ctxmenu2928" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditSimulationPresenterSpecs.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using FakeItEasy;
 using MoBi.Core.Chart;
 using MoBi.Core.Domain.Model;
@@ -14,6 +15,7 @@ using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Events;
 using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Views;
 using OSPSuite.Utility.Events;
 
@@ -36,6 +38,8 @@ namespace MoBi.Presentation
       protected ISimulationRunner _simulationRunner;
       protected ISimulationAnalysisPresenterFactory _simulationAnalysisPresenterFactory;
       protected IEventPublisher _eventPublisher;
+      protected IMoBiSimulationAnalysisCreator _simulationAnalysisCreator;
+      protected ISimulationAnalysisPresenterContextMenuFactory _contextMenuFactory;
       private ISimulationChangesPresenter _simulationChangesPresenter;
 
       protected override void Context()
@@ -56,12 +60,15 @@ namespace MoBi.Presentation
          _simulationRunner = A.Fake<ISimulationRunner>();
          _simulationAnalysisPresenterFactory = A.Fake<ISimulationAnalysisPresenterFactory>();
          _eventPublisher = A.Fake<IEventPublisher>();
+         _simulationAnalysisCreator = A.Fake<IMoBiSimulationAnalysisCreator>();
+         _contextMenuFactory = A.Fake<ISimulationAnalysisPresenterContextMenuFactory>();
 
          sut = new EditSimulationPresenter(_view, _hierarchicalSimulationPresenter, _diagramPresenter,
             _solverSettings, _outputSchemaPresenter, _presenterFactory, new HeavyWorkManagerForSpecs(),
             _editFavoritePresenter, _userDefinedParametersPresenter, _simulationOutputMappingPresenter,
             _context, _outputMappingMatchingTask, _simulationChangesPresenter, _entitySourceReferenceFactory,
-            _simulationRunner, _simulationAnalysisPresenterFactory, _eventPublisher);
+            _simulationRunner, _simulationAnalysisPresenterFactory, _eventPublisher,
+            _simulationAnalysisCreator, _contextMenuFactory);
       }
    }
 
@@ -331,6 +338,138 @@ namespace MoBi.Presentation
       public void should_release_the_presenter_from_events()
       {
          A.CallTo(() => _analysisPresenter.ReleaseFrom(_eventPublisher)).MustHaveHappened();
+      }
+   }
+
+   public abstract class concern_for_EditSimulationPresenterWithEditedAnalysis : concern_for_EditSimulationPresenter
+   {
+      protected IMoBiSimulation _simulation;
+      protected MoBiSimulationTimeProfileChart _chart;
+      protected ISimulationAnalysisPresenter _analysisPresenter;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation = A.Fake<IMoBiSimulation>();
+         _chart = new MoBiSimulationTimeProfileChart();
+         A.CallTo(() => _simulation.Analyses).Returns(new ISimulationAnalysis[] { _chart });
+
+         _analysisPresenter = A.Fake<ISimulationAnalysisPresenter>();
+         A.CallTo(() => _analysisPresenter.Analysis).Returns(_chart);
+         A.CallTo(() => _simulationAnalysisPresenterFactory.PresenterFor(_chart)).Returns(_analysisPresenter);
+
+         sut.Edit(_simulation);
+      }
+   }
+
+   public class When_removing_an_analysis_via_its_presenter : concern_for_EditSimulationPresenterWithEditedAnalysis
+   {
+      protected override void Because()
+      {
+         sut.RemoveAnalysis(_analysisPresenter);
+      }
+
+      [Observation]
+      public void should_remove_the_analysis_from_the_simulation_and_the_view()
+      {
+         A.CallTo(() => _simulation.RemoveAnalysis(_chart)).MustHaveHappened();
+         A.CallTo(() => _view.RemoveAnalysis(_chart)).MustHaveHappened();
+      }
+   }
+
+   public class When_removing_all_analyses : concern_for_EditSimulationPresenterWithEditedAnalysis
+   {
+      private MoBiSimulationTimeProfileChart _otherChart;
+      private ISimulationAnalysisPresenter _otherAnalysisPresenter;
+
+      protected override void Context()
+      {
+         base.Context();
+         _otherChart = new MoBiSimulationTimeProfileChart();
+         _otherAnalysisPresenter = A.Fake<ISimulationAnalysisPresenter>();
+         A.CallTo(() => _otherAnalysisPresenter.Analysis).Returns(_otherChart);
+         A.CallTo(() => _simulationAnalysisPresenterFactory.PresenterFor(_otherChart)).Returns(_otherAnalysisPresenter);
+         sut.Handle(new SimulationAnalysisCreatedEvent(_simulation, _otherChart));
+      }
+
+      protected override void Because()
+      {
+         sut.RemoveAllAnalyses();
+      }
+
+      [Observation]
+      public void should_remove_all_analyses_from_the_simulation()
+      {
+         A.CallTo(() => _simulation.RemoveAnalysis(_chart)).MustHaveHappened();
+         A.CallTo(() => _simulation.RemoveAnalysis(_otherChart)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_remove_all_analyses_from_the_view()
+      {
+         A.CallTo(() => _view.RemoveAnalysis(_chart)).MustHaveHappened();
+         A.CallTo(() => _view.RemoveAnalysis(_otherChart)).MustHaveHappened();
+      }
+   }
+
+   public class When_cloning_an_analysis : concern_for_EditSimulationPresenterWithEditedAnalysis
+   {
+      private MoBiSimulationTimeProfileChart _clonedChart;
+
+      protected override void Context()
+      {
+         base.Context();
+         _clonedChart = new MoBiSimulationTimeProfileChart();
+         A.CallTo(() => _simulationAnalysisCreator.CreateAnalysisBasedOn(_chart)).Returns(_clonedChart);
+      }
+
+      protected override void Because()
+      {
+         sut.CloneAnalysis(_chart);
+      }
+
+      [Observation]
+      public void should_add_the_cloned_analysis_to_the_simulation()
+      {
+         A.CallTo(() => _simulationAnalysisCreator.AddSimulationAnalysisTo(_simulation, _clonedChart)).MustHaveHappened();
+      }
+   }
+
+   public class When_showing_the_context_menu_for_the_tab_of_an_analysis : concern_for_EditSimulationPresenterWithEditedAnalysis
+   {
+      private IContextMenu _contextMenu;
+      private readonly Point _popupLocation = new Point(10, 20);
+
+      protected override void Context()
+      {
+         base.Context();
+         _contextMenu = A.Fake<IContextMenu>();
+         A.CallTo(() => _contextMenuFactory.CreateFor(_analysisPresenter, sut)).Returns(_contextMenu);
+      }
+
+      protected override void Because()
+      {
+         sut.ShowContextMenu(_chart, _popupLocation);
+      }
+
+      [Observation]
+      public void should_show_the_context_menu_created_for_the_analysis_presenter()
+      {
+         A.CallTo(() => _contextMenu.Show(_view, _popupLocation)).MustHaveHappened();
+      }
+   }
+
+   public class When_showing_the_context_menu_for_the_tab_of_an_unknown_analysis : concern_for_EditSimulationPresenterWithEditedAnalysis
+   {
+      protected override void Because()
+      {
+         sut.ShowContextMenu(new MoBiSimulationTimeProfileChart(), new Point(10, 20));
+      }
+
+      [Observation]
+      public void should_not_show_any_context_menu()
+      {
+         A.CallTo(() => _contextMenuFactory.CreateFor(A<ISimulationAnalysisPresenter>._, A<IPresenterWithContextMenu<ISimulationAnalysisPresenter>>._)).MustNotHaveHappened();
       }
    }
 

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.142" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.142" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.142-ctxmenu2928" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.142-ctxmenu2928" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #516

Right-clicking a plot tab now shows the same context menu as in PK-Sim: **Clone**, **Remove**, **Remove All** and **Rename...**

## How it works

The menu itself lives in OSPSuite.Presentation (Open-Systems-Pharmacology/OSPSuite.Core#2929) and is served by the shared `SimulationAnalysisPresenterContextMenuSpecificationFactory`:

- **Simulation plot tabs**: `EditSimulationPresenter` implements the new `IPresenterWithAnalyses` interface (`CloneAnalysis` via `IMoBiSimulationAnalysisCreator`, `RemoveAllAnalyses`, `ShowContextMenu`), and `EditSimulationView` forwards right clicks on analysis tab headers (and becomes an `IViewWithPopup`). Builds on the multiple-plots support from #1709.
- **Parameter identification / sensitivity analysis plot tabs**: no MoBi changes needed — the shared `EditAnalyzablePresenter`/`EditAnalyzableView` already handle the tab right-click, and the menu registration comes with the updated OSPSuite.Core. This closes the gap described in the original issue (no context menu on PI time profile tabs).
- **Rename** goes through the shared `RenameSimulationAnalysisUICommand`, which forbids sibling analysis names; renaming updates the tab caption via the chart presenter caption fix in the Core PR.

## Dependency

⚠️ Draft until Open-Systems-Pharmacology/OSPSuite.Core#2929 is merged and published: the branch currently references a **local** Core build (`13.0.142-ctxmenu2928`). Once the Core packages are published, the version will be bumped to the released one and the PR marked ready.

## Tests

- new specs for `RemoveAllAnalyses`, `CloneAnalysis` and `ShowContextMenu` in `EditSimulationPresenterSpecs`
- full local run: MoBi.Tests 2594 passed / 4 skipped, MoBi.UI.Tests 8 passed (against the local Core build)
- manual UI verification (right-click on the tab headers) still to be done once a released Core build is referenced