### PR TITLE
Remove dead OSPSuite.TeXReporting dependency

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -29,7 +29,6 @@ task :create_setup, [:product_version, :configuration] do |t, args|
 #Files required for setup creation only
 setup_files	 = [
    "#{relative_src_dir}/ChartLayouts/**/*.{wxs,xml}",
-   "#{relative_src_dir}/TeXTemplates/**/*.*",
    'examples/**/*.{wxs,pkml,mbp3}',
    'src/Data/**/*.*',
    'src/MoBi.Assets/Resources/*.ico',
@@ -109,7 +108,6 @@ end
 
 def copy_templates_files(source_dir)
    FileUtils.mkdir_p setup_temp_dir
-   FileUtils.copy_entry File.join(source_dir, 'TeXTemplates'), File.join(setup_temp_dir, 'TeXTemplates')
    FileUtils.copy_entry File.join(source_dir, 'ChartLayouts'), File.join(setup_temp_dir, 'ChartLayouts')
    FileUtils.copy_entry File.join(source_dir, 'Templates'), File.join(setup_temp_dir, 'Templates')
 end
@@ -141,10 +139,6 @@ task :postclean do |t, args|
    
    copy_dependencies packages_dir,   File.join(all_users_application_dir, 'ChartLayouts') do
       copy_files 'ChartLayouts', 'xml'
-   end
-   
-   copy_dependencies packages_dir,   File.join(all_users_application_dir, 'TeXTemplates', 'StandardTemplate') do
-      copy_files 'StandardTemplate', '*'
    end
 end
 

--- a/setup/setup.wxs
+++ b/setup/setup.wxs
@@ -113,14 +113,6 @@
                   </CreateFolder>
                 </Component>
               </Directory>
-
-              <Directory Id="TeXTemplatesFolder" Name="TeXTemplates">
-                <Component Id="TeXTemplatesFolder" Guid="B53F252A-675F-442F-B539-239A210F594A">
-                  <CreateFolder Directory="TeXTemplatesFolder">
-                    <Permission User="Everyone" GenericAll="yes" />
-                  </CreateFolder>
-                </Component>
-              </Directory>
             </Directory>
           </Directory>
         </Directory>
@@ -153,7 +145,6 @@
     <Feature Id="Main" Title="$(var.ProductName)" Level="1" Absent="disallow" AllowAdvertise="no">
       <ComponentGroupRef Id="App" />
       <ComponentGroupRef Id="ChartLayouts" />
-      <ComponentGroupRef Id="OSPSuite.TeXReporting" />
       <ComponentGroupRef Id="Examples" />
       <ComponentGroupRef Id="Templates" />
 
@@ -169,7 +160,6 @@
       <ComponentRef Id="GroupRepository.xml" />
       <ComponentRef Id="MoBiCommonDataFolder" />
       <ComponentRef Id="MoBiCommonDataVersionFolder" />
-      <ComponentRef Id="TeXTemplatesFolder" />
       <ComponentRef Id="ExamplesFolder" />
       <ComponentRef Id="ExampleFolderShortCut" />
       <ComponentRef Id="TemplatesFolder" />

--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -74,8 +74,6 @@ namespace MoBi.Assets
       {
          public static readonly string EmptyColumn = " ";
 
-         public static readonly string ReportCreationStarted = "Report creation started...";
-         public static readonly string ReportCreationFinished = "Report created!";
          public static readonly string Concentration = "Concentration";
       }
 
@@ -1131,7 +1129,6 @@ namespace MoBi.Assets
          public static readonly string ZoomOut = "Zoom Out";
          public static readonly string FitToPage = "Fit to Page";
          public static readonly string ExportHistoryToExcel = "Export to Excel®...";
-         public static readonly string ProjectReport = "Project Report";
          public static readonly string SimulationReport = "Create Simulation Report...";
          public static readonly string SetToDefault = "Set to Default";
          public static readonly string Extend = "Extend";
@@ -1677,8 +1674,6 @@ namespace MoBi.Assets
          public static readonly string ExportModelAsTables = "Export Model as Tables...";
          public static readonly string SelectProjectRateDimension = "Select Reaction Rate Base for Project";
          public static readonly string EmptyColumn = " ";
-         public static readonly string ReportCreationStarted = "Report creation started...";
-         public static readonly string ReportCreationFinished = "Report created!";
          public static readonly string NoValuesFound = "No values imported";
          public static readonly string SelectProjectRateDimensionDescription = "Reactions and their formulas can either compute amount (µmol) or concentration (µmol/l) changes. Please select:";
          public static readonly string AmountBasedModel = "Amount based reactions";
@@ -1885,10 +1880,6 @@ namespace MoBi.Assets
          public static string ManageDisplayUnits(string type) => $"Manage {type} Display Units";
 
          public static string ParameterRightHandSide(string name) => $"d{name}/dt = ";
-
-         public static string ReportCreationStartedMessage(string reportFullPath) => "This might take a while...";
-
-         public static string ReportCreationFinishedMessage(string reportFullPath) => $"Report can be found at {reportFullPath}";
 
          public static string ConvertingExcelSheetToQuantities(string tableName) => $"Converting Excel sheet {tableName}";
 

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -39,9 +39,6 @@
      <Content Include="..\..\pkparameters\OSPSuite.PKParameters.xml" Link="OSPSuite.PKParameters.xml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
      </Content>
-     <Content Include="$(PkgOSPSuite_TeXReporting)\OSPSuite.TeXReporting\**">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-     </Content>
      <Content Include="..\Data\**">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
      </Content>

--- a/src/MoBi.Presentation/MenusAndBars/StatusBarElements.cs
+++ b/src/MoBi.Presentation/MenusAndBars/StatusBarElements.cs
@@ -13,7 +13,6 @@ namespace MoBi.Presentation.MenusAndBars
       public static StatusBarElement ProjectName = createStatusBarElement(StatusBarElementType.Text, StatusBarElementSize.Content, StatusBarElementAlignment.Left, 150);
       public static StatusBarElement ProjectPath = createStatusBarElement(StatusBarElementType.Text, StatusBarElementSize.Content, StatusBarElementAlignment.Left, 150);
       public static StatusBarElement ProjectReactionDimensionMode = createStatusBarElement(StatusBarElementType.Text, StatusBarElementSize.Content, StatusBarElementAlignment.Left, 150);
-      public static StatusBarElement Report = createStatusBarElement(StatusBarElementType.Text, StatusBarElementSize.Content, StatusBarElementAlignment.Right, 150);
       public static StatusBarElement ProgressStatus = createStatusBarElement(StatusBarElementType.Text, StatusBarElementSize.Content, StatusBarElementAlignment.Right, 250);
       public static StatusBarElement ProgressBar = createStatusBarElement(StatusBarElementType.ProgressBar, StatusBarElementSize.None, StatusBarElementAlignment.Right, 150);
       public static StatusBarElement Version = createStatusBarElement(StatusBarElementType.Text, StatusBarElementSize.Content, StatusBarElementAlignment.Right, 0);

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" />
     <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.149" />

--- a/src/MoBi.Presentation/Presenter/Main/StatusBarPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/Main/StatusBarPresenter.cs
@@ -12,7 +12,6 @@ using OSPSuite.Core.Events;
 using OSPSuite.Presentation.MenuAndBars;
 using OSPSuite.Presentation.Presenters.Main;
 using OSPSuite.Presentation.Views;
-using OSPSuite.TeXReporting.Events;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
 
@@ -25,8 +24,6 @@ namespace MoBi.Presentation.Presenter.Main
       IListener<ProgressDoneEvent>,
       IListener<ProjectClosedEvent>,
       IListener<ProjectSavedEvent>,
-      IListener<ReportCreationStartedEvent>,
-      IListener<ReportCreationFinishedEvent>,
       IListener<SimulationRunCanceledEvent>,
       IListener<SimulationRunFinishedEvent>,
       IListener<SimulationRunStartedEvent>,
@@ -39,8 +36,7 @@ namespace MoBi.Presentation.Presenter.Main
       private readonly IStatusBarView _view;
       private readonly IMoBiConfiguration _moBiConfiguration;
       public event EventHandler StatusChanged = delegate { };
-      private int _numberOfReportsBeingCreated;
-      private readonly ConcurrentDictionary<string, bool> _simulations = new ConcurrentDictionary<string, bool>(); 
+      private readonly ConcurrentDictionary<string, bool> _simulations = new ConcurrentDictionary<string, bool>();
 
       private int activeSimulations => _simulations.Count(x => x.Value);
       
@@ -92,18 +88,6 @@ namespace MoBi.Presentation.Presenter.Main
             .WithCaption(reactionDimensionMode)
             .And.ToolTipText($"Reaction Rate Base: {reactionDimensionMode}")
             .And.Enabled(enabled);
-      }
-
-      private void updateReportInfo()
-      {
-         string caption = "";
-         if (_numberOfReportsBeingCreated == 1)
-            caption = "1 report is being created...";
-         else if (_numberOfReportsBeingCreated > 1)
-            caption = $"{_numberOfReportsBeingCreated} reports are being created...";
-
-         update(StatusBarElements.Report)
-            .WithCaption(caption);
       }
 
       private IStatusBarElementExpression update(StatusBarElement statusBarElement)
