### PR TITLE
Fixes #2479 Support removing a neighborhood via a neighborhood defined without neighbors

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,13 +16,13 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.145" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.149" />
       <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.145" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.145" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.145" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.149" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.149" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.149" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -22,15 +22,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.149" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,12 +31,12 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.149" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/DTO/NeighborhoodBuilderDTO.cs
+++ b/src/MoBi.Presentation/DTO/NeighborhoodBuilderDTO.cs
@@ -21,8 +21,8 @@ namespace MoBi.Presentation.DTO
       public NeighborhoodBuilderDTO(NeighborhoodBuilder neighborhoodBuilder, IReadOnlyList<NeighborhoodBuilder> existingNeighborhoods) : base(neighborhoodBuilder)
       {
          Icon = ApplicationIcons.Neighborhood;
-         FirstNeighborDTO = new NeighborhoodObjectPathDTO(this, () => SecondNeighborDTO) { Path = neighborhoodBuilder.FirstNeighborPath?.ToPathString() };
-         SecondNeighborDTO = new NeighborhoodObjectPathDTO(this, () => FirstNeighborDTO) { Path = neighborhoodBuilder.SecondNeighborPath?.ToPathString() };
+         FirstNeighborDTO = new NeighborhoodObjectPathDTO(this, () => SecondNeighborDTO) { Path = neighborhoodBuilder.FirstNeighborPath.ToPathString() };
+         SecondNeighborDTO = new NeighborhoodObjectPathDTO(this, () => FirstNeighborDTO) { Path = neighborhoodBuilder.SecondNeighborPath.ToPathString() };
          addExistingNeighborhoods(existingNeighborhoods);
 
          Rules.AddRange(AllRules.All);
@@ -42,7 +42,7 @@ namespace MoBi.Presentation.DTO
 
       private static void connectPaths(Cache<string, List<string>> connections, ObjectPath path1, ObjectPath path2)
       {
-         if (isNullPath(path1) || isNullPath(path2))
+         if (isEmptyPath(path1) || isEmptyPath(path2))
             return;
 
          if (!connections.Contains(path1))
@@ -51,9 +51,9 @@ namespace MoBi.Presentation.DTO
          connections[path1].Add(path2);
       }
 
-      private static bool isNullPath(ObjectPath path1)
+      private static bool isEmptyPath(ObjectPath path)
       {
-         return path1 == null || string.IsNullOrEmpty(path1.PathAsString);
+         return string.IsNullOrEmpty(path.PathAsString);
       }
 
       public bool HasConnectionBetween(string path, string secondNeighborPath)
@@ -66,24 +66,26 @@ namespace MoBi.Presentation.DTO
 
       private static class AllRules
       {
+         //A neighborhood defined without neighbors removes the neighborhood with the same name from the simulation
+         //when merging modules. The rules do not apply to an empty path (emptiness itself is validated per path)
          private static IBusinessRule noEquivalentForFirstNeighbor { get; } = CreateRule.For<NeighborhoodBuilderDTO>()
             .Property(x => x.FirstNeighborPath)
-            .WithRule((dto, path) => !dto.HasConnectionBetween(path, dto.SecondNeighborPath))
+            .WithRule((dto, path) => string.IsNullOrEmpty(path) || !dto.HasConnectionBetween(path, dto.SecondNeighborPath))
             .WithError((dto, path) => AppConstants.Validation.HasEquivalentNeighborhood(path, dto.SecondNeighborPath));
 
          private static IBusinessRule noEquivalentForSecondNeighbor { get; } = CreateRule.For<NeighborhoodBuilderDTO>()
             .Property(x => x.SecondNeighborPath)
-            .WithRule((dto, path) => !dto.HasConnectionBetween(path, dto.FirstNeighborPath))
+            .WithRule((dto, path) => string.IsNullOrEmpty(path) || !dto.HasConnectionBetween(path, dto.FirstNeighborPath))
             .WithError((dto, path) => AppConstants.Validation.HasEquivalentNeighborhood(path, dto.FirstNeighborPath));
 
          private static IBusinessRule notEqualToSecondNeighbor { get; } = CreateRule.For<NeighborhoodBuilderDTO>()
             .Property(x => x.FirstNeighborPath)
-            .WithRule((dto, path) => !Equals(path, dto.SecondNeighborPath))
+            .WithRule((dto, path) => string.IsNullOrEmpty(path) || !Equals(path, dto.SecondNeighborPath))
             .WithError((dto, path) => AppConstants.Validation.CannotCreateANeighborhoodThatConnectsAContainerToItself);
 
          private static IBusinessRule notEqualToFirstNeighbor { get; } = CreateRule.For<NeighborhoodBuilderDTO>()
             .Property(x => x.SecondNeighborPath)
-            .WithRule((dto, path) => !Equals(path, dto.FirstNeighborPath))
+            .WithRule((dto, path) => string.IsNullOrEmpty(path) || !Equals(path, dto.FirstNeighborPath))
             .WithError((dto, path) => AppConstants.Validation.CannotCreateANeighborhoodThatConnectsAContainerToItself);
 
          public static IReadOnlyList<IBusinessRule> All { get; } = new[]

--- a/src/MoBi.Presentation/DTO/NeighborhoodObjectPathDTO.cs
+++ b/src/MoBi.Presentation/DTO/NeighborhoodObjectPathDTO.cs
@@ -42,21 +42,26 @@ namespace MoBi.Presentation.DTO
 
       private static class AllRules
       {
-         private static IBusinessRule notEmptyPathRule { get; } = GenericRules.NonEmptyRule<NeighborhoodObjectPathDTO>(x => x.Path, AppConstants.Validation.EmptyPath);
+         //A neighborhood defined without neighbors removes the neighborhood with the same name from the simulation
+         //when merging modules. An empty path is therefore allowed as long as the other path is also empty
+         private static IBusinessRule notEmptyPathRule { get; } = CreateRule.For<NeighborhoodObjectPathDTO>()
+            .Property(x => x.Path)
+            .WithRule((dto, path) => !string.IsNullOrEmpty(path) || string.IsNullOrEmpty(dto._myNeighbor().Path))
+            .WithError((dto, _) => AppConstants.Validation.EmptyPath);
 
          private static IBusinessRule noEquivalentNeighborhood { get; } = CreateRule.For<NeighborhoodObjectPathDTO>()
             .Property(x => x.Path)
-            .WithRule((dto, path) => !dto.Neighborhood.HasConnectionBetween(path, dto._myNeighbor().Path))
+            .WithRule((dto, path) => string.IsNullOrEmpty(path) || !dto.Neighborhood.HasConnectionBetween(path, dto._myNeighbor().Path))
             .WithError((dto, path) => AppConstants.Validation.HasEquivalentNeighborhood(path, dto._myNeighbor().Path));
 
          private static IBusinessRule neighborsAreNotEqual { get; } = CreateRule.For<NeighborhoodObjectPathDTO>()
             .Property(x => x.Path)
-            .WithRule((dto, path) => !Equals(path, dto._myNeighbor().Path))
+            .WithRule((dto, path) => string.IsNullOrEmpty(path) || !Equals(path, dto._myNeighbor().Path))
             .WithError((dto, path) => AppConstants.Validation.CannotCreateANeighborhoodThatConnectsAContainerToItself);
 
          private static IBusinessRule neighborsArePhysical { get; } = CreateRule.For<NeighborhoodObjectPathDTO>()
-               .Property(x => x.Path) 
-               .WithRule((dto, path) => dto.Mode != ContainerMode.Logical)
+               .Property(x => x.Path)
+               .WithRule((dto, path) => string.IsNullOrEmpty(path) || dto.Mode != ContainerMode.Logical)
                .WithError((dto, _) => AppConstants.Validation.CannotCreateANeighborhoodFromLogicalContainers);
 
          public static IReadOnlyList<IBusinessRule> All { get; } = new[]

--- a/src/MoBi.Presentation/Mappers/NeighborhoodToNeighborDTOMapper.cs
+++ b/src/MoBi.Presentation/Mappers/NeighborhoodToNeighborDTOMapper.cs
@@ -32,9 +32,9 @@ namespace MoBi.Presentation.Mappers
 
       private IEnumerable<NeighborDTO> createDTOFromNeighborhoodPaths(string parentId, ObjectPath firstNeighborPath, ObjectPath secondNeighborPath)
       {
-         if(firstNeighborPath != null)
+         if(!string.IsNullOrEmpty(firstNeighborPath.PathAsString))
             yield return new NeighborDTO(firstNeighborPath) { Icon = ApplicationIcons.Neighbor, Id = createNeighborhoodId(parentId, firstNeighborPath) };
-         if(secondNeighborPath != null)
+         if(!string.IsNullOrEmpty(secondNeighborPath.PathAsString))
             yield return new NeighborDTO(secondNeighborPath) { Icon = ApplicationIcons.Neighbor, Id = createNeighborhoodId(parentId, secondNeighborPath) };
       }
 

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -21,9 +21,9 @@
   <ItemGroup>
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/Main/NotificationPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/NotificationPresenter.cs
@@ -23,8 +23,8 @@ using OSPSuite.Utility.Collections;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
 using static MoBi.Assets.AppConstants;
-using Error = OSPSuite.Assets.Error;
 using Validation = OSPSuite.Assets.Validation;
+using Warning = OSPSuite.Assets.Warning;
 
 namespace MoBi.Presentation.Presenter.Main
 {
@@ -220,8 +220,8 @@ namespace MoBi.Presentation.Presenter.Main
 
          var logicalNeighborMessages = new[]
          {
-            Error.NeighborIsLogical(neighborhood.FirstNeighbor.Name, neighborhood.Name),
-            Error.NeighborIsLogical(neighborhood.SecondNeighbor.Name, neighborhood.Name)
+            Warning.NeighborIsLogical(neighborhood.FirstNeighbor.Name, neighborhood.Name),
+            Warning.NeighborIsLogical(neighborhood.SecondNeighbor.Name, neighborhood.Name)
          };
 
          //details are only defined when more than one message was created for the neighborhood. Other messages should still be displayed

--- a/src/MoBi.Presentation/Tasks/CheckNameVisitor.cs
+++ b/src/MoBi.Presentation/Tasks/CheckNameVisitor.cs
@@ -174,13 +174,13 @@ namespace MoBi.Presentation.Tasks
          }
 
          //check first and second neighbors
-         if (neighborhoodBuilder.FirstNeighborPath?.Contains(_oldName) ?? false)
+         if (neighborhoodBuilder.FirstNeighborPath.Contains(_oldName))
          {
             var modifiedPath = renamedPathFrom(neighborhoodBuilder.FirstNeighborPath);
             _changes.Add(neighborhoodBuilder, new ChangeFirstNeighborPathCommand(modifiedPath, neighborhoodBuilder, spatialStructure));
          }
 
-         if (neighborhoodBuilder.SecondNeighborPath?.Contains(_oldName) ?? false)
+         if (neighborhoodBuilder.SecondNeighborPath.Contains(_oldName))
          {
             var modifiedPath = renamedPathFrom(neighborhoodBuilder.SecondNeighborPath);
             _changes.Add(neighborhoodBuilder, new ChangeSecondNeighborPathCommand(modifiedPath, neighborhoodBuilder, spatialStructure));

--- a/src/MoBi.Presentation/Tasks/Edit/EditTaskForNeighborhoodBuilder.cs
+++ b/src/MoBi.Presentation/Tasks/Edit/EditTaskForNeighborhoodBuilder.cs
@@ -36,8 +36,7 @@ namespace MoBi.Presentation.Tasks.Edit
          return base.EditEntityModal(neighborhood, existingObjectsInParent, commandCollector, buildingBlock);
       }
 
-      private bool neighborhoodIsConnected(NeighborhoodBuilder neighborhood) =>
-         neighborhood.FirstNeighborPath != null && neighborhood.SecondNeighborPath != null;
+      private bool neighborhoodIsConnected(NeighborhoodBuilder neighborhood) => neighborhood.HasDefinedNeighborPaths;
 
       private bool editConnectedNeighborhood(NeighborhoodBuilder neighborhood, IEnumerable<IObjectBase> existingObjectsInParent)
       {

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForSimulation.cs
@@ -52,19 +52,22 @@ namespace MoBi.Presentation.Tasks.Interaction
       private readonly ISimulationFactory _simulationFactory;
       private readonly ITemplateResolverTask _templateResolverTask;
       private readonly ICloneManagerForSimulation _cloneManager;
+      private readonly IRemovedNeighborhoodsDialogTask _removedNeighborhoodsDialogTask;
 
       public InteractionTasksForSimulation(IInteractionTaskContext interactionTaskContext,
          IEditTasksForSimulation editTask,
          ISimulationReferenceUpdater simulationReferenceUpdater,
          ISimulationFactory simulationFactory,
          ITemplateResolverTask templateResolverTask,
-         ICloneManagerForSimulation cloneManager)
+         ICloneManagerForSimulation cloneManager,
+         IRemovedNeighborhoodsDialogTask removedNeighborhoodsDialogTask)
          : base(interactionTaskContext, editTask)
       {
          _simulationReferenceUpdater = simulationReferenceUpdater;
          _simulationFactory = simulationFactory;
          _templateResolverTask = templateResolverTask;
          _cloneManager = cloneManager;
+         _removedNeighborhoodsDialogTask = removedNeighborhoodsDialogTask;
       }
 
       protected override string ObjectName => ObjectTypes.Simulation;
@@ -136,7 +139,9 @@ namespace MoBi.Presentation.Tasks.Interaction
             if (simulationConfiguration == null)
                return null;
 
-            return _simulationFactory.CreateSimulationAndValidate(simulationConfiguration, presenter.SimulationName).Simulation;
+            var (simulation, validationResult) = _simulationFactory.CreateSimulationAndValidate(simulationConfiguration, presenter.SimulationName);
+            _removedNeighborhoodsDialogTask.ShowRemovedNeighborhoodsFrom(validationResult);
+            return simulation;
          }
       }
 

--- a/src/MoBi.Presentation/Tasks/RemovedNeighborhoodsDialogTask.cs
+++ b/src/MoBi.Presentation/Tasks/RemovedNeighborhoodsDialogTask.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Services;
+using OSPSuite.Utility.Extensions;
+
+namespace MoBi.Presentation.Tasks
+{
+   public interface IRemovedNeighborhoodsDialogTask
+   {
+      /// <summary>
+      ///    Shows a dialog describing all neighborhoods that were removed from the simulation because a module redefines them
+      ///    without neighbors. Nothing is shown if no neighborhood was removed
+      /// </summary>
+      void ShowRemovedNeighborhoodsFrom(ValidationResult validationResult);
+   }
+
+   public class RemovedNeighborhoodsDialogTask : IRemovedNeighborhoodsDialogTask
+   {
+      private readonly IDialogCreator _dialogCreator;
+
+      public RemovedNeighborhoodsDialogTask(IDialogCreator dialogCreator)
+      {
+         _dialogCreator = dialogCreator;
+      }
+
+      public void ShowRemovedNeighborhoodsFrom(ValidationResult validationResult)
+      {
+         if (validationResult == null)
+            return;
+
+         //removal warnings are identified by the neighborhood builder without neighbors they were created for
+         var removalWarnings = validationResult.Messages
+            .Where(x => x.NotificationType == NotificationType.Warning)
+            .Where(x => x.Object is NeighborhoodBuilder neighborhoodBuilder && neighborhoodBuilder.HasNoNeighbors)
+            .Select(x => x.Text)
+            .ToList();
+
+         if (!removalWarnings.Any())
+            return;
+
+         _dialogCreator.MessageBoxInfo(removalWarnings.ToString("\n\n"));
+      }
+   }
+}

--- a/src/MoBi.Presentation/Tasks/SimulationUpdateTask.cs
+++ b/src/MoBi.Presentation/Tasks/SimulationUpdateTask.cs
@@ -56,6 +56,7 @@ namespace MoBi.Presentation.Tasks
       private readonly IHeavyWorkManager _heavyWorkManager;
       private readonly IConcurrencyManager _concurrencyManager;
       private readonly ICoreUserSettings _coreUserSettings;
+      private readonly IRemovedNeighborhoodsDialogTask _removedNeighborhoodsDialogTask;
 
       public SimulationUpdateTask(IMoBiContext context,
          IMoBiApplicationController applicationController,
@@ -63,7 +64,8 @@ namespace MoBi.Presentation.Tasks
          ICloneManagerForBuildingBlock cloneManager,
          IHeavyWorkManager heavyWorkManager,
          IConcurrencyManager concurrencyManager,
-         ICoreUserSettings coreUserSettings)
+         ICoreUserSettings coreUserSettings,
+         IRemovedNeighborhoodsDialogTask removedNeighborhoodsDialogTask)
       {
          _context = context;
          _applicationController = applicationController;
@@ -72,6 +74,7 @@ namespace MoBi.Presentation.Tasks
          _heavyWorkManager = heavyWorkManager;
          _concurrencyManager = concurrencyManager;
          _coreUserSettings = coreUserSettings;
+         _removedNeighborhoodsDialogTask = removedNeighborhoodsDialogTask;
       }
 
       public ICommand UpdateSimulation(IMoBiSimulation simulationToUpdate)
