### PR TITLE
Fixes #2446 Enable the Next button when returning from the calculation methods page

### DIFF
--- a/src/MoBi.Presentation/Presenter/CreateSimulationConfigurationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/CreateSimulationConfigurationPresenter.cs
@@ -101,6 +101,8 @@ namespace MoBi.Presentation.Presenter
             // the calculation methods page. That way the list of molecules represents all the selected modules
             View.SetControlEnabled(SimulationItems.MoleculeCalculationMethodsConfiguration, false);
          }
+         else
+            View.NextEnabled = true;
 
          View.OkEnabled = CanClose;
       }

--- a/tests/MoBi.Tests/Presentation/CreateSimulationConfigurationPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/CreateSimulationConfigurationPresenterSpecs.cs
@@ -232,6 +232,26 @@ namespace MoBi.Presentation
       }
    }
 
+   public class When_wizard_previous_is_called_from_the_calculation_methods_page : concern_for_CreateSimulationConfigurationPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _view.IsControlVisible(A<ISubPresenterItem>._)).Returns(true);
+      }
+
+      protected override void Because()
+      {
+         sut.WizardPrevious(SimulationItems.MoleculeCalculationMethodsConfiguration.Index);
+      }
+
+      [Observation]
+      public void should_enable_the_next_button()
+      {
+         _view.NextEnabled.ShouldBeTrue();
+      }
+   }
+
    public class When_wizard_next_is_called_from_the_page_before_calculation_methods : concern_for_CreateSimulationConfigurationPresenter
    {
       private IEditModuleConfigurationsPresenter _moduleConfigPresenter;


### PR DESCRIPTION
Fixes #2446

Clicking **Previous** from the **Calculation Methods** page left **Next** greyed out. The base `WizardPresenter` disables Next on the last page, and MoBi's `UpdateControls` override only re-enabled it for the first page, so the middle page stayed stuck.

Adds the `else` branch that re-enables Next off the first page, matching the pattern PK-Sim's wizards already use. This also covers navigating back via the tab headers, which goes through the same path.

Covered by a new spec in `CreateSimulationConfigurationPresenterSpecs`.