### PR TITLE
Fixes #2368 Show v13 conversion notice once on startup

### DIFF
--- a/src/MoBi.Assets/AppConstants.cs
+++ b/src/MoBi.Assets/AppConstants.cs
@@ -47,6 +47,7 @@ namespace MoBi.Assets
       public static readonly string Website = "www.open-systems-pharmacology.org";
       public static readonly string ProductSiteDownload = "http://setup.open-systems-pharmacology.org";
       public static readonly string IssueTrackerUrl = "https://github.com/open-systems-pharmacology/mobi/issues";
+      public static readonly string V13ConversionDocumentationUrl = "https://docs.open-systems-pharmacology.org/v13/working-with-mobi/mobi-documentation/reuse-of-project-information-from-previous-versions/converting-v12-projects-to-v13";
       public static readonly string Persitable = "Persitable";
       public static readonly string CVODE_1002_2_SOLVER = "CVODE1002_2";
       public static readonly int MAX_PATH_DEPTH = 10;
@@ -1433,6 +1434,7 @@ namespace MoBi.Assets
          public static readonly string ProjectExplorer = "Project Explorer";
          public static readonly string BuildingBlockExplorer = "Building Block Explorer";
          public static readonly string WarningsCaption = "Solver Warnings";
+         public static readonly string V13ConversionNoticeDescription = $"<b>Changes in MoBi v13</b>{Environment.NewLine}{Environment.NewLine}The merge behavior of several building-block types changed when modules are combined —{Environment.NewLine}specifically the difference between the <b>Extend</b> and <b>Overwrite</b> merge modes.{Environment.NewLine}{Environment.NewLine}See <a href='{V13ConversionDocumentationUrl}'>Converting v12 projects to v13</a> for details.";
          public static readonly string HistoryBrowser = "History";
          public static readonly string RenameRelatedEntities = "Rename related entities";
          public static readonly string AddReactionMolecule = "Molecule Name";

--- a/src/MoBi.BatchTool/Services/BatchUserSettings.cs
+++ b/src/MoBi.BatchTool/Services/BatchUserSettings.cs
@@ -77,6 +77,7 @@ namespace MoBi.BatchTool.Services
       public ValidationSettings ValidationSettings { get; private set; }
       public OutputSelections OutputSelections { get; set; }
       public bool GroupParameters { get; set; }