@@ -83,11 +86,17 @@ namespace MoBi.Presentation.Tasks
             Description = AppConstants.Commands.ConfigureSimulationsDescription(1)
          };
 
+         ValidationResult validationResult = null;
          _heavyWorkManager.Start(() =>
          {
             var simulationConfiguration = _context.Resolve<ISimulationConfigurationFactory>().CreateFromProjectTemplatesBasedOn(simulationToUpdate.Configuration);
-            macroCommand.Add(updateSimulation(simulationToUpdate, simulationConfiguration));
+            var (command, result) = updateSimulation(simulationToUpdate, simulationConfiguration);
+            macroCommand.Add(command);
+            validationResult = result;
          }, AppConstants.Captions.UpdatingSimulation);
+
+         //shown once the heavy work completes so that the dialog is displayed from the UI thread
+         _removedNeighborhoodsDialogTask.ShowRemovedNeighborhoodsFrom(validationResult);
 
          return macroCommand;
       }
@@ -186,12 +195,19 @@ namespace MoBi.Presentation.Tasks
             return new MoBiEmptyCommand();
 
          ICommand command = null;
-         _heavyWorkManager.Start(() => { command = updateSimulation(simulationToConfigure, simulationConfiguration); }, AppConstants.Captions.ConfiguringSimulation);
+         ValidationResult validationResult = null;
+         _heavyWorkManager.Start(() =>
+         {
+            (command, validationResult) = updateSimulation(simulationToConfigure, simulationConfiguration);
+         }, AppConstants.Captions.ConfiguringSimulation);
+
+         //shown once the heavy work completes so that the dialog is displayed from the UI thread
+         _removedNeighborhoodsDialogTask.ShowRemovedNeighborhoodsFrom(validationResult);
 
          return command ?? new MoBiEmptyCommand();
       }
 
