### PR TITLE
Fixes #2485 Preserve MoBi building block names when round-tripping PK-Sim snapshots

### DIFF
--- a/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
+++ b/src/MoBi.Core/Snapshots/Mappers/ProjectMapper.cs
@@ -80,11 +80,11 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
 
       var inputMappings = new List<InputMapping>();
 
-      return (await mapToModel(snapshot, projectContext, (module, project) =>
-         inputMappings.AddRange(loadModulesAndExportInputsFromPKSimSnapshot(module, project, qualificationConfiguration))), inputMappings.ToArray());
+      return (await mapToModel(snapshot, projectContext, (module, moBiName, project) =>
+         inputMappings.AddRange(loadModulesAndExportInputsFromPKSimSnapshot(module, moBiName, project, qualificationConfiguration))), inputMappings.ToArray());
    }
 
-   private async Task<ModelProject> mapToModel(SnapshotProject projectSnapshot, ProjectContext context, Action<string, ModelProject> rebuildAction)
+   private async Task<ModelProject> mapToModel(SnapshotProject projectSnapshot, ProjectContext context, Action<string, string, ModelProject> rebuildAction)
    {
       var project = context.MoBiProject();
 
@@ -98,7 +98,7 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
       projectSnapshot.PKSimModules?.Each((x, i) =>
       {
          _logger.AddInfo($"Loading PK-Sim module from project snapshot ({i + 1}/{projectSnapshot.PKSimModules.Length})...", projectSnapshot.Name);
-         rebuildAction(pkSimSnapshotToBase64String(x), project);
+         rebuildAction(pkSimSnapshotToBase64String(x), moBiModuleNameAt(projectSnapshot, i), project);
       });
 
       projectSnapshot.ExtensionModules?.Each(x => project.AddModule(deserializeFromBase64PKML<Module>(x, project)));
@@ -155,6 +155,8 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
    private ExpressionProfileBuildingBlock loadExpressionProfileFromSnapshotAndUpdateValues(ExpressionProfileSnapshot expressionProfileSnapshot, ModelProject project)
    {
       var buildingBlock = _pkSimSnapshotConverter.LoadExpressionProfileFromSnapshot(pkSimSnapshotToBase64String(expressionProfileSnapshot.PKSimSnapshot));
+      if (!string.IsNullOrEmpty(expressionProfileSnapshot.MoBiName))
+         buildingBlock.Name = expressionProfileSnapshot.MoBiName;
       expressionProfileSnapshot.UpdatedValues?.Each(x => _parameterValueUpdateManager.UpdateParameterValueIn<ExpressionProfileBuildingBlock, ExpressionParameter>(buildingBlock, x, formulaCacheFrom(expressionProfileSnapshot, project)));
       return buildingBlock;
    }
@@ -162,6 +164,8 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
    private IndividualBuildingBlock loadIndividualFromSnapshotAndUpdateValues(IndividualSnapshot individualSnapshot, ModelProject project)
    {
       var buildingBlock = _pkSimSnapshotConverter.LoadIndividualFromSnapshot(pkSimSnapshotToBase64String(individualSnapshot.PKSimSnapshot));
+      if (!string.IsNullOrEmpty(individualSnapshot.MoBiName))
+         buildingBlock.Name = individualSnapshot.MoBiName;
       individualSnapshot.UpdatedValues?.Each(x => _parameterValueUpdateManager.UpdateParameterValueIn<IndividualBuildingBlock, IndividualParameter>(buildingBlock, x, formulaCacheFrom(individualSnapshot, project)));
       return buildingBlock;
    }
@@ -202,26 +206,35 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
       AddClassifiableToProject<ClassifiableSimulation, IMoBiSimulation>(project, x, project.AddSimulation, project.Simulations);
    }
 
-   private void loadModulesFromPKSimSnapshot(string snapshot, ModelProject project)
+   private void loadModulesFromPKSimSnapshot(string snapshot, string moBiName, ModelProject project)
    {
       var module = _pkSimSnapshotConverter.LoadModuleFromSnapshot(snapshot);
 
-      loadModuleToProject(project, module);
+      loadModuleToProject(project, module, moBiName);
    }
 
-   private static void loadModuleToProject(ModelProject project, Module module)
+   private static void loadModuleToProject(ModelProject project, Module module, string moBiName)
    {
+      //PK-Sim rebuilds the module using the name of the simulation captured in the snapshot, but the MoBi module may
+      //have been renamed on import to avoid a collision (for example two simulations sharing the same individual).
+      //Restore the MoBi name so simulations can still resolve their module by name.
+      if (!string.IsNullOrEmpty(moBiName))
+         module.Name = moBiName;
+
       project.AddModule(module);
    }
 