@@ -200,18 +184,6 @@ namespace MoBi.Presentation.Presenter.Main
       public void ReleaseFrom(IEventPublisher eventPublisher)
       {
          eventPublisher.RemoveListener(this);
-      }
-
-      public void Handle(ReportCreationStartedEvent eventToHandle)
-      {
-         _numberOfReportsBeingCreated++;
-         updateReportInfo();
-      }
-
-      public void Handle(ReportCreationFinishedEvent eventToHandle)
-      {
-         _numberOfReportsBeingCreated--;
-         updateReportInfo();
       }
 
       public void Handle(SimulationRunFinishedEvent eventToHandle)

--- a/src/MoBi.Presentation/Presenter/MoBiMainViewPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/MoBiMainViewPresenter.cs
@@ -9,7 +9,6 @@ using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Presenters.ContextMenus;
 using OSPSuite.Presentation.Presenters.Main;
 using OSPSuite.Presentation.Services;
-using OSPSuite.TeXReporting.Events;
 using OSPSuite.Utility.Collections;
 using OSPSuite.Utility.Events;
 using OSPSuite.Utility.Extensions;
@@ -18,8 +17,6 @@ using IProjectTask = MoBi.Presentation.Tasks.IProjectTask;
 namespace MoBi.Presentation.Presenter
 {
    public interface IMoBiMainViewPresenter : IMainViewPresenter,
-      IListener<ReportCreationStartedEvent>,
-      IListener<ReportCreationFinishedEvent>,
       IListener<ProjectLoadedEvent>,
       IListener<ProjectClosedEvent>,
       IListener<ProjectSavedEvent>
@@ -107,18 +104,6 @@ namespace MoBi.Presentation.Presenter
             default:
                return;
          }