-      private ICommand<IMoBiContext> updateSimulation(
+      private (ICommand<IMoBiContext> command, ValidationResult validationResult) updateSimulation(
          IMoBiSimulation simulationToUpdate,
          SimulationConfiguration simulationConfigurationReferencingTemplates)
       {
@@ -202,7 +218,7 @@ namespace MoBi.Presentation.Tasks
          results = _simulationFactory.CreateModelAndValidate(simulationConfigurationReferencingTemplates, simulationToUpdate.Model.Name);
 
          if (results == null)
-            return new MoBiEmptyCommand();
+            return (new MoBiEmptyCommand(), null);
 
          //create a clone then that will be saved in the simulation
          var simulationBuildConfiguration = _cloneManager.Clone(simulationConfigurationReferencingTemplates);
@@ -211,7 +227,7 @@ namespace MoBi.Presentation.Tasks
 
          updateSimulationCommand.RunCommand(_context);
 
-         return updateSimulationCommand;
+         return (updateSimulationCommand, results.ValidationResult);
       }
    }
 }

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.149" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/Diagram/DiagramManagers/SpatialStructureDiagramManager.cs
+++ b/src/MoBi.UI/Diagram/DiagramManagers/SpatialStructureDiagramManager.cs
@@ -124,20 +124,15 @@ namespace MoBi.UI.Diagram.DiagramManagers
       {
          var (firstNeighborNode, secondNeighborNode) = base.GetNeighborHoodNodes(neighborhoodBase);
 
-         if (neighborhoodBase is NeighborhoodBuilder neighborhoodBuilder && isComplete(neighborhoodBuilder))
+         if (neighborhoodBase is NeighborhoodBuilder neighborhoodBuilder && neighborhoodBuilder.HasDefinedNeighborPaths)
          {
             if (firstNeighborNode == null)
                firstNeighborNode = DiagramModel.GetNode<IContainerNode>(neighborhoodBuilder.FirstNeighborPath);
             if (secondNeighborNode == null)
                secondNeighborNode = DiagramModel.GetNode<IContainerNode>(neighborhoodBuilder.SecondNeighborPath);
          }
-           
-         return (firstNeighborNode, secondNeighborNode);
-      }
 
