### PR TITLE
Fixes #2086 Reset the simulation state correctly when rolling back multiple parameter changes

### DIFF
--- a/src/MoBi.Core/Commands/SetQuantityValueInSimulationCommand.cs
+++ b/src/MoBi.Core/Commands/SetQuantityValueInSimulationCommand.cs
@@ -32,8 +32,9 @@ namespace MoBi.Core.Commands
             resetQuantity();
          else
          {
+            var wasFixedValue = _quantity.IsFixedValue;
             _quantity.Value = _valueToSet;
-            _fixedValueSetHere = true;
+            _fixedValueSetHere = !wasFixedValue;
 
             if (formulaIsConstantEqualsToTheNewValue)
                resetQuantity();

--- a/src/MoBi.Core/Commands/SynchronizeInitialConditionCommand.cs
+++ b/src/MoBi.Core/Commands/SynchronizeInitialConditionCommand.cs
@@ -1,4 +1,4 @@
-﻿using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Commands.Core;
 using MoBi.Core.Domain.Model;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
@@ -6,6 +6,7 @@ using OSPSuite.Core.Domain.Formulas;
 using MoBi.Assets;
 using OSPSuite.Assets;
 using MoBi.Core.Domain.Services;
+using OSPSuite.Core.Domain.UnitSystem;
 
 namespace MoBi.Core.Commands
 {
@@ -17,10 +18,14 @@ namespace MoBi.Core.Commands
       private IMoBiSimulation _simulation;
       private readonly string _simulationId;
       private readonly string _quantityId;
+      private double? _originalValue;
+      private Unit _originalDisplayUnit;
+      private double _originalScaleDivisor;
+      private readonly ValueOrigin _originalValueOrigin = new ValueOrigin();
 
       /// <summary>
       ///    Ensures that the value defined in the <see cref="InitialCondition" /> of simulation are synchronized
-      ///    with the values defined in the <see cref="IQuantity" /> 
+      ///    with the values defined in the <see cref="IQuantity" />
       /// </summary>
       public SynchronizeInitialConditionCommand(IQuantity quantity, InitialCondition initialCondition, InitialConditionsBuildingBlock buildingBlock, IMoBiSimulation simulation) : base(buildingBlock)
       {
@@ -37,6 +42,11 @@ namespace MoBi.Core.Commands
       protected override void ExecuteWith(IMoBiContext context)
       {
          base.ExecuteWith(context);
+         _originalValue = _initialCondition.Value;
+         _originalDisplayUnit = _initialCondition.DisplayUnit;
+         _originalScaleDivisor = _initialCondition.ScaleDivisor;
+         _originalValueOrigin.UpdateFrom(_initialCondition.ValueOrigin);
+
          updateInitialCondition();
 
          if (_initialCondition.Dimension == _quantity.Dimension)
@@ -54,7 +64,7 @@ namespace MoBi.Core.Commands
       {
          _initialCondition.UpdateValueOriginFrom(_quantity.ValueOrigin);
 
-         //we are dealing with a quantity in simulation that was initialized with a constant value, we can update 
+         //we are dealing with a quantity in simulation that was initialized with a constant value, we can update
          if (_quantity.Formula.IsConstant())
          {
             _initialCondition.Value = _quantity.Value;
@@ -82,7 +92,7 @@ namespace MoBi.Core.Commands
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
       {
-         return new SynchronizeInitialConditionCommand(_quantity, _initialCondition, _buildingBlock, _simulation)
+         return new RestoreInitialConditionCommand(_quantity, _initialCondition, _buildingBlock, _simulation, _originalValue, _originalDisplayUnit, _originalScaleDivisor, _originalValueOrigin)
          {
             Visible = Visible
          }.AsInverseFor(this);
@@ -93,6 +103,70 @@ namespace MoBi.Core.Commands
          base.RestoreExecutionData(context);
          _quantity = context.Get<IQuantity>(_quantityId);
          _simulation = context.CurrentProject.Simulations.FindById(_simulationId);
+      }
+
+      // Should only ever be invoked as an inverse to the SynchronizeInitialConditionCommand command. The values committed to the
+      // building block cannot be recovered from the quantity because it still holds the value that was committed.
+      private class RestoreInitialConditionCommand : BuildingBlockChangeCommandBase<InitialConditionsBuildingBlock>
+      {
+         private IQuantity _quantity;
+         private readonly InitialCondition _initialCondition;
+         private IMoBiSimulation _simulation;
+         private readonly string _simulationId;
+         private readonly string _quantityId;
+         private readonly double? _valueToRestore;
+         private readonly Unit _displayUnitToRestore;
+         private readonly double _scaleDivisorToRestore;
+         private readonly ValueOrigin _valueOriginToRestore;
+
+         public RestoreInitialConditionCommand(IQuantity quantity, InitialCondition initialCondition, InitialConditionsBuildingBlock buildingBlock, IMoBiSimulation simulation,
+            double? valueToRestore, Unit displayUnitToRestore, double scaleDivisorToRestore, ValueOrigin valueOriginToRestore) : base(buildingBlock)
+         {
+            _quantity = quantity;
+            _quantityId = quantity.Id;
+            _initialCondition = initialCondition;
+            _simulation = simulation;
+            _simulationId = simulation.Id;
+            _valueToRestore = valueToRestore;
+            _displayUnitToRestore = displayUnitToRestore;
+            _scaleDivisorToRestore = scaleDivisorToRestore;
+            _valueOriginToRestore = valueOriginToRestore;
+            ObjectType = ObjectTypes.InitialCondition;
+            CommandType = AppConstants.Commands.UpdateCommand;
+         }
+
+         protected override void ExecuteWith(IMoBiContext context)
+         {
+            base.ExecuteWith(context);
+            _initialCondition.Value = _valueToRestore;
+            _initialCondition.DisplayUnit = _displayUnitToRestore;
+            _initialCondition.ScaleDivisor = _scaleDivisorToRestore;
+            _initialCondition.UpdateValueOriginFrom(_valueOriginToRestore);
+
+            Description = AppConstants.Commands.UpdateInitialCondition(_initialCondition.Path, _initialCondition.Value, _initialCondition.IsPresent, _initialCondition.DisplayUnit, _initialCondition.ScaleDivisor, _initialCondition.NegativeValuesAllowed);
+         }
+
+         protected override void ClearReferences()
+         {
+            base.ClearReferences();
+            _quantity = null;
+            _simulation = null;
+         }
+
+         protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
+         {
+            return new SynchronizeInitialConditionCommand(_quantity, _initialCondition, _buildingBlock, _simulation)
+            {
+               Visible = Visible
+            }.AsInverseFor(this);
+         }
+
+         public override void RestoreExecutionData(IMoBiContext context)
+         {
+            base.RestoreExecutionData(context);
+            _quantity = context.Get<IQuantity>(_quantityId);
+            _simulation = context.CurrentProject.Simulations.FindById(_simulationId);
+         }
       }
    }
 }

--- a/src/MoBi.Core/Commands/SynchronizeParameterValueCommand.cs
+++ b/src/MoBi.Core/Commands/SynchronizeParameterValueCommand.cs
@@ -1,10 +1,11 @@
-﻿using MoBi.Assets;
+using MoBi.Assets;
 using MoBi.Core.Domain.Model;
 using MoBi.Core.Domain.Services;
 using OSPSuite.Assets;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.UnitSystem;
 
 namespace MoBi.Core.Commands
 {
@@ -15,6 +16,10 @@ namespace MoBi.Core.Commands
       private IMoBiSimulation _simulation;
       private readonly string _parameterId;
       private readonly string _simulationId;
+      private double? _originalValue;
+      private IDimension _originalDimension;
+      private Unit _originalDisplayUnit;
+      private readonly ValueOrigin _originalValueOrigin = new ValueOrigin();
 
       public SynchronizeParameterValueCommand(IParameter parameter, ParameterValue parameterValue, ParameterValuesBuildingBlock changingBuildingBlock, IMoBiSimulation simulation) : base(changingBuildingBlock)
       {
@@ -30,6 +35,11 @@ namespace MoBi.Core.Commands
       protected override void ExecuteWith(IMoBiContext context)
       {
          base.ExecuteWith(context);
+         _originalValue = _parameterValue.Value;
+         _originalDimension = _parameterValue.Dimension;
+         _originalDisplayUnit = _parameterValue.DisplayUnit;
+         _originalValueOrigin.UpdateFrom(_parameterValue.ValueOrigin);
+
          _parameterValue.Value = _parameter.Value;
          _parameterValue.Dimension = _parameter.Dimension;
          _parameterValue.DisplayUnit = _parameter.DisplayUnit;
@@ -48,7 +58,7 @@ namespace MoBi.Core.Commands
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
       {
-         return new SynchronizeParameterValueCommand(_parameter, _parameterValue, _buildingBlock, _simulation)
+         return new RestoreParameterValueCommand(_parameter, _parameterValue, _buildingBlock, _simulation, _originalValue, _originalDimension, _originalDisplayUnit, _originalValueOrigin)
          {
             Visible = Visible,
          }.AsInverseFor(this);
@@ -59,6 +69,70 @@ namespace MoBi.Core.Commands
          base.RestoreExecutionData(context);
          _parameter = context.Get<IParameter>(_parameterId);
          _simulation = context.CurrentProject.Simulations.FindById(_simulationId);
+      }
+
+      // Should only ever be invoked as an inverse to the SynchronizeParameterValueCommand command. The values committed to the
+      // building block cannot be recovered from the parameter because it still holds the value that was committed.
+      private class RestoreParameterValueCommand : BuildingBlockChangeCommandBase<ParameterValuesBuildingBlock>
+      {
+         private IParameter _parameter;
+         private readonly ParameterValue _parameterValue;
+         private IMoBiSimulation _simulation;
+         private readonly string _parameterId;
+         private readonly string _simulationId;
+         private readonly double? _valueToRestore;
+         private readonly IDimension _dimensionToRestore;
+         private readonly Unit _displayUnitToRestore;
+         private readonly ValueOrigin _valueOriginToRestore;
+
+         public RestoreParameterValueCommand(IParameter parameter, ParameterValue parameterValue, ParameterValuesBuildingBlock changingBuildingBlock, IMoBiSimulation simulation,
+            double? valueToRestore, IDimension dimensionToRestore, Unit displayUnitToRestore, ValueOrigin valueOriginToRestore) : base(changingBuildingBlock)
+         {
+            _parameter = parameter;
+            _parameterId = parameter.Id;
+            _parameterValue = parameterValue;
+            _simulation = simulation;
+            _simulationId = simulation.Id;
+            _valueToRestore = valueToRestore;
+            _dimensionToRestore = dimensionToRestore;
+            _displayUnitToRestore = displayUnitToRestore;
+            _valueOriginToRestore = valueOriginToRestore;
+            CommandType = AppConstants.Commands.UpdateCommand;
+            ObjectType = ObjectTypes.ParameterValue;
+         }
+
+         protected override void ExecuteWith(IMoBiContext context)
+         {
+            base.ExecuteWith(context);
+            _parameterValue.Value = _valueToRestore;
+            _parameterValue.Dimension = _dimensionToRestore;
+            _parameterValue.DisplayUnit = _displayUnitToRestore;
+            _parameterValue.UpdateValueOriginFrom(_valueOriginToRestore);
+
+            Description = AppConstants.Commands.UpdateParameterValue(_parameterValue.Path, _parameterValue.Value, _parameterValue.DisplayUnit);
+         }
+
+         protected override void ClearReferences()
+         {
+            base.ClearReferences();
+            _parameter = null;
+            _simulation = null;
+         }
+
+         protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
+         {
+            return new SynchronizeParameterValueCommand(_parameter, _parameterValue, _buildingBlock, _simulation)
+            {
+               Visible = Visible,
+            }.AsInverseFor(this);
+         }
+
+         public override void RestoreExecutionData(IMoBiContext context)
+         {
+            base.RestoreExecutionData(context);
+            _parameter = context.Get<IParameter>(_parameterId);
+            _simulation = context.CurrentProject.Simulations.FindById(_simulationId);
+         }
       }
    }
 }

--- a/tests/MoBi.Tests/Core/Commands/SetQuantityValueInSimulationCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/SetQuantityValueInSimulationCommandSpecs.cs
@@ -96,6 +96,33 @@ namespace MoBi.Core.Commands
       }
    }
 
+   public class When_executing_the_inverse_of_setting_a_value_in_a_quantity_that_was_already_fixed : concern_for_SetQuantityValueInSimulationCommand
+   {
+      protected override IQuantity CreateQuantity()
+      {
+         var quantity = new Parameter().WithFormula(new ConstantFormula(_oldValue));
+         quantity.Value = 7;
+         return quantity;
+      }
+
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_context);
+      }
+
+      [Observation]
+      public void should_have_restored_the_previously_fixed_value()
+      {
+         _quantity.Value.ShouldBeEqualTo(7);
+      }
+
+      [Observation]
+      public void the_quantity_should_still_be_marked_as_fixed()
+      {
+         _quantity.IsFixedValue.ShouldBeTrue();
+      }
+   }
+
    public class When_setting_a_value_in_a_quantity_with_explicit_formula : concern_for_SetQuantityValueInSimulationCommand
    {
       protected override IQuantity CreateQuantity()

--- a/tests/MoBi.Tests/Core/Commands/SetQuantityValueInSimulationCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/SetQuantityValueInSimulationCommandSpecs.cs
@@ -123,6 +123,33 @@ namespace MoBi.Core.Commands
       }
    }
 
