### PR TITLE
Fixes #2498 Do not add MoleculeProperties container by default

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -1190,6 +1190,7 @@ namespace MoBi.Assets
          public static readonly string Export = "Export";
          public static readonly string ReloadExpressionProfile = "Reload Expression Profile";
          public static readonly string ReloadIndividual = "Reload Individual";
+         public static readonly string AddMoleculeProperties = "Add MoleculeProperties";
 
          public static string AddNew(string objectTypeName) => $"Create {objectTypeName}...";
 

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForContainer.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForContainer.cs
@@ -100,10 +100,20 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          {
             _allMenuItems.Add(CreateAddNewItemFor(container));
             _allMenuItems.Add(CreateAddExistingItemFor(container));
+
+            if (container.Mode == ContainerMode.Physical && container.Container(Constants.MOLECULE_PROPERTIES) == null)
+               _allMenuItems.Add(createAddMoleculePropertiesItemFor(container));
          }
 
          _allMenuItems.Add(CreateAddNewChild<IDistributedParameter>(container));
          return this;
+      }
+
+      private IMenuBarItem createAddMoleculePropertiesItemFor(IContainer container)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddMoleculeProperties)
+            .WithIcon(ApplicationIcons.Add)
+            .WithCommandFor<AddMoleculePropertiesToContainerUICommand, IContainer>(container, _container);
       }
 
       protected override void AddSaveItems(IContainer container)

--- a/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/EditContainerPresenter.cs
@@ -118,15 +118,10 @@ namespace MoBi.Presentation.Presenter
       public ContainerMode ConfirmAndSetContainerMode(ContainerMode newContainerMode)
       {
          var oldContainerMode = _container.Mode;
+
          if (_isNewEntity)
          {
             _container.Mode = newContainerMode;
-
-            if(newContainerMode == ContainerMode.Physical && !hasMoleculeProperties(_container))
-               _container.Add(createMoleculePropertiesContainer());
-            else if (newContainerMode == ContainerMode.Logical && hasMoleculeProperties(_container))
-               _container.RemoveChild(_editTasks.GetMoleculeProperties(_container));
-              
             return newContainerMode;
          }
 
@@ -150,24 +145,13 @@ namespace MoBi.Presentation.Presenter
          {
             var moleculeProperties = _editTasks.GetMoleculeProperties(_container);
 
-            if (hasMoleculeProperties(_container))
+            if (moleculeProperties != null)
                macroCommand.Add(new RemoveContainerFromSpatialStructureCommand(_container, moleculeProperties, (MoBiSpatialStructure)BuildingBlock).RunCommand(_context));
-         }
-         else if(!hasMoleculeProperties(_container))
-         {
-            macroCommand.Add(new AddContainerToSpatialStructureCommand(_container, createMoleculePropertiesContainer(), (MoBiSpatialStructure)BuildingBlock).RunCommand(_context));
          }
 
          AddCommand(macroCommand);
          return newContainerMode;
       }
-
-      private bool hasMoleculeProperties(IContainer container) => _editTasks.GetMoleculeProperties(container) != null;
-
-      private IContainer createMoleculePropertiesContainer() =>
-         _context.Create<IContainer>()
-            .WithName(Constants.MOLECULE_PROPERTIES)
-            .WithMode(ContainerMode.Logical);
 
       public IReadOnlyList<ContainerType> AllContainerTypes { get; } = new[]
       {

--- a/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainerBase.cs
+++ b/src/MoBi.Presentation/Tasks/Interaction/InteractionTasksForContainerBase.cs
@@ -34,20 +34,6 @@ namespace MoBi.Presentation.Tasks.Interaction
          _initialConditionsTask = initialConditionsTask;
       }
 