-      private bool isComplete(NeighborhoodBuilder neighborhoodBuilder)
-      {
-         return neighborhoodBuilder.FirstNeighborPath != null && neighborhoodBuilder.SecondNeighborPath != null;
+         return (firstNeighborNode, secondNeighborNode);
       }
    }
 }

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -25,11 +25,11 @@
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -57,13 +57,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.145" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" GeneratePathProperty="true" />
     <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/Core/Commands/ChangeFirstNeighborPathCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/ChangeFirstNeighborPathCommandSpecs.cs
@@ -69,9 +69,10 @@ namespace MoBi.Core.Commands
       }
 
       [Observation]
-      public void should_set_the_path_as_expected()
+      public void should_set_the_path_to_an_empty_path()
       {
-         _neighborhoodBuilder.FirstNeighborPath.ShouldBeNull();
+         //the neighbor path is never null: an empty path indicates that the neighbor is not defined
+         _neighborhoodBuilder.FirstNeighborPath.PathAsString.ShouldBeEqualTo(string.Empty);
       }
    }
 }

--- a/tests/MoBi.Tests/Core/Commands/ChangeSecondNeighborPathCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/ChangeSecondNeighborPathCommandSpecs.cs
@@ -56,9 +56,10 @@ namespace MoBi.Core.Commands
       }
 
       [Observation]