+   public class When_executing_the_inverse_of_setting_a_value_in_a_quantity_that_was_already_fixed_to_the_constant_formula_value : concern_for_SetQuantityValueInSimulationCommand
+   {
+      protected override IQuantity CreateQuantity()
+      {
+         var quantity = new Parameter().WithFormula(new ConstantFormula(_valueToSet));
+         quantity.Value = 7;
+         return quantity;
+      }
+
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_context);
+      }
+
+      [Observation]
+      public void should_have_restored_the_previously_fixed_value()
+      {
+         _quantity.Value.ShouldBeEqualTo(7);
+      }
+
+      [Observation]
+      public void the_quantity_should_still_be_marked_as_fixed()
+      {
+         _quantity.IsFixedValue.ShouldBeTrue();
+      }
+   }
+
    public class When_setting_a_value_in_a_quantity_with_explicit_formula : concern_for_SetQuantityValueInSimulationCommand
    {
       protected override IQuantity CreateQuantity()

--- a/tests/MoBi.Tests/Core/Commands/SynchronizeInitialConditionCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/SynchronizeInitialConditionCommandSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using FakeItEasy;
 using MoBi.Core.Domain.Model;
+using MoBi.HelpersForTests;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
@@ -18,7 +19,7 @@ namespace MoBi.Core.Commands
       private Unit _displayUnit1;
       protected Unit _displayUnit2;
       protected IMoBiContext _context;
-      private IMoBiSimulation _simulation;
+      protected IMoBiSimulation _simulation;
 
       protected override void Context()
       {
@@ -150,6 +151,46 @@ namespace MoBi.Core.Commands
       public void should_update_the_start_value()
       {
          _initialCondition.Value.ShouldBeEqualTo(5);
+      }
+   }
+
+   public class When_synchronizing_an_initial_condition_that_already_had_a_value_and_getting_reverse_command : concern_for_SynchronizeInitialConditionCommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _initialCondition.Dimension = _dimension1;
+         _initialCondition.DisplayUnit = _displayUnit2;
+         _initialCondition.Value = 20;
+         _initialCondition.ScaleDivisor = 3;
+
+         var project = DomainHelperForSpecs.NewProject();
+         project.AddSimulation(_simulation);
+         A.CallTo(() => _context.CurrentProject).Returns(project);
+         A.CallTo(() => _context.Get<IQuantity>(_moleculeAmount.Id)).Returns(_moleculeAmount);
+      }
+
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_context);
+      }
+
+      [Observation]
+      public void should_have_restored_the_previous_value_of_the_initial_condition()
+      {
+         _initialCondition.Value.ShouldBeEqualTo(20);
+      }
+
+      [Observation]
+      public void should_have_restored_the_previous_scale_divisor()
+      {
+         _initialCondition.ScaleDivisor.ShouldBeEqualTo(3);
+      }
+
+      [Observation]
+      public void should_have_restored_the_previous_display_unit()
+      {
+         _initialCondition.DisplayUnit.ShouldBeEqualTo(_displayUnit2);
       }
    }
 }