-      public override IContainer CreateNewEntity(TParent parent)
-      {
-         var newContainer = base.CreateNewEntity(parent);
-
-         if (newContainer.Mode != ContainerMode.Physical) 
-            return newContainer;
-
-         var moleculeProperties = Context.Create<IContainer>()
-            .WithName(Constants.MOLECULE_PROPERTIES)
-            .WithMode(ContainerMode.Logical);
-         newContainer.Add(moleculeProperties);
-         return newContainer;
-      }
-
       private MoBiSpatialStructure getSpatialStructure(IBuildingBlock buildingBlockWithFormulaCache)
       {
          return buildingBlockWithFormulaCache as MoBiSpatialStructure ?? _interactionTaskContext.Active<MoBiSpatialStructure>();

--- a/src/MoBi.Presentation/UICommand/AddMoleculePropertiesToContainerUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/AddMoleculePropertiesToContainerUICommand.cs
@@ -1,0 +1,31 @@
+using MoBi.Core.Commands;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Services;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class AddMoleculePropertiesToContainerUICommand : ObjectUICommand<IContainer>
+   {
+      private readonly IMoBiContext _context;
+      private readonly IActiveSubjectRetriever _activeSubjectRetriever;
+
+      public AddMoleculePropertiesToContainerUICommand(IMoBiContext context, IActiveSubjectRetriever activeSubjectRetriever)
+      {
+         _context = context;
+         _activeSubjectRetriever = activeSubjectRetriever;
+      }
+
+      protected override void PerformExecute()
+      {
+         var spatialStructure = _activeSubjectRetriever.Active<MoBiSpatialStructure>();
+         var moleculeProperties = _context.Create<IContainer>()
+            .WithName(Constants.MOLECULE_PROPERTIES)
+            .WithMode(ContainerMode.Logical);
+
+         _context.AddToHistory(new AddContainerToSpatialStructureCommand(Subject, moleculeProperties, spatialStructure).RunCommand(_context));
+      }
+   }
+}

--- a/src/MoBi.Presentation/UICommand/AddMoleculePropertiesToContainerUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/AddMoleculePropertiesToContainerUICommand.cs
@@ -20,6 +20,9 @@ namespace MoBi.Presentation.UICommand
 
       protected override void PerformExecute()
       {
+         if (Subject.Container(Constants.MOLECULE_PROPERTIES) != null)
+            return;
+
          var spatialStructure = _activeSubjectRetriever.Active<MoBiSpatialStructure>();
          var moleculeProperties = _context.Create<IContainer>()
             .WithName(Constants.MOLECULE_PROPERTIES)

--- a/tests/MoBi.Tests/Presentation/AddMoleculePropertiesToContainerUICommandSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/AddMoleculePropertiesToContainerUICommandSpecs.cs
@@ -54,4 +54,24 @@ namespace MoBi.Presentation
          A.CallTo(() => _context.AddToHistory(A<OSPSuite.Core.Commands.Core.ICommand>._)).MustHaveHappened();
       }
    }
+
+   public class When_adding_molecule_properties_to_a_container_that_already_has_them : concern_for_AddMoleculePropertiesToContainerUICommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _container.Add(new Container().WithName(Constants.MOLECULE_PROPERTIES).WithMode(ContainerMode.Logical));
+      }
+
+      protected override void Because()
+      {
+         sut.Execute();
+      }
+
+      [Observation]
+      public void should_not_add_another_molecule_properties_container()
+      {
+         A.CallTo(() => _context.AddToHistory(A<OSPSuite.Core.Commands.Core.ICommand>._)).MustNotHaveHappened();
+      }
+   }
 }

