### PR TITLE
Fail a qualification run when errors are logged

### DIFF
--- a/src/MoBi.CLI/ErrorCountingLoggerProvider.cs
+++ b/src/MoBi.CLI/ErrorCountingLoggerProvider.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace MoBi.CLI
+{
+   public class ErrorCountingLoggerProvider : ILoggerProvider
+   {
+      private int _errorCount;
+
+      public bool HasErrors => _errorCount > 0;
+
+      public ILogger CreateLogger(string categoryName) => new ErrorCountingLogger(this);
+
+      private void increment() => Interlocked.Increment(ref _errorCount);
+
+      public void Dispose()
+      {
+      }
+
+      private class ErrorCountingLogger : ILogger
+      {
+         private readonly ErrorCountingLoggerProvider _provider;
+
+         public ErrorCountingLogger(ErrorCountingLoggerProvider provider) => _provider = provider;
+
+         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+         {
+            if (logLevel >= LogLevel.Error)
+               _provider.increment();
+         }
+
+         public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
+
+         public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+      }
+
+      private class NullScope : IDisposable
+      {
+         public static readonly NullScope Instance = new NullScope();
+
+         public void Dispose()
+         {
+         }
+      }
+   }
+}

--- a/src/MoBi.CLI/Program.cs
+++ b/src/MoBi.CLI/Program.cs
@@ -48,7 +48,9 @@ namespace MoBi.CLI
          if (!string.IsNullOrEmpty(runOptions.PKSimPath))
             IoC.Resolve<IApplicationSettings>().PKSimPath = runOptions.PKSimPath;
 
-         var logger = initializeLogger(command);
+         var errorCounter = command is QualificationRunCommand ? new ErrorCountingLoggerProvider() : null;
+
+         var logger = initializeLogger(command, errorCounter);
          if (command.LogCommandName)
             logger.AddInfo($"Starting {command.Name.ToLower()} run");
 
@@ -65,11 +67,17 @@ namespace MoBi.CLI
             _valid = false;
          }
 
+         if (errorCounter != null && errorCounter.HasErrors)
+         {
+            logger.AddError("Qualification run finished with errors. See the log for details.");
+            _valid = false;
+         }
+
          if (command.LogCommandName)
             logger.AddInfo($"{command.Name} run finished");
       }
 
-      private static IOSPSuiteLogger initializeLogger(CLICommand runCommand)
+      private static IOSPSuiteLogger initializeLogger(CLICommand runCommand, ErrorCountingLoggerProvider errorCounter)
       {
          var loggerCreator = IoC.Resolve<ILoggerCreator>();
 
@@ -87,6 +95,9 @@ namespace MoBi.CLI
                builder
                   .SetMinimumLevel(runCommand.LogLevel)
                   .AddFile(runCommand.LogFilesFullPath.ToArray(), runCommand.LogLevel, true));
+
+         if (errorCounter != null)
+            loggerCreator.AddLoggingBuilderConfiguration(builder => builder.AddProvider(errorCounter));
 
          return logger;
       }


### PR DESCRIPTION
Fixes #2505

Logged errors during a qualification run now set a non-zero exit code so the QualificationRunner stops instead of reporting success with wrong results.

Adds an error-counting logger provider to `MoBi.CLI`, registered for the qualification command; any `Error`/`Critical` message logged during the run fails it.

Mirror of PK-Sim Log error return code.