--- a/tests/MoBi.Tests/Core/Commands/SynchronizeParameterValueCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/SynchronizeParameterValueCommandSpecs.cs
@@ -98,4 +98,34 @@ namespace MoBi.Core.Commands
          A.CallTo(() => _context.CurrentProject).MustHaveHappened();
       }
    }
+
+   public class synchronizing_a_parameter_value_that_already_had_a_value_and_getting_reverse_command : concern_for_SynchronizeParameterValueCommand
+   {
+      private MoBiProject _project;
+
+      protected override void Context()
+      {
+         base.Context();
+         _parameter.Dimension = A.Fake<IDimension>();
+         _parameter.DisplayUnit = A.Fake<Unit>();
+         _parameter.Value = 32;
+         _parameterStartValue.Value = 31;
+         A.CallTo(() => _context.Get<IParameter>(_parameter.Id)).Returns(_parameter);
+
+         _project = DomainHelperForSpecs.NewProject();
+         _project.AddSimulation(_simulation);
+         A.CallTo(() => _context.CurrentProject).Returns(_project);
+      }
+
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_context);
+      }
+
+      [Observation]
+      public void should_have_restored_the_previous_value_of_the_parameter_value()
+      {
+         _parameterStartValue.Value.ShouldBeEqualTo(31);
+      }
+   }
 }


### PR DESCRIPTION
Two defects made a rollback leave a simulation inconsistent after the same parameter was changed and committed twice.

**`SetQuantityValueInSimulationCommand`** marked itself as the command that turned `IsFixedValue` on even when the quantity was already fixed. Undoing the second change therefore cleared the flag and dropped the quantity to its formula value. The stale value no longer matched the tracked original, so the change survived the rollback and the simulation stayed marked as changed. Fixes #2086.

**`SynchronizeParameterValueCommand` / `SynchronizeInitialConditionCommand`** built their inverse as another synchronize command, which re-reads the live quantity at execute time. During a rollback that runs before the quantity itself is undone, so the building block kept the committed value while the simulation reported no changes. Both now snapshot the previous value (plus dimension, display unit, scale divisor and value origin) and restore it.

Regression specs added for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved undo behavior when restoring simulation quantities that were already fixed.
  - Synchronizing initial conditions now correctly restores previous values, units, scale, and value origin when undone.
  - Synchronizing parameter values now reliably restores their prior state during undo.

- **Tests**
  - Added coverage for preserving fixed quantities and restoring previous initial-condition and parameter settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->