--- a/tests/MoBi.Tests/Presentation/AddMoleculePropertiesToContainerUICommandSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/AddMoleculePropertiesToContainerUICommandSpecs.cs
@@ -1,0 +1,57 @@
+using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.UICommand;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Diagram;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Services;
+
+namespace MoBi.Presentation
+{
+   public abstract class concern_for_AddMoleculePropertiesToContainerUICommand : ContextSpecification<AddMoleculePropertiesToContainerUICommand>
+   {
+      protected IMoBiContext _context;
+      protected IActiveSubjectRetriever _activeSubjectRetriever;
+      protected IContainer _container;
+      protected MoBiSpatialStructure _spatialStructure;
+
+      protected override void Context()
+      {
+         _context = A.Fake<IMoBiContext>();
+         _activeSubjectRetriever = A.Fake<IActiveSubjectRetriever>();
+         _container = new Container().WithName("Muscle").WithMode(ContainerMode.Physical);
+         _spatialStructure = new MoBiSpatialStructure
+         {
+            DiagramManager = A.Fake<IDiagramManager<MoBiSpatialStructure>>()
+         };
+         _spatialStructure.AddTopContainer(_container);
+
+         A.CallTo(() => _context.Create<IContainer>()).Returns(new Container());
+         A.CallTo(() => _activeSubjectRetriever.Active<MoBiSpatialStructure>()).Returns(_spatialStructure);
+
+         sut = new AddMoleculePropertiesToContainerUICommand(_context, _activeSubjectRetriever);
+         sut.For(_container);
+      }
+   }
+
+   public class When_adding_molecule_properties_to_a_physical_container : concern_for_AddMoleculePropertiesToContainerUICommand
+   {
+      protected override void Because()
+      {
+         sut.Execute();
+      }
+
+      [Observation]
+      public void should_add_a_molecule_properties_container_to_the_container()
+      {
+         _container.Container(Constants.MOLECULE_PROPERTIES).ShouldNotBeNull();
+      }
+
+      [Observation]
+      public void should_add_the_command_to_history()
+      {
+         A.CallTo(() => _context.AddToHistory(A<OSPSuite.Core.Commands.Core.ICommand>._)).MustHaveHappened();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/EditContainerPresenterSpecs.cs
@@ -252,46 +252,7 @@ namespace MoBi.Presentation
       }
    }
 
-   internal class When_setting_container_mode_to_physical_in_new_container : concern_for_EditContainerPresenter
-   {
-      private IContainer _muscle;
-      private MoBiSpatialStructure _spatialStructure;
-
-      protected override void Context()
-      {
-         base.Context();
-         _muscle = new Container { ParentPath = new ObjectPath("A", "B") };
-         _spatialStructure = new MoBiSpatialStructure
-         {
-            NeighborhoodsContainer = new Container(),
-            DiagramManager = A.Fake<IDiagramManager<MoBiSpatialStructure>>()
-         };
-         _spatialStructure.AddTopContainer(_muscle);
-         _muscle.Mode = ContainerMode.Logical;
-         A.CallTo(() => _context.Get(_muscle.Id)).Returns(null);
-         sut.Edit(_muscle);
-         sut.BuildingBlock = _spatialStructure;
-      }
-
-      protected override void Because()
-      {
-         sut.ConfirmAndSetContainerMode(ContainerMode.Physical);
-      }
-
-      [Observation]
-      public void should_change_mode()
-      {
-         _muscle.Mode.ShouldBeEqualTo(ContainerMode.Physical);
-      }
-
-      [Observation]
-      public void should_add_molecule_properties()
-      {
-         _muscle.Children.FindByName(Constants.MOLECULE_PROPERTIES).ShouldNotBeNull();
-      }
-   }
-
-   internal class When_setting_container_mode_to_logical_in_new_container : concern_for_EditContainerPresenter
+   internal class When_setting_container_mode_to_new_container : concern_for_EditContainerPresenter
    {
       private IContainer _muscle;
       private MoBiSpatialStructure _spatialStructure;
@@ -307,10 +268,6 @@ namespace MoBi.Presentation
          };
          _spatialStructure.AddTopContainer(_muscle);
          _muscle.Mode = ContainerMode.Physical;
-         var moleculeProperties = _context.Create<IContainer>()
-            .WithName(Constants.MOLECULE_PROPERTIES)
-            .WithMode(ContainerMode.Logical);
-         _muscle.Add(moleculeProperties);
          A.CallTo(() => _context.Get(_muscle.Id)).Returns(null);
          sut.Edit(_muscle);
          sut.BuildingBlock = _spatialStructure;
@@ -328,7 +285,7 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void should_remove_molecule_properties()
+      public void should_not_add_molecule_properties()
       {
          _muscle.Children.FindByName(Constants.MOLECULE_PROPERTIES).ShouldBeNull();
       }
@@ -365,11 +322,11 @@ namespace MoBi.Presentation
       }
 
       [Observation]
-      public void should_add_molecule_properties_when_not_present_already()
+      public void should_not_add_molecule_properties()
       {
          _commandCollector.All().Any(x => x.IsAnImplementationOf<MoBiMacroCommand>()).ShouldBeTrue();
          var macroCommand = _commandCollector.All().FirstOrDefault() as MoBiMacroCommand;
-         macroCommand.All().Any(x => x.IsAnImplementationOf<AddContainerToSpatialStructureCommand>()).ShouldBeTrue();
+         macroCommand.All().Any(x => x.IsAnImplementationOf<AddContainerToSpatialStructureCommand>()).ShouldBeFalse();
       }
 
       [Observation]


### PR DESCRIPTION
MoleculeProperties is no longer added automatically (on container creation or when switching a container to Physical).

- **Add** it via a new "Add MoleculeProperties" context menu, shown only for physical containers that don't already have one.
- **Remove** it by switching the container to Logical (existing confirmation prompt).

Reverts #1987 and the other per-container auto-add sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Add Molecule Properties** option to physical container context menus when molecule properties are not already present.
  * Users can now manually add molecule properties to a physical container.

* **Behavior Changes**
  * Molecule properties are no longer added automatically when creating or switching containers.
  * Switching an existing container to logical mode removes molecule properties only when they exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->