### PR TITLE
Fixes #2471 Allow selecting the Properties tab of a container in a simulation

### DIFF
--- a/src/MoBi.UI/Views/EditContainerView.cs
+++ b/src/MoBi.UI/Views/EditContainerView.cs
@@ -166,8 +166,6 @@ namespace MoBi.UI.Views
             btParentPath.Enabled = enabled;
             htmlEditor.Enabled = enabled;
             panelTags.Enabled = enabled;
-
-            tabProperties.Enabled = enabled;
          }
       }
 


### PR DESCRIPTION
The read-only mode of the container view disabled the whole Properties tab page. Since #1816 made Parameters the default tab, the page became unreachable in simulations. All controls on it are already individually disabled in read-only mode, so the tab-level disable is removed and the tab can be selected again (read-only), matching the other in-simulation views.

Fixes #2471

🤖 Generated with [Claude Code](https://claude.com/claude-code)