-      }
-
-      public void Handle(ReportCreationStartedEvent reportStartedEvent)
-      {
-         _view.DisplayNotification(AppConstants.Captions.ReportCreationStarted,
-            AppConstants.Captions.ReportCreationStartedMessage(reportStartedEvent.ReportFullPath), string.Empty);
-      }
-
-      public void Handle(ReportCreationFinishedEvent reportFinishedEvent)
-      {
-         _view.DisplayNotification(AppConstants.Captions.ReportCreationFinished,
-            AppConstants.Captions.ReportCreationFinishedMessage(reportFinishedEvent.ReportFullPath), reportFinishedEvent.ReportFullPath);
       }
 
       public bool FormClosing()

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -34,9 +34,6 @@
     <Content Include="$(PkgOSPSuite_Presentation)\OSPSuite.Presentation\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="$(PkgOSPSuite_TeXReporting)\OSPSuite.TeXReporting\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="..\Data\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -64,7 +61,6 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" GeneratePathProperty="true" />
-    <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -15,9 +15,6 @@
     <Content Include="..\..\pkparameters\OSPSuite.PKParameters.xml" Link="OSPSuite.PKParameters.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="$(PkgOSPSuite_TeXReporting)\OSPSuite.TeXReporting\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
@@ -36,7 +33,6 @@
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.TeXReporting" Version="3.0.1.3" GeneratePathProperty="true" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.CLI.Core\MoBi.CLI.Core.csproj" />


### PR DESCRIPTION
Fixes #2496

MiKTeX is being dropped from the Suite installer (Open-Systems-Pharmacology/Suite#202, Open-Systems-Pharmacology/Suite#204). Nothing in MoBi invoked TeXReporting: the only publisher of `ReportCreationStartedEvent`/`ReportCreationFinishedEvent` is its own `ReportCreator`, which MoBi never constructs, so the handlers were unreachable. Same change as Open-Systems-Pharmacology/PK-Sim#3674.

Removed:
- the unreachable handlers in `StatusBarPresenter` and `MoBiMainViewPresenter`, plus `StatusBarElements.Report` and the constants they used
- `PackageReference` and `Content Include` for `OSPSuite.TeXReporting` across `MoBi`, `MoBi.CLI`, `MoBi.Presentation` and `MoBi.Tests`, and the `ComponentGroupRef` in `setup.wxs`
- the `TeXTemplates` plumbing in `rakefile.rb` and `setup.wxs`, which existed only to deploy the TeX templates

Kept deliberately:
- `MenuNames.SimulationReport` — still live via `ContextMenuForSimulation` → `CreateSimulationReportUICommand` → `EditTasksForSimulation.CreateReport`, which writes a text file using Core's `ModelReportCreator`. Only its neighbour `ProjectReport` was dead.
- MoBi's own `Templates` (pkml) folder in `rakefile.rb` — unrelated to TeX despite the similar name. Only the `TeXTemplates` lines were removed.
- the `Progress*` listeners in both presenters, which come from OSPSuite.Utility and OSPSuite.Core.

Note the `TeXTemplates` removal had to land in the same change: `rakefile.rb` copied it from the build output, where it only appeared via the TeXReporting content copy, so removing the content copy alone would have broken the portable setup.

`ReportCreationStarted`/`Finished` were defined twice, in both `Groups` and `Captions`. The presenter used the `Captions` pair; both are unreferenced now and both are removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed project report generation and related status notifications.
  * Removed TeX-based report templates and installer components.
  * Removed report-related status-bar messaging and menu entries.
* **Maintenance**
  * Cleaned up report-generation files and package content from application, CLI, installer, and test deployments.
  * Simulation progress tracking and other status-bar functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->