### PR TITLE
Fixes #2313 Cannot create simulation if PV contains a formula based on the parameter in the individual

### DIFF
--- a/src/MoBi.Core/Commands/AddPathAndValueEntityFromQuantityInSimulationCommand.cs
+++ b/src/MoBi.Core/Commands/AddPathAndValueEntityFromQuantityInSimulationCommand.cs
@@ -3,6 +3,7 @@ using MoBi.Core.Domain.Model;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Utility.Extensions;
 using MoBi.Assets;
 using MoBi.Core.Domain.Services;
 using MoBi.Core.Helper;
@@ -41,6 +42,7 @@ namespace MoBi.Core.Commands
             return;
 
          var pathAndValueEntity = CreateNewEntity(context);
+         removeSimulationRootFromFormulaReferences(pathAndValueEntity);
          ObjectType = _objectTypeResolver.TypeFor(pathAndValueEntity);
          Description = AppConstants.Commands.AddedPathAndValueEntity(pathAndValueEntity, _buildingBlock.Name, ObjectType);
          _buildingBlock.Add(pathAndValueEntity);
@@ -48,6 +50,20 @@ namespace MoBi.Core.Commands
          var entitySourceUpdater = context.Resolve<ISimulationEntitySourceUpdater>();
          _originalSource = _simulation.EntitySources.SourceByPath(_objectPath);
          entitySourceUpdater.UpdateSourcesForNewPathAndValueEntity(_buildingBlock, _objectPath, _simulation);
+      }
+
+      //Reverse of TopContainerPathReplacer: strip the model root (simulation) name from formula references so they resolve in a new simulation
+      private void removeSimulationRootFromFormulaReferences(TPathAndValueEntity pathAndValueEntity)
+      {
+         var rootContainer = _simulation.Model?.Root;
+         if (pathAndValueEntity.Formula == null || rootContainer == null)
+            return;
+
+         pathAndValueEntity.Formula.ObjectPaths.Each(path =>
+         {
+            if (path.Count > 0 && string.Equals(path[0], rootContainer.Name))
+               path.RemoveFirst();
+         });
       }
 
       protected abstract TPathAndValueEntity CreateNewEntity(IMoBiContext context);

--- a/tests/MoBi.Tests/Core/Commands/AddParameterValueFromQuantityInSimulationCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/AddParameterValueFromQuantityInSimulationCommandSpecs.cs
@@ -6,6 +6,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Commands.Core;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.Services;
 
 namespace MoBi.Core.Commands
@@ -80,6 +81,45 @@ namespace MoBi.Core.Commands
       public void the_source_must_be_updated_in_the_simulation()
       {
          A.CallTo(() => _entitySourceUpdater.UpdateSourcesForNewPathAndValueEntity(_parameterValuesBuildingBlock, _objectPath, _simulation)).MustHaveHappened();
+      }
+   }
+
+   public class adding_a_parameter_value_whose_formula_references_the_simulation_root : concern_for_AddParameterValueFromQuantityInSimulationCommand
+   {
+      private ParameterValue _parameterValue;
+      private FormulaUsablePath _absolutePath;
+      private FormulaUsablePath _relativePath;
+
+      protected override void Context()
+      {
+         base.Context();
+         _simulation.Model.Root.Name = "S1";
+
+         var formula = new ExplicitFormula("A + B");
+         _absolutePath = new FormulaUsablePath(new[] { "S1", "Organism", "Lumen", "Effective surface area variability factor" }) { Alias = "A" };
+         _relativePath = new FormulaUsablePath(new[] { ObjectPath.PARENT_CONTAINER, "Geometric surface area" }) { Alias = "B" };
+         formula.AddObjectPath(_absolutePath);
+         formula.AddObjectPath(_relativePath);
+
+         _parameterValue = new ParameterValue { Path = _objectPath, Formula = formula };
+         A.CallTo(() => _parameterValuesCreator.CreateParameterValue(_objectPath, _parameter)).Returns(_parameterValue);
+      }
+
+      protected override void Because()
+      {
+         sut.Execute(_context);
+      }
+
+      [Observation]
+      public void should_remove_the_simulation_root_from_absolute_formula_references()
+      {
+         _absolutePath.PathAsString.ShouldBeEqualTo("Organism|Lumen|Effective surface area variability factor");
+      }
+
+      [Observation]
+      public void should_leave_relative_formula_references_unchanged()
+      {
+         _relativePath.PathAsString.ShouldBeEqualTo("..|Geometric surface area");
       }
    }
 


### PR DESCRIPTION
Fixes #2313 

When a simulation parameter is committed to a Parameter Values / Initial Conditions building block, its formula references were cloned verbatim from the built model, keeping the simulation-root prefix (e.g. `S1|Organism|...`). On a later build `TopContainerPathReplacer` only re-roots paths starting with a top-container name, so the stale `S1` was never rewritten and the reference failed to resolve in the new simulation.

Fix: strip the model-root (simulation) name from the committed formula references (inverse of `TopContainerPathReplacer`) so the building block stores model-relative paths. Covers both ParameterValue and InitialCondition commits.

Note: projects already saved with an `S1`-rooted formula in a building block's FormulaCache are not auto-healed; delete the affected PV and its cached formula, then re-commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed formulas added from simulation quantities so absolute references correctly omit the simulation model root.
  - Preserved relative formula references when adding path/value entities.

- **Tests**
  - Added coverage for both absolute references requiring cleanup and relative references that should remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->