### PR TITLE
Fixes #2514 Allow deletion of the MoleculeProperties container

### DIFF
--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuFor.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuFor.cs
@@ -52,8 +52,11 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
 
             _allMenuItems = new List<IMenuBarItem> {CreateEditItemFor(objectBase)};
 
-            if (dto.Name.IsSpecialName()) 
+            if (dto.Name.IsSpecialName())
+            {
+               AddMenuItemsForSpecialName(objectBase);
                return this;
+            }
 
             _allMenuItems.Add(CreateRenameItemFor(objectBase));
             AddSaveItems(objectBase);
@@ -64,6 +67,10 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          {
             return new EmptyContextMenu();
          }
+      }
+
+      protected virtual void AddMenuItemsForSpecialName(TObjectBase objectBase)
+      {
       }
 
       protected virtual void AddSaveItems(TObjectBase objectBase)

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForContainer.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForContainer.cs
@@ -109,6 +109,12 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          return this;
       }
 
+      protected override void AddMenuItemsForSpecialName(IContainer container)
+      {
+         if (container.IsMoleculeProperties() && container.ParentContainer != null)
+            _allMenuItems.Add(CreateDeleteItemFor(container));
+      }
+
       private IMenuBarItem createAddMoleculePropertiesItemFor(IContainer container)
       {
          return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddMoleculeProperties)

--- a/tests/MoBi.Tests/Presentation/ContextMenuForContainerSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ContextMenuForContainerSpecs.cs
@@ -1,0 +1,126 @@
+using System.Linq;
+using FakeItEasy;
+using MoBi.Assets;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.DTO;
+using MoBi.Presentation.MenusAndBars.ContextMenus;
+using OSPSuite.Assets;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
+using OSPSuite.Infrastructure.Container.Castle;
+using OSPSuite.Presentation.Presenters;
+using OSPSuite.Presentation.Views.ContextMenus;
+
+namespace MoBi.Presentation
+{
+   public abstract class concern_for_ContextMenuForContainer : ContextSpecification<ContextMenuForContainer>
+   {
+      protected IMoBiContext _context;
+      protected IContainer _moleculeProperties;
+      protected ObjectBaseDTO _dto;
+
+      public override void GlobalContext()
+      {
+         base.GlobalContext();
+         var container = new CastleWindsorContainer();
+         OSPSuite.Utility.Container.IoC.InitializeWith(container);
+         container.RegisterImplementationOf(A.Fake<IContextMenuView>());
+      }
+
+      protected override void Context()
+      {
+         _context = A.Fake<IMoBiContext>();
+         var objectTypeResolver = A.Fake<IObjectTypeResolver>();
+         A.CallTo(() => objectTypeResolver.TypeFor<IParameter>()).Returns(ObjectTypes.Parameter);
+         A.CallTo(() => objectTypeResolver.TypeFor<IContainer>()).Returns(ObjectTypes.Container);
+         A.CallTo(() => objectTypeResolver.TypeFor<IDistributedParameter>()).Returns(ObjectTypes.DistributedParameter);
+
+         _moleculeProperties = new Container().WithName(Constants.MOLECULE_PROPERTIES).WithMode(ContainerMode.Logical);
+         _dto = new ObjectBaseDTO(_moleculeProperties) {Name = Constants.MOLECULE_PROPERTIES};
+         A.CallTo(() => _context.Get<IContainer>(A<string>._)).Returns(_moleculeProperties);
+
+         sut = new ContextMenuForContainer(_context, objectTypeResolver, A.Fake<OSPSuite.Utility.Container.IContainer>(), A.Fake<IEntityPathResolver>());
+      }
+
+      protected override void Because()
+      {
+         sut.InitializeWith(_dto, A.Fake<IPresenter>());
+      }
+
+      protected bool hasDeleteItem => sut.AllMenuItems().Any(x => Equals(x.Caption, AppConstants.MenuNames.Delete));
+   }
+
+   public class When_creating_the_context_menu_for_the_molecule_properties_of_a_physical_container : concern_for_ContextMenuForContainer
+   {
+      protected override void Context()
+      {
+         base.Context();
+         new Container().WithName("Liver").WithMode(ContainerMode.Physical).Add(_moleculeProperties);
+      }
+
+      [Observation]
+      public void should_allow_the_molecule_properties_to_be_deleted()
+      {
+         hasDeleteItem.ShouldBeTrue();
+      }
+   }
+
+   public class When_creating_the_context_menu_for_the_global_molecule_properties_of_a_spatial_structure : concern_for_ContextMenuForContainer
+   {
+      [Observation]
+      public void should_not_allow_the_molecule_properties_to_be_deleted()
+      {
+         hasDeleteItem.ShouldBeFalse();
+      }
+   }
+
+   public class When_creating_the_context_menu_for_the_molecule_properties_of_a_logical_container : concern_for_ContextMenuForContainer
+   {
+      protected override void Context()
+      {
+         base.Context();
+         new Container().WithName("Organism").WithMode(ContainerMode.Logical).Add(_moleculeProperties);
+      }
+
+      [Observation]
+      public void should_allow_the_molecule_properties_to_be_deleted()
+      {
+         hasDeleteItem.ShouldBeTrue();
+      }
+   }
+
+   public class When_creating_the_context_menu_for_the_molecule_properties_of_a_neighborhood : concern_for_ContextMenuForContainer
+   {
+      protected override void Context()
+      {
+         base.Context();
+         new NeighborhoodBuilder().WithName("Liver_to_Kidney").Add(_moleculeProperties);
+      }
+
+      [Observation]
+      public void should_allow_the_molecule_properties_to_be_deleted()
+      {
+         hasDeleteItem.ShouldBeTrue();
+      }
+   }
+
+   public class When_creating_the_context_menu_for_a_physical_container : concern_for_ContextMenuForContainer
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _moleculeProperties = new Container().WithName("Liver").WithMode(ContainerMode.Physical);
+         _dto = new ObjectBaseDTO(_moleculeProperties) {Name = "Liver"};
+         A.CallTo(() => _context.Get<IContainer>(A<string>._)).Returns(_moleculeProperties);
+      }
+
+      [Observation]
+      public void should_allow_the_container_to_be_deleted()
+      {
+         hasDeleteItem.ShouldBeTrue();
+      }
+   }
+}


### PR DESCRIPTION
Fixes #2514

Follow-up to #2504. `Delete` was suppressed for every container whose name is "special" (`ContextMenuFor.InitializeWith` returns early for `MoleculeProperties` and `Neighborhoods`), so the only way to remove a `MoleculeProperties` container was to switch its parent to `Logical`.

`Delete` is now offered for any `MoleculeProperties` that has a parent container — under a physical parent, under a logical parent, and inside a neighborhood. It routes through the normal `RemoveCommandForContainer`, so the usual confirmation dialog, diagram cleanup and undo all apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Delete option for eligible molecule-properties containers that have a parent container.
  - Added support for displaying this option across physical, logical, neighborhood, and global spatial-structure contexts.

- **Bug Fixes**
  - Corrected context menus for special-name containers so applicable deletion actions are available.

- **Tests**
  - Added coverage verifying Delete menu behavior for supported container types and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->