-      public void should_set_the_path_as_expected()
+      public void should_set_the_path_to_an_empty_path()
       {
-         _neighborhoodBuilder.SecondNeighborPath.ShouldBeNull();
+         //the neighbor path is never null: an empty path indicates that the neighbor is not defined
+         _neighborhoodBuilder.SecondNeighborPath.PathAsString.ShouldBeEqualTo(string.Empty);
       }
    }
 }

--- a/tests/MoBi.Tests/Core/Service/SimulationUpdateTaskSpecs.cs
+++ b/tests/MoBi.Tests/Core/Service/SimulationUpdateTaskSpecs.cs
@@ -34,6 +34,7 @@ namespace MoBi.Core.Service
       protected ISimulationConfigurationFactory _simulationConfigurationFactory;
       private IConcurrencyManager _concurrencyManager;
       private ICoreUserSettings _coreUserSettings;
+      protected IRemovedNeighborhoodsDialogTask _removedNeighborhoodsDialogTask;
       private SynchronizationContext _originalSynchronizationContext;
 
       protected override void Context()
@@ -56,7 +57,9 @@ namespace MoBi.Core.Service
          _originalSynchronizationContext = SynchronizationContext.Current;
          SynchronizationContext.SetSynchronizationContext(new SynchronousSynchronizationContextForSpecs());
 