-   private InputMapping[] loadModulesAndExportInputsFromPKSimSnapshot(string snapshot, ModelProject project, QualificationConfiguration config)
+   private InputMapping[] loadModulesAndExportInputsFromPKSimSnapshot(string snapshot, string moBiName, ModelProject project, QualificationConfiguration config)
    {
       var (module, inputMappings) = _pkSimSnapshotConverter.LoadModuleFromSnapshotAndExportInputs(snapshot, config);
 
-      loadModuleToProject(project, module);
+      loadModuleToProject(project, module, moBiName);
 
       return inputMappings;
    }
+
+   private static string moBiModuleNameAt(SnapshotProject projectSnapshot, int index) =>
+      projectSnapshot.PKSimModuleNames != null && index < projectSnapshot.PKSimModuleNames.Length ? projectSnapshot.PKSimModuleNames[index] : null;
 
    private Task updateProjectClassifications(SnapshotProject snapshot, SnapshotContext snapshotContext)
    {
@@ -252,7 +265,9 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
          x.Description = SnapshotValueFor(project.Description);
       });
 
-      snapshot.PKSimModules = mapPKSimModules(project);
+      var pkSimModules = project.Modules.Where(shouldUsePKSimSnapshot).ToList();
+      snapshot.PKSimModules = pkSimModules.Select(x => base64StringToPKSimSnapshot(x.Snapshot)).ToArray();
+      snapshot.PKSimModuleNames = pkSimModules.Select(x => x.Name).ToArray();
       snapshot.ExtensionModules = mapExtensionModules(project);
       snapshot.ExpressionProfileBuildingBlocks = mapExpressionProfilesBuildingBlocks(project);
       snapshot.IndividualBuildingBlocks = mapIndividualBuildingBlocks(project);
@@ -275,8 +290,6 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
 
    private Simulation[] mapSimulations(IReadOnlyList<MoBiSimulation> projectSimulations, ModelProject project) => _simulationMapper.MapToSnapshots(projectSimulations, project).Result;
 
-   private object[] mapPKSimModules(ModelProject project) => project.Modules.Where(shouldUsePKSimSnapshot).Select(x => base64StringToPKSimSnapshot(x.Snapshot)).ToArray();
-
    private string[] mapExtensionModules(ModelProject project) => project.Modules.Where(x => !shouldUsePKSimSnapshot(x)).Select(serializeToBase64PKML).ToArray();
 
    private string[] mapExpressionProfilesBuildingBlocks(ModelProject project) => project.ExpressionProfileCollection.Where(x => !x.HasSnapshot).Select(serializeToBase64PKML).ToArray();
