### PR TITLE
Fixes #2511 Add tooltip to "Warn for non-finite quantities" option

### DIFF
--- a/src/MoBi.Assets/ToolTips.cs
+++ b/src/MoBi.Assets/ToolTips.cs
@@ -20,7 +20,7 @@ namespace MoBi.Assets
       public static readonly string AddToProject = "Save as a new building block in project.";
       public static readonly string ResetParameterToolTip = "Reset parameter to default";
       public static readonly string SaveSimulationSettingsToolTip = "Save current simulations settings as template into project or user profile. These settings will be used as default settings for each newly created simulation.";
-      public static readonly string WarnForNonFiniteQuantities = "Show a warning for each quantity whose value is NaN or infinite at time t=0. The check is performed when a simulation is created and each time it is run.";
+      public static readonly string WarnForNonFiniteQuantities = "Show a warning for each quantity whose value is NaN or infinite at time t=0.\nThe check is performed when a simulation is created and each time it is run.";
 
       public static class BuildingBlockMolecule
       {

--- a/src/MoBi.Assets/ToolTips.cs
+++ b/src/MoBi.Assets/ToolTips.cs
@@ -20,6 +20,7 @@ namespace MoBi.Assets
       public static readonly string AddToProject = "Save as a new building block in project.";
       public static readonly string ResetParameterToolTip = "Reset parameter to default";
       public static readonly string SaveSimulationSettingsToolTip = "Save current simulations settings as template into project or user profile. These settings will be used as default settings for each newly created simulation.";
+      public static readonly string WarnForNonFiniteQuantities = "Show a warning for each quantity whose value is NaN or infinite at time t=0. The check is performed when a simulation is created and each time it is run.";
 
       public static class BuildingBlockMolecule
       {

--- a/src/MoBi.UI/Views/UserSettingsView.cs
+++ b/src/MoBi.UI/Views/UserSettingsView.cs
@@ -12,6 +12,7 @@ using OSPSuite.Presentation.Extensions;
 using OSPSuite.Presentation.Views;
 using OSPSuite.UI.Extensions;
 using OSPSuite.UI.Views;
+using ToolTips = MoBi.Assets.ToolTips;
 
 namespace MoBi.UI.Views
 {
@@ -75,6 +76,7 @@ namespace MoBi.UI.Views
 
          chkRenameDependent.Text = AppConstants.Captions.RenameDependentObjects;
          chkWarnForNonFiniteQUantities.Text = AppConstants.Captions.WarnForNonFiniteQuantities;
+         chkWarnForNonFiniteQUantities.ToolTip = ToolTips.WarnForNonFiniteQuantities;
       }
 
       public override bool HasError => _screenBinder.HasError;


### PR DESCRIPTION
## Summary

Fixes #2511. The **Warn for non-finite quantities** option on the *General* tab of the Options dialog gave no hint about what it checks or when it runs. It now has a tooltip:

> Show a warning for each quantity whose value is NaN or infinite at time t=0.
> The check is performed when a simulation is created and each time it is run.

The wording follows what the setting actually drives — `SimulationQuantityValueWarningTask.WarnForNonFiniteQuantities` in Core walks all `IQuantity` children of the model root and raises a warning for each NaN and each infinite value. It is invoked from two places: `ModelConstructor` during simulation creation, and `SimulationRunner` before each run.