-         sut = new SimulationUpdateTask(_context, _applicationController, _simulationFactory, _cloneManager, createHeavyWorkManager(), _concurrencyManager, _coreUserSettings);
+         _removedNeighborhoodsDialogTask = A.Fake<IRemovedNeighborhoodsDialogTask>();
+
+         sut = new SimulationUpdateTask(_context, _applicationController, _simulationFactory, _cloneManager, createHeavyWorkManager(), _concurrencyManager, _coreUserSettings, _removedNeighborhoodsDialogTask);
       }
 
       protected virtual IHeavyWorkManager createHeavyWorkManager() => new HeavyWorkManagerForSpecs();

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -28,9 +28,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.149" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/MoBi.Tests/Presentation/ComparisonChartPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ComparisonChartPresenterSpecs.cs
@@ -21,6 +21,7 @@ using OSPSuite.Presentation.Presenters.Charts;
 using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Services.Charts;
 using OSPSuite.Presentation.Views.Charts;
+using OSPSuite.Utility.Events;
 using IApplicationSettings = OSPSuite.Core.IApplicationSettings;
 using IChartTemplatingTask = MoBi.Presentation.Tasks.IChartTemplatingTask;
 
@@ -83,7 +84,7 @@ public class concern_for_ComparisonChartPresenter : ContextSpecification<Compari
    protected virtual IChartDisplayPresenter CreateDisplayPresenter()
    {
       return new ChartDisplayPresenter(_chartDisplayView, _curveBinderFactory, _contextMenuFactoryForProjectItem,
-         _axisBinderFactory, _dataModeMapper, _chartExportTask, _applicationSettings, _applicationController, _dialogCreator);
+         _axisBinderFactory, _dataModeMapper, _chartExportTask, _applicationSettings, _applicationController, _dialogCreator, A.Fake<IEventPublisher>());
    }
 }
 

--- a/tests/MoBi.Tests/Presentation/InteractionTasksForSimulationSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/InteractionTasksForSimulationSpecs.cs
@@ -6,6 +6,7 @@ using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
 using MoBi.Core.Services;
 using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Tasks;
 using MoBi.Presentation.Tasks.Edit;
 using MoBi.Presentation.Tasks.Interaction;
 using OSPSuite.BDDHelper;
@@ -33,6 +34,7 @@ namespace MoBi.Presentation
       protected MoBiProject _moBiProject;
       protected ITemplateResolverTask _templateResolver;
       protected ICloneManagerForSimulation _cloneManager;
