### PR TITLE
Comment why the error counter is only created for qualification

### DIFF
--- a/src/MoBi.CLI/Program.cs
+++ b/src/MoBi.CLI/Program.cs
@@ -48,6 +48,7 @@ namespace MoBi.CLI
          if (!string.IsNullOrEmpty(runOptions.PKSimPath))
             IoC.Resolve<IApplicationSettings>().PKSimPath = runOptions.PKSimPath;
 
+         // If a qualification workflow logs errors, the return code should be non-zero
          var errorCounter = command is QualificationRunCommand ? new ErrorCountingLoggerProvider() : null;
 
          var logger = initializeLogger(command, errorCounter);


### PR DESCRIPTION
Follow-up to #2506: adds a one-line comment clarifying that the error counter (and the non-zero exit on logged errors) applies only to the qualification workflow, as asked in review.