@@ -288,6 +301,7 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
    {
       var snapshot = new ExpressionProfileSnapshot
       {
+         MoBiName = buildingBlock.Name,
          PKSimSnapshot = base64StringToPKSimSnapshot(buildingBlock.Snapshot),
          UpdatedValues = buildingBlock.ExpressionParameters.Where(x => x.HasInitialState).MapAllUsing(_parameterValueUpdateManager).ToArray()
       };
@@ -313,6 +327,7 @@ public class ProjectMapper : ProjectMapper<ModelProject, SnapshotProject, Projec
    {
       var snapshot = new IndividualSnapshot
       {
+         MoBiName = buildingBlock.Name,
          PKSimSnapshot = base64StringToPKSimSnapshot(buildingBlock.Snapshot),
          UpdatedValues = buildingBlock.Where(x => x.HasInitialState).MapAllUsing(_parameterValueUpdateManager).ToArray()
       };

--- a/src/MoBi.Core/Snapshots/ParameterValueSnapshotWithUpdates.cs
+++ b/src/MoBi.Core/Snapshots/ParameterValueSnapshotWithUpdates.cs
@@ -2,6 +2,13 @@
 
 public abstract class ParameterValueSnapshotWithUpdates
 {
+   /// <summary>
+   ///    The name of the building block in the MoBi project. The <see cref="PKSimSnapshot" /> carries the PK-Sim name, but
+   ///    the MoBi building block may have been renamed on import to avoid a collision with an existing building block (for
+   ///    example when importing two simulations that share the same individual). Preserving the MoBi name here keeps the
+   ///    round-trip unique so simulations can still resolve their building blocks after the snapshot is loaded.
+   /// </summary>
+   public string MoBiName { get; set; }
    public object PKSimSnapshot { get; set; }
    public UpdatedParameterValue[] UpdatedValues { get; set; }
    public string FormulaCache { get; set; }

--- a/src/MoBi.Core/Snapshots/Project.cs
+++ b/src/MoBi.Core/Snapshots/Project.cs
@@ -12,6 +12,14 @@ public class Project : SnapshotBase
 
    public object[] PKSimModules { set; get; }
 
+   /// <summary>
+   ///    The MoBi project names of the modules in <see cref="PKSimModules" />, in the same order. Each PK-Sim snapshot
+   ///    carries the name it had in PK-Sim, but the MoBi module may have been renamed on import to avoid a collision (for
+   ///    example when importing two simulations that share the same individual). Preserving the MoBi name keeps the module
+   ///    resolvable by simulations after the snapshot is loaded. Null for snapshots written before this was introduced.
+   /// </summary>
+   public string[] PKSimModuleNames { set; get; }
+
    public string[] ExtensionModules { set; get; }
 
    public string[] ExpressionProfileBuildingBlocks { set; get; }

--- a/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectMapperSpecs.cs
+++ b/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectMapperSpecs.cs
@@ -461,4 +461,124 @@ namespace MoBi.IntegrationTests.Snapshots
          A.CallTo(() => _parameterValueUpdateManager.MapFrom(_expressionParameter)).MustHaveHappened();
       }
    }
+
+   internal class When_mapping_project_to_snapshot_with_renamed_pksim_building_blocks : concern_for_ProjectMapper
+   {
+      private SnapshotProject _snapshot;
+
+      protected override void Context()
+      {
+         base.Context();
+         _snapshotIndividualBuildingBlock.Name = "Walker 1979 Volunteer 6 1";
+         _snapshotExpressionProfile.Name = "CYP3A4|Human|Healthy 1";
+      }
+
+      protected override void Because()
+      {
+         _snapshot = sut.MapToSnapshot(_project).Result;
+      }
+
+      [Observation]
+      public void the_individual_snapshot_should_carry_the_current_building_block_name()
+      {
+         _snapshot.IndividualBuildingBlockSnapshots.Single().MoBiName.ShouldBeEqualTo("Walker 1979 Volunteer 6 1");
+      }
+
+      [Observation]
+      public void the_expression_profile_snapshot_should_carry_the_current_building_block_name()
+      {
+         _snapshot.ExpressionProfileSnapshots.Single().MoBiName.ShouldBeEqualTo("CYP3A4|Human|Healthy 1");
+      }
+   }
+
+   internal class When_mapping_snapshot_to_project_with_renamed_pksim_building_blocks : concern_for_ProjectMapper
+   {
+      private SnapshotProject _snapshot;
+      private MoBiProject _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _snapshotIndividualBuildingBlock.Name = "Walker 1979 Volunteer 6 1";
+         _snapshotExpressionProfile.Name = "CYP3A4|Human|Healthy 1";
+
+         //PK-Sim always recreates the building blocks with their original (colliding) names
+         A.CallTo(() => _pkSimStarter.LoadIndividualFromSnapshot(A<string>._)).ReturnsLazily(() => new IndividualBuildingBlock().WithName("Walker 1979 Volunteer 6"));
+         A.CallTo(() => _pkSimStarter.LoadExpressionProfileFromSnapshot(A<string>._)).ReturnsLazily(() => new ExpressionProfileBuildingBlock { Type = ExpressionTypes.MetabolizingEnzyme, Name = "CYP3A4|Human|Healthy" });
+
+         _snapshot = sut.MapToSnapshot(_project).Result;
+      }
+
+      protected override void Because()
+      {
+         _result = sut.MapToModel(_snapshot, new ProjectContext(new MoBiProject(), runSimulations: false)).Result;
+      }
+
+      [Observation]
+      public void the_loaded_individual_should_keep_the_name_stored_in_the_snapshot()
+      {
+         _result.IndividualsCollection.Select(x => x.Name).ShouldContain("Walker 1979 Volunteer 6 1");
+      }
+
+      [Observation]
+      public void the_loaded_expression_profile_should_keep_the_name_stored_in_the_snapshot()
+      {
+         _result.ExpressionProfileCollection.Select(x => x.Name).ShouldContain("CYP3A4|Human|Healthy 1");
+      }
+   }
+
+   internal class When_mapping_project_to_snapshot_with_renamed_pksim_modules : concern_for_ProjectMapper
+   {
+      private SnapshotProject _snapshot;
+
+      protected override void Context()
+      {
+         base.Context();
+         _project.Modules.Single(x => x.Id == "pksimmodule").Name = "Henrist oral Hot stage extrusion as table";
+         var secondPKSimModule = new Module { IsPKSimModule = true, Snapshot = "{ \"JSON\":true }".ToBase64String(), Id = "pksimmodule2" }.WithName("Henrist oral Hot stage extrusion as table 1 1");
+         _project.AddModule(secondPKSimModule);
+      }
+
+      protected override void Because()
+      {
+         _snapshot = sut.MapToSnapshot(_project).Result;
+      }
+
+      [Observation]
+      public void the_snapshot_should_carry_the_current_module_names_in_the_same_order_as_the_pksim_modules()
+      {
+         _snapshot.PKSimModuleNames.Length.ShouldBeEqualTo(_snapshot.PKSimModules.Length);
+         _snapshot.PKSimModuleNames.ShouldContain("Henrist oral Hot stage extrusion as table", "Henrist oral Hot stage extrusion as table 1 1");
+      }
+   }
+
+   internal class When_mapping_snapshot_to_project_with_renamed_pksim_modules : concern_for_ProjectMapper
+   {
+      private SnapshotProject _snapshot;
+      private MoBiProject _result;
+
+      protected override void Context()
+      {
+         base.Context();
+         _project.Modules.Single(x => x.Id == "pksimmodule").Name = "Henrist oral Hot stage extrusion as table";
+         var secondPKSimModule = new Module { IsPKSimModule = true, Snapshot = "{ \"JSON\":true }".ToBase64String(), Id = "pksimmodule2" }.WithName("Henrist oral Hot stage extrusion as table 1 1");
+         _project.AddModule(secondPKSimModule);
+
+         //PK-Sim always recreates the module with the (colliding) simulation name captured in the snapshot
+         A.CallTo(() => _pkSimStarter.LoadModuleFromSnapshot(A<string>._)).ReturnsLazily(() => new Module { IsPKSimModule = true }.WithName("Henrist oral Hot stage extrusion as table"));
+
+         _snapshot = sut.MapToSnapshot(_project).Result;
+      }
+
+      protected override void Because()
+      {
+         _result = sut.MapToModel(_snapshot, new ProjectContext(new MoBiProject(), runSimulations: false)).Result;
+      }
+
+      [Observation]
+      public void the_loaded_modules_should_keep_the_names_stored_in_the_snapshot()
+      {
+         _result.Modules.Select(x => x.Name).ShouldContain("Henrist oral Hot stage extrusion as table", "Henrist oral Hot stage extrusion as table 1 1");
+      }
+   }
 }

