### PR TITLE
Fixes #2484 Display simulation curves in charts after loading a snapshot

### DIFF
--- a/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
+++ b/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
@@ -122,6 +122,7 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
          NumberOfSimulationsLoaded = 0
       };
 
+      var simulationsWithSnapshots = new List<(MoBiSimulation simulation, Simulation snapshot)>();
       if (projectSnapshot.Simulations != null)
       {
          foreach (var x in projectSnapshot.Simulations)
@@ -130,6 +131,7 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
             {
                var simulation = await _simulationMapper.MapToModel(x, simulationContext);
                addSimulations(project, simulation);
+               simulationsWithSnapshots.Add((simulation, x));
                simulationContext.NumberOfSimulationsLoaded++;
             }
             catch (Exception e)
@@ -146,6 +148,9 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
       {
          await runParallelSimulations(project);
       }
+
+      //map analyses after the run so that simulation result columns are available to resolve the curves
+      simulationsWithSnapshots.Each(x => _simulationMapper.MapAnalysesToSimulation(x.simulation, x.snapshot, simulationContext));
 
       await updateProjectClassifications(projectSnapshot, snapshotContext);
 

--- a/src/MoBi.Core/Snapshots/Mappers/SimulationMapper.cs
+++ b/src/MoBi.Core/Snapshots/Mappers/SimulationMapper.cs
@@ -74,12 +74,6 @@ public class SimulationMapper : ObjectBaseSnapshotMapperBase<MoBiSimulation, Sim
       var snapshotContextWithSimulation = new SnapshotContextWithSimulation(mobiSimulation, context);
       mobiSimulation.Settings.OutputSelections = await _outputSelectionsMapper.MapToModel(snapshot.OutputSelections, snapshotContextWithSimulation);
 
-      var simulationAnalysisContext = new SimulationAnalysisContext(context.Project.AllObservedData, context);
-
-      snapshot.Charts?.Each(x => mobiSimulation.AddAnalysis(_timeProfileChartMapper.MapToModel(x, simulationAnalysisContext).Result));
-      snapshot.PredictedVsObservedCharts?.Each(x => mobiSimulation.AddAnalysis(_predictedVsObservedChartMapper.MapToModel(x, simulationAnalysisContext).Result));
-      snapshot.ResidualVsTimeCharts?.Each(x => mobiSimulation.AddAnalysis(_residualsVsTimeChartMapper.MapToModel(x, simulationAnalysisContext).Result));
-
       snapshot.OutputMappings?.Each(x => mobiSimulation.OutputMappings.Add(_outputMappingMapper.MapToModel(x, snapshotContextWithSimulation).Result));
 
       updateParameters(mobiSimulation, snapshot.Parameters);
@@ -87,6 +81,18 @@ public class SimulationMapper : ObjectBaseSnapshotMapperBase<MoBiSimulation, Sim
       updateScaleDivisors(mobiSimulation, snapshot.ScaleDivisors);
 
       return mobiSimulation;
+   }
+
+   //Must run after the simulation so its result columns are available to resolve curves referencing simulation outputs
+   public void MapAnalysesToSimulation(MoBiSimulation simulation, Simulation snapshot, SimulationContext context)
+   {
+      var simulationAnalysisContext = new SimulationAnalysisContext(context.Project.AllObservedData, context) { RunSimulation = context.Run };
+      if (simulation.ResultsDataRepository != null)
+         simulationAnalysisContext.AddDataRepository(simulation.ResultsDataRepository);
+
+      snapshot.Charts?.Each(x => simulation.AddAnalysis(_timeProfileChartMapper.MapToModel(x, simulationAnalysisContext).Result));
+      snapshot.PredictedVsObservedCharts?.Each(x => simulation.AddAnalysis(_predictedVsObservedChartMapper.MapToModel(x, simulationAnalysisContext).Result));
+      snapshot.ResidualVsTimeCharts?.Each(x => simulation.AddAnalysis(_residualsVsTimeChartMapper.MapToModel(x, simulationAnalysisContext).Result));
    }
 
    public override async Task<Simulation> MapToSnapshot(MoBiSimulation simulation, MoBiProject project)

--- a/tests/MoBi.Tests/IntegrationTests/Snapshots/SimulationMapperSpecs.cs
+++ b/tests/MoBi.Tests/IntegrationTests/Snapshots/SimulationMapperSpecs.cs
@@ -11,8 +11,10 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Chart.Simulations;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Data;
+using OSPSuite.Core.Snapshots.Mappers;
 using OSPSuite.Utility.Container;
 using SimulationPredictedVsObservedChart = OSPSuite.Core.Chart.Simulations.SimulationPredictedVsObservedChart;