+      public bool V13ConversionInfoShown { get; set; }
 
       public BatchUserSettings()
       {

--- a/src/MoBi.Presentation/Presenter/MoBiMainViewPresenter.cs
+++ b/src/MoBi.Presentation/Presenter/MoBiMainViewPresenter.cs
@@ -37,7 +37,8 @@ namespace MoBi.Presentation.Presenter
       private readonly IUserSettings _userSettings;
       private readonly IMoBiConfiguration _configuration;
       private readonly IWatermarkStatusChecker _watermarkStatusChecker;
-        
+      private readonly IDialogCreator _dialogCreator;
+
       public MoBiMainViewPresenter(
          IMoBiMainView view,
          IRepository<IMainViewItemPresenter> allMainViewItemPresenters,
@@ -48,13 +49,15 @@ namespace MoBi.Presentation.Presenter
          IUserSettings userSettings,
          ITabbedMdiChildViewContextMenuFactory contextMenuFactory,
          IMoBiConfiguration configuration,
-         IWatermarkStatusChecker watermarkStatusChecker) : base(view, eventPublisher, contextMenuFactory)
+         IWatermarkStatusChecker watermarkStatusChecker,
+         IDialogCreator dialogCreator) : base(view, eventPublisher, contextMenuFactory)
       {
          _skinManager = skinManager;
          _exitCommand = exitCommand;
          _userSettings = userSettings;
          _configuration = configuration;
          _watermarkStatusChecker = watermarkStatusChecker;
+         _dialogCreator = dialogCreator;
          _allMainViewItemPresenters = allMainViewItemPresenters;
          _projectTask = projectTask;
          _view.AttachPresenter(this);
@@ -72,6 +75,16 @@ namespace MoBi.Presentation.Presenter
       public override void Run()
       {
          _watermarkStatusChecker.CheckWatermarkStatus();
+         showV13ConversionNoticeIfRequired();
+      }
+
+      private void showV13ConversionNoticeIfRequired()
+      {
+         if (_userSettings.V13ConversionInfoShown)
+            return;
+
+         _dialogCreator.MessageBoxInfo(AppConstants.Captions.V13ConversionNoticeDescription);
+         _userSettings.V13ConversionInfoShown = true;
       }
 
       public override void RemoveAlert()

--- a/src/MoBi.Presentation/Serialization/Xml/Serializer/UserSettingsXmlSerialiser.cs
+++ b/src/MoBi.Presentation/Serialization/Xml/Serializer/UserSettingsXmlSerialiser.cs
@@ -33,6 +33,7 @@ namespace MoBi.Presentation.Serialization.Xml.Serializer
          Map(x => x.CheckRules);
          Map(x => x.CheckCircularReference);
          Map(x => x.GroupParameters);
+         Map(x => x.V13ConversionInfoShown);
          Map(x => x.DisplayUnits);
          Map(x => x.ComparerSettings);
          Map(x => x.JournalPageEditorSettings);

--- a/src/MoBi.Presentation/Settings/IUserSettings.cs
+++ b/src/MoBi.Presentation/Settings/IUserSettings.cs
@@ -52,6 +52,7 @@ namespace MoBi.Presentation.Settings
       bool ShowUnresolvedEndosomeMessagesForInitialConditions { get; set; }
       bool CheckCircularReference { get; set; }
       bool GroupParameters { get; set; }
+      bool V13ConversionInfoShown { get; set; }
 
       ValidationSettings ValidationSettings { get; }
       OutputSelections OutputSelections { get; set; }

--- a/src/MoBi.UI/Settings/UserSettings.cs
+++ b/src/MoBi.UI/Settings/UserSettings.cs
@@ -90,6 +90,7 @@ namespace MoBi.UI.Settings
       private readonly INumericFormatterOptions _numericFormatterOptions;
       public bool ShowAdvancedParameters { get; set; }
       public bool GroupParameters { get; set; }
+      public bool V13ConversionInfoShown { get; set; }
       public string ChartEditorLayout { get; set; }
       public int MaximumNumberOfCoresToUse { get; set; }
       public int NumberOfBins { get; set; }
@@ -119,6 +120,7 @@ namespace MoBi.UI.Settings
          DirectoryMapSettings.AddUsedDirectory(AppConstants.DirectoryKey.LAYOUT, configuration.CurrentUserFolderPath);
          ShowAdvancedParameters = true;
          GroupParameters = false;
+         V13ConversionInfoShown = false;
          VisibleNotification = NotificationType.Warning | NotificationType.Error;
          ValidationSettings = new ValidationSettings { CheckDimensions = true, CheckCircularReference = true };
          DisplayUnits = new DisplayUnitsManager();

--- a/tests/MoBi.Tests/Presentation/MoBiMainViewPresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/MoBiMainViewPresenterSpecs.cs
@@ -1,0 +1,90 @@
+using FakeItEasy;
+using MoBi.Assets;
+using MoBi.Core;
+using MoBi.Presentation.Presenter;
+using MoBi.Presentation.Settings;
+using MoBi.Presentation.UICommand;
+using MoBi.Presentation.Views;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Services;
+using OSPSuite.Presentation.Presenters.ContextMenus;
+using OSPSuite.Presentation.Presenters.Main;
+using OSPSuite.Presentation.Services;
+using OSPSuite.Utility.Collections;
+using OSPSuite.Utility.Events;
+using IProjectTask = MoBi.Presentation.Tasks.IProjectTask;
+
+namespace MoBi.Presentation
+{
+   public abstract class concern_for_MoBiMainViewPresenter : ContextSpecification<MoBiMainViewPresenter>
+   {
+      protected IUserSettings _userSettings;
+      protected IDialogCreator _dialogCreator;
+
+      protected override void Context()
+      {
+         _userSettings = A.Fake<IUserSettings>();
+         _dialogCreator = A.Fake<IDialogCreator>();
+
+         sut = new MoBiMainViewPresenter(
+            A.Fake<IMoBiMainView>(),
+            A.Fake<IRepository<IMainViewItemPresenter>>(),
+            A.Fake<IProjectTask>(),
+            A.Fake<ISkinManager>(),
+            A.Fake<IExitCommand>(),
+            A.Fake<IEventPublisher>(),
+            _userSettings,
+            A.Fake<ITabbedMdiChildViewContextMenuFactory>(),
+            A.Fake<IMoBiConfiguration>(),
+            A.Fake<IWatermarkStatusChecker>(),
+            _dialogCreator);
+      }
+   }
+
+   public class When_running_the_main_view_presenter_and_the_v13_conversion_notice_has_not_been_shown : concern_for_MoBiMainViewPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _userSettings.V13ConversionInfoShown = false;
+      }
+
+      protected override void Because()
+      {
+         sut.Run();
+      }
+
+      [Observation]
+      public void should_show_the_v13_conversion_notice()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(AppConstants.Captions.V13ConversionNoticeDescription)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void should_remember_that_the_notice_was_shown()
+      {
+         _userSettings.V13ConversionInfoShown.ShouldBeTrue();
+      }
+   }
+
+   public class When_running_the_main_view_presenter_and_the_v13_conversion_notice_was_already_shown : concern_for_MoBiMainViewPresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _userSettings.V13ConversionInfoShown = true;
+      }
+
+      protected override void Because()
+      {
+         sut.Run();
+      }
+
+      [Observation]
+      public void should_not_show_the_v13_conversion_notice_again()
+      {
+         A.CallTo(() => _dialogCreator.MessageBoxInfo(A<string>._)).MustNotHaveHappened();
+      }
+   }
+}


### PR DESCRIPTION
## Summary

Fixes #2368. On the first v13 startup, MoBi now shows a one-time informational dialog describing the changed merge behavior of building-block types when modules are combined — specifically the difference between the **Extend** and **Overwrite** merge modes — with a link to the [conversion documentation](https://docs.open-systems-pharmacology.org/v13/working-with-mobi/mobi-documentation/reuse-of-project-information-from-previous-versions/converting-v12-projects-to-v13).

The dialog is shown only once; a new persisted user setting (`V13ConversionInfoShown`) records that it has been seen.
<img width="572" height="220" alt="image" src="https://github.com/user-attachments/assets/af0f7197-78fa-4ba4-a023-c27bfe56759a" />