--- a/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectMapperSpecs.cs
+++ b/tests/MoBi.Tests/IntegrationTests/Snapshots/ProjectMapperSpecs.cs
@@ -547,8 +547,7 @@ namespace MoBi.IntegrationTests.Snapshots
       [Observation]
       public void the_snapshot_should_carry_the_current_module_names_in_the_same_order_as_the_pksim_modules()
       {
-         _snapshot.PKSimModuleNames.Length.ShouldBeEqualTo(_snapshot.PKSimModules.Length);
-         _snapshot.PKSimModuleNames.ShouldContain("Henrist oral Hot stage extrusion as table", "Henrist oral Hot stage extrusion as table 1 1");
+         _snapshot.PKSimModuleNames.ShouldOnlyContainInOrder("Henrist oral Hot stage extrusion as table", "Henrist oral Hot stage extrusion as table 1 1");
       }
    }
 


### PR DESCRIPTION
Fixes #2485

## Problem

When two PK-Sim simulations share the same individual (or expression profile, or have colliding module names), MoBi renames the colliding building blocks on import to keep them unique (e.g. `Man` → `Man 1`). But the snapshot export rebuilt each building block from its stored PK-Sim snapshot, which still carried the **original** PK-Sim name. Two building blocks were therefore written to the snapshot with identical names.

On load this produced either:
- `Sequence contains more than one matching element` — `TemplateResolverTask` does a `.Single(...)` over building blocks that now share a name (the individual case in the issue), or
- `Object reference not set to an instance of an object` — a simulation's `ModuleConfiguration` could no longer resolve its (renamed) module by name, so `ModuleByName(...)` returned null.

## Fix

Preserve the MoBi building-block name across the snapshot round-trip and re-apply it after PK-Sim recreates each building block:

- **Individuals / expression profiles** — added `MoBiName` to the snapshot wrapper (`ParameterValueSnapshotWithUpdates`); on load the recreated building block is renamed back to it.
- **PK-Sim modules** — added `PKSimModuleNames` to the project snapshot (parallel to `PKSimModules`); on load each rebuilt module is renamed back to its MoBi name. PK-Sim names a rebuilt module after the simulation captured in the snapshot, so this mirrors the rename MoBi applied on import.

Snapshots written before this change have neither field, so the loader falls back to the PK-Sim name — the change is backward compatible.

## Tests

Added regression specs in `ProjectMapperSpecs` covering export and load for individuals, expression profiles, and modules (that the renamed names survive the round-trip). Full snapshot suite passes (73/73).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved renamed PK-Sim building block and module names when saving, exporting, and restoring projects.
  * Restored module names reliably, including when names conflict with newly recreated objects.
  * Maintained the correct module ordering during project restoration.
  * Improved compatibility with older snapshots that do not contain module name information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->