+using SnapshotSimulation = MoBi.Core.Snapshots.Simulation;
 
 namespace MoBi.IntegrationTests.Snapshots
 {
@@ -130,6 +132,102 @@ namespace MoBi.IntegrationTests.Snapshots
       {
          _result.OutputSelections.Count().ShouldBeEqualTo(1);
          _result.OutputSelections.First().ShouldBeEqualTo("sim|container|quantity");
+      }
+   }
+
+   public abstract class concern_for_mapping_analyses_to_simulation : concern_for_SimulationMapper
+   {
+      protected MoBiSimulation _simulationWithAnalyses;
+      protected SnapshotSimulation _snapshot;
+      protected SimulationContext _context;
+      protected bool _run;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _simulationWithAnalyses = new MoBiSimulation().WithName("sim");
+         SetupResults();
+
+         _snapshot = new SnapshotSimulation
+         {
+            Charts = new[]
+            {
+               new OSPSuite.Core.Snapshots.CurveChart
+               {
+                  Curves = new[]
+                  {
+                     new OSPSuite.Core.Snapshots.Curve
+                     {
+                        Name = "simulation output curve",
+                        X = "Time",
+                        Y = "sim|Comp|Liver|Cell|Concentration",
+                        CurveOptions = new OSPSuite.Core.Snapshots.CurveOptions()
+                     }
+                  }
+               }
+            }
+         };
+
+         _context = new SimulationContext(_run, new SnapshotContext(_project, OSPSuite.Core.Snapshots.SnapshotVersions.Current));
+      }
+
+      protected abstract void SetupResults();
+
+      protected override void Because()
+      {
+         sut.MapAnalysesToSimulation(_simulationWithAnalyses, _snapshot, _context);
+      }
+   }
+
+   public class When_mapping_analyses_to_a_simulation_that_has_results : concern_for_mapping_analyses_to_simulation
+   {
+      protected override void Context()
+      {
+         _run = true;
+         base.Context();
+      }
+
+      protected override void SetupResults()
+      {
+         _simulationWithAnalyses.ResultsDataRepository = DomainHelperForSpecs.IndividualSimulationDataRepositoryFor("sim");
+      }
+
+      [Observation]
+      public void the_time_profile_chart_should_be_added_to_the_simulation()
+      {
+         _simulationWithAnalyses.Charts.Count().ShouldBeEqualTo(1);
+      }
+
+      [Observation]
+      public void the_curve_referencing_the_simulation_output_should_be_created_from_the_result_data()
+      {
+         _simulationWithAnalyses.Charts.Single().Curves.Count.ShouldBeEqualTo(1);
+      }
+   }
+
+   public class When_mapping_analyses_to_a_simulation_that_has_no_results : concern_for_mapping_analyses_to_simulation
+   {
+      protected override void Context()
+      {
+         _run = false;
+         base.Context();
+      }
+
+      protected override void SetupResults()
+      {
+      }
+
+      [Observation]
+      public void the_time_profile_chart_should_be_added_to_the_simulation()
+      {
+         _simulationWithAnalyses.Charts.Count().ShouldBeEqualTo(1);
+      }
+
+      [Observation]
+      public void the_curve_referencing_the_simulation_output_cannot_be_resolved_without_results()
+      {
+         _simulationWithAnalyses.Charts.Single().Curves.Count.ShouldBeEqualTo(0);
       }
    }
 }


### PR DESCRIPTION
## Issue

Fixes #2484

After loading a snapshot, curves that reference **simulation outputs** were not shown in a simulation's charts (observed-data curves loaded fine), even with **Run simulations** enabled.

## Root cause

In `SimulationMapper.MapToModel` the chart analyses were mapped immediately while creating each simulation, using a `SimulationAnalysisContext` built only from the project's observed data. The simulations were only run afterwards in `ProjectMapper` (`runParallelSimulations`). So at chart-mapping time no simulation results existed and the results repository was never added to the context, so `CurveMapper` could not resolve the simulation-output columns and silently dropped those curves.

## Fix

Mirror how PK-Sim loads simulation analyses from a snapshot:

- `SimulationMapper` no longer maps the charts inside `MapToModel`. A new `MapAnalysesToSimulation(...)` maps the time-profile / predicted-vs-observed / residual charts, building the analysis context with `RunSimulation = context.Run` and adding the simulation's own `ResultsDataRepository` when present.
- `ProjectMapper.mapToModel` collects the `(simulation, snapshot)` pairs, runs the simulations, and only then maps the analyses — so the simulation result columns are available to resolve the curves.

Behaviour when **Run simulations** is unchecked is unchanged (no results → nothing to plot for simulation-output curves).

## Tests

Added specs in `SimulationMapperSpecs` covering `MapAnalysesToSimulation`:
- a simulation with results resolves its simulation-output curve;
- a simulation without results still gets the chart but drops the unresolvable curve.