### PR TITLE
Update OSPSuite.Core to 13.0.159

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -16,7 +16,7 @@ namespace MoBi.Assets
 {
    public static class AppConstants
    {
-      public static readonly int LayoutVersion = 25;
+      public static readonly int LayoutVersion = 26;
       public static readonly string NotMatch = "not tagged with";
       public static readonly string Match = "tagged with";
       public static readonly string MatchAll = "in all containers";

--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,13 +16,13 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.149" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.159" />
       <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.149" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.149" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.149" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.159" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.159" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.159" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -22,15 +22,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.159" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,12 +31,12 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.159" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.159" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -20,9 +20,9 @@
 
   <ItemGroup>
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.159" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -25,11 +25,11 @@
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -54,13 +54,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.149" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.159" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -25,9 +25,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.159" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.149" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.149" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.159" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.159" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Updates the OSPSuite packages from 13.0.149 to 13.0.159.

Also bumps `AppConstants.LayoutVersion` (25 → 26): the new Core release reorders the icon list, shifting the ordinal image indices, so persisted ribbon/dock layouts must reset to avoid showing stale icons.