+      protected IRemovedNeighborhoodsDialogTask _removedNeighborhoodsDialogTask;
 
       protected override void Context()
       {
@@ -56,8 +58,9 @@ namespace MoBi.Presentation
          A.CallTo(() => _interactionTaskContext.Context).Returns(_moBiContext);
 
          _templateResolver = A.Fake<ITemplateResolverTask>();
+         _removedNeighborhoodsDialogTask = A.Fake<IRemovedNeighborhoodsDialogTask>();
 
-         sut = new InteractionTasksForSimulation(_interactionTaskContext, _editTask, _simulationReferenceUpdater, _simulationFactory, _templateResolver, _cloneManager);
+         sut = new InteractionTasksForSimulation(_interactionTaskContext, _editTask, _simulationReferenceUpdater, _simulationFactory, _templateResolver, _cloneManager, _removedNeighborhoodsDialogTask);
       }
    }
 

--- a/tests/MoBi.Tests/Presentation/NeighborhoodBuilderDTOSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/NeighborhoodBuilderDTOSpecs.cs
@@ -69,6 +69,32 @@ namespace MoBi.Presentation
       }
    }
 
+   public class When_validating_a_neighborhood_without_neighbors : concern_for_NeighborhoodBuilderDTO
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _neighborhoodBuilderDTO.Name = "NeighborhoodName";
+         //both neighbor paths remain empty: such a neighborhood removes the neighborhood with the same name when merging modules
+      }
+
+      protected override List<NeighborhoodBuilder> GetExistingNeighborhoods()
+      {
+         return new List<NeighborhoodBuilder>
+         {
+            new NeighborhoodBuilder { FirstNeighborPath = new ObjectPath("FirstNeighborPath1"), SecondNeighborPath = new ObjectPath("SecondNeighborPath1") },
+         };
+      }
+
+      [Observation]
+      public void should_be_valid()
+      {
+         _neighborhoodBuilderDTO.Validate().IsEmpty.ShouldBeTrue();
+         _neighborhoodBuilderDTO.FirstNeighborDTO.Validate().IsEmpty.ShouldBeTrue();
+         _neighborhoodBuilderDTO.SecondNeighborDTO.Validate().IsEmpty.ShouldBeTrue();
+      }
+   }
+
    public class When_validating_a_neighborhood_with_colliding_neighborhoods_with_a_name : concern_for_NeighborhoodBuilderDTO
    {
       protected override void Context()

--- a/tests/MoBi.Tests/Presentation/NotificationPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/NotificationPresenterSpecs.cs
@@ -296,7 +296,7 @@ namespace MoBi.Presentation
 
       private void addLogicalNeighborWarningFor(Neighborhood neighborhood, IContainer neighbor)
       {
-         _validationResult.AddMessage(NotificationType.Warning, neighborhood, Error.NeighborIsLogical(neighbor.Name, neighborhood.Name));
+         _validationResult.AddMessage(NotificationType.Warning, neighborhood, Warning.NeighborIsLogical(neighbor.Name, neighborhood.Name));
       }
 
       protected override void Because()

--- a/tests/MoBi.Tests/Presentation/RemovedNeighborhoodsDialogTaskSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/RemovedNeighborhoodsDialogTaskSpecs.cs
@@ -1,0 +1,88 @@
+using FakeItEasy;
+using MoBi.Presentation.Tasks;
+using OSPSuite.BDDHelper;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Services;
+
+namespace MoBi.Presentation
+{
+   public abstract class concern_for_RemovedNeighborhoodsDialogTask : ContextSpecification<IRemovedNeighborhoodsDialogTask>
+   {
+      protected IDialogCreator _dialogCreator;
+      protected ValidationResult _validationResult;
+
+      protected override void Context()
+      {
+         _dialogCreator = A.Fake<IDialogCreator>();
+         _validationResult = new ValidationResult();
+         sut = new RemovedNeighborhoodsDialogTask(_dialogCreator);
+      }
+   }
+
+   public class When_showing_the_removed_neighborhoods_for_a_validation_result_with_removal_warnings : concern_for_RemovedNeighborhoodsDialogTask
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var neighborhoodWithoutNeighbors = new NeighborhoodBuilder().WithName("removed_neighborhood");
+         _validationResult.AddMessage(NotificationType.Warning, neighborhoodWithoutNeighbors, "The neighborhood 'removed_neighborhood' was removed");
+
+         //a warning for a neighborhood with neighbors (e.g. a logical neighbor warning) is not a removal
+         var connectedNeighborhood = new NeighborhoodBuilder().WithName("connected_neighborhood");
+         connectedNeighborhood.FirstNeighborPath = new ObjectPath("A");
+         connectedNeighborhood.SecondNeighborPath = new ObjectPath("B");
+         _validationResult.AddMessage(NotificationType.Warning, connectedNeighborhood, "Container 'A' is defined as logical");
+      }
+
+      protected override void Because()
+      {
+         sut.ShowRemovedNeighborhoodsFrom(_validationResult);
+      }
+
+      [Observation]
+      public void should_show_a_dialog_describing_only_the_removed_neighborhoods()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>.That.Matches(x =>
+            x.Contains("The neighborhood 'removed_neighborhood' was removed") &&
+            !x.Contains("logical")))).MustHaveHappened();
+      }
+   }
+
+   public class When_showing_the_removed_neighborhoods_for_a_validation_result_without_removal_warnings : concern_for_RemovedNeighborhoodsDialogTask
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var connectedNeighborhood = new NeighborhoodBuilder().WithName("connected_neighborhood");
+         connectedNeighborhood.FirstNeighborPath = new ObjectPath("A");
+         connectedNeighborhood.SecondNeighborPath = new ObjectPath("B");
+         _validationResult.AddMessage(NotificationType.Warning, connectedNeighborhood, "Container 'A' is defined as logical");
+      }
+
+      protected override void Because()
+      {
+         sut.ShowRemovedNeighborhoodsFrom(_validationResult);
+      }
+
+      [Observation]
+      public void should_not_show_a_dialog()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>._)).MustNotHaveHappened();
+      }
+   }
+
+   public class When_showing_the_removed_neighborhoods_for_an_undefined_validation_result : concern_for_RemovedNeighborhoodsDialogTask
+   {
+      protected override void Because()
+      {
+         sut.ShowRemovedNeighborhoodsFrom(null);
+      }
+
+      [Observation]
+      public void should_not_show_a_dialog()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>._)).MustNotHaveHappened();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/SimulationChartPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/SimulationChartPresenterSpecs.cs
@@ -23,6 +23,7 @@ using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Presenters.Nodes;
 using OSPSuite.Presentation.Services.Charts;
 using OSPSuite.Presentation.Views.Charts;
