### PR TITLE
Fixes #2081 Prompt when adding building blocks converts a PK-Sim module

### DIFF
--- a/src/MoBi.Core/Commands/AddMultipleBuildingBlocksToModuleCommand.cs
+++ b/src/MoBi.Core/Commands/AddMultipleBuildingBlocksToModuleCommand.cs
@@ -8,7 +8,7 @@ using OSPSuite.Utility.Extensions;
 
 namespace MoBi.Core.Commands
 {
-   public class AddMultipleBuildingBlocksToModuleCommand : MoBiMacroCommand
+   public class AddMultipleBuildingBlocksToModuleCommand : MoBiMacroCommand, IWillConvertPKSimModuleToExtensionModule
    {
       private Module _existingModule;
       private IReadOnlyList<IBuildingBlock> _listOfNewBuildingBlocks;
@@ -21,6 +21,10 @@ namespace MoBi.Core.Commands
          _listOfNewBuildingBlocks = listOfNewBuildingBlocks;
          Description = AppConstants.Commands.AddBuildingBlocksToModule(_existingModule.Name);
       }
+
+      public bool WillConvertPKSimModuleToExtensionModule => _existingModule.IsPKSimModule;
+
+      public Module Module => _existingModule;
 
       public override void Execute(IMoBiContext context)
       {

--- a/tests/MoBi.Tests/Core/Commands/AddBuildingBlocksToModuleCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/AddBuildingBlocksToModuleCommandSpecs.cs
@@ -57,4 +57,34 @@ namespace MoBi.Core.Commands
          _existingModule.EventGroups.ShouldBeEqualTo(_newEventGroupBuildingBlock);
       }
    }
+
+   public class When_checking_if_adding_building_blocks_converts_a_pksim_module : concern_for_AddBuildingBlocksToModuleCommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _existingModule.IsPKSimModule = true;
+      }
+
+      [Observation]
+      public void the_command_should_convert_the_module_to_an_extension_module()
+      {
+         sut.WillConvertPKSimModuleToExtensionModule.ShouldBeTrue();
+      }
+
+      [Observation]
+      public void the_module_should_be_the_module_being_changed()
+      {
+         sut.Module.ShouldBeEqualTo(_existingModule);
+      }
+   }
+
+   public class When_checking_if_adding_building_blocks_converts_an_extension_module : concern_for_AddBuildingBlocksToModuleCommand
+   {
+      [Observation]
+      public void the_command_should_not_convert_the_module()
+      {
+         sut.WillConvertPKSimModuleToExtensionModule.ShouldBeFalse();
+      }
+   }
 }

--- a/tests/MoBi.Tests/Core/MoBiContextSpecs.cs
+++ b/tests/MoBi.Tests/Core/MoBiContextSpecs.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using FakeItEasy;
 using MoBi.Core.Commands;
 using MoBi.Core.Domain.Model;
@@ -329,6 +330,66 @@ namespace MoBi.Core
       public void the_user_should_be_prompted()
       {
          A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+   public class When_running_a_command_adding_multiple_building_blocks_to_a_pksim_module : concern_for_MoBiContext
+   {
+      private AddMultipleBuildingBlocksToModuleCommand _command;
+      private Module _module;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.CurrentProject = new MoBiProject();
+         _module = new Module
+         {
+            IsPKSimModule = true
+         };
+         sut.CurrentProject.AddModule(_module);
+         _command = new AddMultipleBuildingBlocksToModuleCommand(_module, new List<IBuildingBlock> {new ParameterValuesBuildingBlock()});
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).Returns(ViewResult.Yes);
+      }
+
+      protected override void Because()
+      {
+         sut.PromptForCancellation(_command);
+      }
+
+      [Observation]
+      public void the_user_should_be_prompted()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).MustHaveHappenedOnceExactly();
+      }
+   }
+
+   public class When_running_a_command_adding_multiple_building_blocks_to_an_extension_module : concern_for_MoBiContext
+   {
+      private AddMultipleBuildingBlocksToModuleCommand _command;
+      private Module _module;
+
+      protected override void Context()
+      {
+         base.Context();
+         sut.CurrentProject = new MoBiProject();
+         _module = new Module
+         {
+            IsPKSimModule = false
+         };
+         sut.CurrentProject.AddModule(_module);
+         _command = new AddMultipleBuildingBlocksToModuleCommand(_module, new List<IBuildingBlock> {new ParameterValuesBuildingBlock()});
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).Returns(ViewResult.Yes);
+      }
+
+      protected override void Because()
+      {
+         sut.PromptForCancellation(_command);
+      }
+
+      [Observation]
+      public void the_user_should_not_be_prompted()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).MustNotHaveHappened();
       }
    }
 


### PR DESCRIPTION
Fixes #2081

the command did not implement `IWillConvertPKSimModuleToExtensionModule` as it should have. Same command for all the symptoms