+using OSPSuite.Utility.Events;
 using IApplicationSettings = OSPSuite.Core.IApplicationSettings;
 using IChartTemplatingTask = MoBi.Presentation.Tasks.IChartTemplatingTask;
 
@@ -100,7 +101,7 @@ public class concern_for_SimulationChartPresenter : ContextSpecification<Simulat
 
    protected virtual IChartDisplayPresenter CreateDisplayPresenter()
    {
-      return new ChartDisplayPresenter(_chartDisplayView, _curveBinderFactory, _contextMenuFactoryForProjectItem, _axisBinderFactory, _dataModeMapper, _chartExportTask, _applicationSettings, _applicationController, _dialogCreator);
+      return new ChartDisplayPresenter(_chartDisplayView, _curveBinderFactory, _contextMenuFactoryForProjectItem, _axisBinderFactory, _dataModeMapper, _chartExportTask, _applicationSettings, _applicationController, _dialogCreator, A.Fake<IEventPublisher>());
    }
 }
 

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.145" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.145" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.149" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #2479

MoBi side of Open-Systems-Pharmacology/OSPSuite.Core#2919, where a neighborhood defined without neighbors removes the neighborhood with the same name when merging modules.

- Neighborhood validation accepts both neighbor paths being empty, so the removal can be authored
- A dialog lists the removed neighborhoods after creating, updating or configuring a simulation
- `NeighborIsLogical` moved from `Error` to `Warning`, and neighbor paths are never null (empty means undefined)
- Core bumped to 13.0.149

Blank neighborhoods are valid
<img width="699" height="213" alt="image" src="https://github.com/user-attachments/assets/39546c47-578b-4973-9e7c-fdb80f9f1b5a" />

Removed neighborhoods are listed. They also have notification messages
<img width="860" height="179" alt="image" src="https://github.com/user-attachments/assets/bda06dd6-013c-4989-b1ef-993a365a5df6" />

If you specify an invalid neighbor in any module, the simulation will not build and you will see this error
<img width="1034" height="163" alt="image" src="https://github.com/user-attachments/assets/eb4f3344-4e3d-46dc-b587-356d8655e46a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications identifying neighborhoods removed during simulation creation or updates.
  * Added support for neighborhoods with intentionally empty neighbor paths.
* **Bug Fixes**
  * Improved neighborhood validation and connectivity handling for empty paths.
  * Corrected warning notifications for logical neighboring objects.
  * Improved diagram behavior when resolving configured neighbor paths.
* **Chores**
  * Updated OSPSuite components to version 13.0.149.
* **Tests**
  * Expanded coverage for empty neighborhoods, removal notifications, and updated validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->