### PR TITLE
Fixes #2512 Do not create the global MoleculeProperties container by default

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.160" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,13 +16,13 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.160" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.160" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.161" />
       <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.160" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.160" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.160" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.161" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.161" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.161" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -22,15 +22,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.161" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/Commands/AddGlobalMoleculePropertiesCommand.cs
+++ b/src/MoBi.Core/Commands/AddGlobalMoleculePropertiesCommand.cs
@@ -1,0 +1,40 @@
+using MoBi.Core.Domain.Model;
+using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
+
+namespace MoBi.Core.Commands
+{
+   public class AddGlobalMoleculePropertiesCommand : AddObjectBaseCommand<IContainer, MoBiSpatialStructure>
+   {
+      public AddGlobalMoleculePropertiesCommand(MoBiSpatialStructure spatialStructure, IContainer moleculeProperties) : base(spatialStructure, moleculeProperties, spatialStructure)
+      {
+      }
+
+      protected override void AddTo(IContainer moleculeProperties, MoBiSpatialStructure spatialStructure, IMoBiContext context)
+      {
+         spatialStructure.GlobalMoleculeDependentProperties = moleculeProperties;
+      }
+
+      protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
+      {
+         return new RemoveGlobalMoleculePropertiesCommand(_parent, _itemToAdd).AsInverseFor(this);
+      }
+   }
+
+   public class RemoveGlobalMoleculePropertiesCommand : RemoveObjectBaseCommand<IContainer, MoBiSpatialStructure>
+   {
+      public RemoveGlobalMoleculePropertiesCommand(MoBiSpatialStructure spatialStructure, IContainer moleculeProperties) : base(spatialStructure, moleculeProperties, spatialStructure)
+      {
+      }
+
+      protected override void RemoveFrom(IContainer moleculeProperties, MoBiSpatialStructure spatialStructure, IMoBiContext context)
+      {
+         spatialStructure.GlobalMoleculeDependentProperties = null;
+      }
+
+      protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)
+      {
+         return new AddGlobalMoleculePropertiesCommand(_parent, _itemToRemove).AsInverseFor(this);
+      }
+   }
+}

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,12 +31,12 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.161" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>

--- a/src/MoBi.Core/Services/ParameterResolver.cs
+++ b/src/MoBi.Core/Services/ParameterResolver.cs
@@ -115,7 +115,7 @@ namespace MoBi.Core.Services
       /// <returns>The property if found, otherwise null</returns>
       private IParameter resolveMoleculePropertiesInSpatialStructure(string parameterName)
       {
-         return _spatialStructure.GlobalMoleculeDependentProperties.GetSingleChildByName<IParameter>(parameterName);
+         return _spatialStructure.GlobalMoleculeDependentProperties?.GetSingleChildByName<IParameter>(parameterName);
       }
 
       /// <summary>

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForContainer.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/ContextMenuForContainer.cs
@@ -7,6 +7,7 @@ using OSPSuite.Assets;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Extensions;
+using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.MenuAndBars;
 using OSPSuite.Presentation.Presenters;
@@ -85,10 +86,12 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
    public class ContextMenuForContainer : ContextMenuForContainerBase<IContainer>
    {
       private readonly IEntityPathResolver _entityPathResolver;
+      private readonly IActiveSubjectRetriever _activeSubjectRetriever;
 
-      public ContextMenuForContainer(IMoBiContext context, IObjectTypeResolver objectTypeResolver, OSPSuite.Utility.Container.IContainer container, IEntityPathResolver entityPathResolver) : base(context, objectTypeResolver, container)
+      public ContextMenuForContainer(IMoBiContext context, IObjectTypeResolver objectTypeResolver, OSPSuite.Utility.Container.IContainer container, IEntityPathResolver entityPathResolver, IActiveSubjectRetriever activeSubjectRetriever) : base(context, objectTypeResolver, container)
       {
          _entityPathResolver = entityPathResolver;
+         _activeSubjectRetriever = activeSubjectRetriever;
       }
 
       public override IContextMenu InitializeWith(ObjectBaseDTO dto, IPresenter presenter)
@@ -113,13 +116,25 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
       {
          if (container.IsMoleculeProperties() && container.ParentContainer != null)
             _allMenuItems.Add(CreateDeleteItemFor(container));
+         else if (isGlobalMoleculeProperties(container))
+            _allMenuItems.Add(createRemoveGlobalMoleculePropertiesItemFor(container));
       }
+
+      private bool isGlobalMoleculeProperties(IContainer container) =>
+         container != null && Equals(_activeSubjectRetriever.Active<MoBiSpatialStructure>()?.GlobalMoleculeDependentProperties, container);
 
       private IMenuBarItem createAddMoleculePropertiesItemFor(IContainer container)
       {
          return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddMoleculeProperties)
             .WithIcon(ApplicationIcons.Add)
             .WithCommandFor<AddMoleculePropertiesToContainerUICommand, IContainer>(container, _container);
+      }
+
+      private IMenuBarItem createRemoveGlobalMoleculePropertiesItemFor(IContainer container)
+      {
+         return CreateMenuButton.WithCaption(AppConstants.MenuNames.Delete)
+            .WithIcon(ApplicationIcons.Delete)
+            .WithCommandFor<RemoveGlobalMoleculePropertiesUICommand, IContainer>(container, _container);
       }
 
       protected override void AddSaveItems(IContainer container)

--- a/src/MoBi.Presentation/MenusAndBars/ContextMenus/RootContextMenuForSpatialStructure.cs
+++ b/src/MoBi.Presentation/MenusAndBars/ContextMenus/RootContextMenuForSpatialStructure.cs
@@ -2,9 +2,11 @@ using System.Collections.Generic;
 using MoBi.Assets;
 using OSPSuite.Presentation.MenuAndBars;
 using OSPSuite.Utility.Extensions;
+using MoBi.Core.Domain.Model;
 using MoBi.Presentation.DTO;
 using MoBi.Presentation.Presenter;
 using MoBi.Presentation.UICommand;
+using OSPSuite.Core.Services;
 using OSPSuite.Presentation.Core;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Presenters.ContextMenus;
@@ -16,10 +18,12 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
    public class RootContextMenuForSpatialStructure : ContextMenuBase
    {
       private readonly IContainer _container;
+      private readonly MoBiSpatialStructure _spatialStructure;
 
-      public RootContextMenuForSpatialStructure(IContainer container)
+      public RootContextMenuForSpatialStructure(IContainer container, MoBiSpatialStructure spatialStructure)
       {
          _container = container;
+         _spatialStructure = spatialStructure;
       }
       public override IEnumerable<IMenuBarItem> AllMenuItems()
       {
@@ -30,21 +34,28 @@ namespace MoBi.Presentation.MenusAndBars.ContextMenus
          yield return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddExisting("Top Container"))
             .WithIcon(ApplicationIcons.ContainerLoad)
             .WithCommand<AddExistingTopContainerCommand>(_container);
+
+         if (_spatialStructure?.GlobalMoleculeDependentProperties == null)
+            yield return CreateMenuButton.WithCaption(AppConstants.MenuNames.AddMoleculeProperties)
+               .WithIcon(ApplicationIcons.Add)
+               .WithCommand<AddGlobalMoleculePropertiesUICommand>(_container);
       }
    }
 
    public class RootContextMenuForSpatialStructureFactory : IContextMenuSpecificationFactory<IViewItem>
    {
       private readonly IContainer _container;
+      private readonly IActiveSubjectRetriever _activeSubjectRetriever;
 
-      public RootContextMenuForSpatialStructureFactory(IContainer container)
+      public RootContextMenuForSpatialStructureFactory(IContainer container, IActiveSubjectRetriever activeSubjectRetriever)
       {
          _container = container;
+         _activeSubjectRetriever = activeSubjectRetriever;
       }
 
       public IContextMenu CreateFor(IViewItem objectRequestingContextMenu, IPresenterWithContextMenu<IViewItem> presenter)
       {
-         return new RootContextMenuForSpatialStructure(_container);
+         return new RootContextMenuForSpatialStructure(_container, _activeSubjectRetriever.Active<MoBiSpatialStructure>());
       }
 
       public bool IsSatisfiedBy(IViewItem objectRequestingContextMenu, IPresenterWithContextMenu<IViewItem> presenter)

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -20,9 +20,9 @@
 
   <ItemGroup>
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.Presentation/Presenter/HierarchicalSpatialStructurePresenter.cs
+++ b/src/MoBi.Presentation/Presenter/HierarchicalSpatialStructurePresenter.cs
@@ -51,7 +51,10 @@ namespace MoBi.Presentation.Presenter
          _view.AddNode(_favoritesNode);
          _view.AddNode(_userDefinedNode);
 
-         var roots = new List<ObjectBaseDTO> { _objectBaseMapper.MapFrom(spatialStructure.GlobalMoleculeDependentProperties) };
+         var roots = new List<ObjectBaseDTO>();
+         if (spatialStructure.GlobalMoleculeDependentProperties != null)
+            roots.Add(_objectBaseMapper.MapFrom(spatialStructure.GlobalMoleculeDependentProperties));
+
          spatialStructure.TopContainers.Each(x => roots.Add(_objectBaseMapper.MapFrom(x)));
 
          var neighborhood = _objectBaseMapper.MapFrom(spatialStructure.NeighborhoodsContainer);
@@ -131,13 +134,15 @@ namespace MoBi.Presentation.Presenter
       private void remove(IEntity entity) => _view.Remove(entity);
 
       /// <summary>
-      ///    Entity is in spatial structure when its root container is either one of top container or the neighborhood container
+      ///    Entity is in spatial structure when its root container is either one of top container, the neighborhood container
+      ///    or the global molecule properties container
       /// </summary>
       private bool entityIsInSpatialStructure(IEntity entity)
       {
          var rootContainer = entity.RootContainer;
          return _spatialStructure.TopContainers.Contains(rootContainer) ||
-                Equals(_spatialStructure.NeighborhoodsContainer, rootContainer);
+                Equals(_spatialStructure.NeighborhoodsContainer, rootContainer) ||
+                Equals(_spatialStructure.GlobalMoleculeDependentProperties, rootContainer);
       }
 
       public void Handle(EntitySelectedEvent eventToHandle)

--- a/src/MoBi.Presentation/UICommand/AddGlobalMoleculePropertiesUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/AddGlobalMoleculePropertiesUICommand.cs
@@ -1,0 +1,30 @@
+using MoBi.Core.Commands;
+using MoBi.Core.Domain.Builder;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Extensions;
+using OSPSuite.Core.Services;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class AddGlobalMoleculePropertiesUICommand : ActiveObjectUICommand<MoBiSpatialStructure>
+   {
+      private readonly IMoBiContext _context;
+      private readonly IMoBiSpatialStructureFactory _spatialStructureFactory;
+
+      public AddGlobalMoleculePropertiesUICommand(IActiveSubjectRetriever activeSubjectRetriever, IMoBiContext context, IMoBiSpatialStructureFactory spatialStructureFactory) : base(activeSubjectRetriever)
+      {
+         _context = context;
+         _spatialStructureFactory = spatialStructureFactory;
+      }
+
+      protected override void PerformExecute()
+      {
+         if (Subject.GlobalMoleculeDependentProperties != null)
+            return;
+
+         var moleculeProperties = _spatialStructureFactory.CreateGlobalMoleculeDependentProperties();
+         _context.AddToHistory(new AddGlobalMoleculePropertiesCommand(Subject, moleculeProperties).RunCommand(_context));
+      }
+   }
+}

--- a/src/MoBi.Presentation/UICommand/RemoveGlobalMoleculePropertiesUICommand.cs
+++ b/src/MoBi.Presentation/UICommand/RemoveGlobalMoleculePropertiesUICommand.cs
@@ -1,0 +1,37 @@
+using MoBi.Assets;
+using MoBi.Core.Commands;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Extensions;
+using OSPSuite.Assets;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Services;
+using OSPSuite.Presentation.UICommands;
+
+namespace MoBi.Presentation.UICommand
+{
+   public class RemoveGlobalMoleculePropertiesUICommand : ObjectUICommand<IContainer>
+   {
+      private readonly IMoBiContext _context;
+      private readonly IActiveSubjectRetriever _activeSubjectRetriever;
+      private readonly IDialogCreator _dialogCreator;
+
+      public RemoveGlobalMoleculePropertiesUICommand(IMoBiContext context, IActiveSubjectRetriever activeSubjectRetriever, IDialogCreator dialogCreator)
+      {
+         _context = context;
+         _activeSubjectRetriever = activeSubjectRetriever;
+         _dialogCreator = dialogCreator;
+      }
+
+      protected override void PerformExecute()
+      {
+         var spatialStructure = _activeSubjectRetriever.Active<MoBiSpatialStructure>();
+         if (!Equals(spatialStructure.GlobalMoleculeDependentProperties, Subject))
+            return;
+
+         if (_dialogCreator.MessageBoxYesNo(AppConstants.Dialog.Remove(ObjectTypes.Container, Subject.Name, spatialStructure.Name)) != ViewResult.Yes)
+            return;
+
+         _context.AddToHistory(new RemoveGlobalMoleculePropertiesCommand(spatialStructure, Subject).RunCommand(_context));
+      }
+   }
+}

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.161" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -25,11 +25,11 @@
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -54,13 +54,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.160" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.161" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/Core/Commands/AddGlobalMoleculePropertiesCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/AddGlobalMoleculePropertiesCommandSpecs.cs
@@ -1,0 +1,76 @@
+using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Core.Domain.Model.Diagram;
+using MoBi.Core.Domain.Services;
+using MoBi.Core.Extensions;
+using MoBi.HelpersForTests;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Domain;
+
+namespace MoBi.Core.Commands
+{
+   internal class concern_for_AddGlobalMoleculePropertiesCommand : ContextSpecification<AddGlobalMoleculePropertiesCommand>
+   {
+      protected MoBiSpatialStructure _spatialStructure;
+      protected IContainer _moleculeProperties;
+      protected IMoBiContext _context;
+      protected IRegisterTask _registerTask;
+
+      protected override void Context()
+      {
+         _spatialStructure = new MoBiSpatialStructure { DiagramManager = A.Fake<ISpatialStructureDiagramManager>() }.WithName("SpSt");
+         _moleculeProperties = new Container().WithName(Constants.MOLECULE_PROPERTIES).WithMode(ContainerMode.Logical);
+
+         _context = A.Fake<IMoBiContext>();
+         _registerTask = A.Fake<IRegisterTask>();
+
+         A.CallTo(() => _context.ObjectPathFactory).Returns(new ObjectPathFactoryForSpecs());
+         A.CallTo(() => _context.Resolve<IRegisterTask>()).Returns(_registerTask);
+
+         sut = new AddGlobalMoleculePropertiesCommand(_spatialStructure, _moleculeProperties);
+      }
+   }
+
+   internal class When_adding_the_global_molecule_properties_to_the_spatial_structure : concern_for_AddGlobalMoleculePropertiesCommand
+   {
+      protected override void Because()
+      {
+         sut.RunCommand(_context);
+      }
+
+      [Observation]
+      public void the_container_should_be_registered_using_the_task()
+      {
+         A.CallTo(() => _registerTask.RegisterAllIn(_moleculeProperties)).MustHaveHappened();
+      }
+
+      [Observation]
+      public void the_container_should_be_set_as_the_global_molecule_dependent_properties()
+      {
+         _spatialStructure.GlobalMoleculeDependentProperties.ShouldBeEqualTo(_moleculeProperties);
+      }
+   }
+
+   internal class When_reverting_the_add_global_molecule_properties_command : concern_for_AddGlobalMoleculePropertiesCommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _context.Get<MoBiSpatialStructure>(A<string>._)).Returns(_spatialStructure);
+         A.CallTo(() => _context.Get<IContainer>(_moleculeProperties.Id)).Returns(_moleculeProperties);
+         A.CallTo(() => _context.Resolve<IUnregisterTask>()).Returns(A.Fake<IUnregisterTask>());
+      }
+
+      protected override void Because()
+      {
+         sut.ExecuteAndInvokeInverse(_context);
+      }
+
+      [Observation]
+      public void should_remove_the_global_molecule_properties_from_the_spatial_structure()
+      {
+         _spatialStructure.GlobalMoleculeDependentProperties.ShouldBeNull();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Core/MoBiSpatialStructureFactorySpecs.cs
+++ b/tests/MoBi.Tests/Core/MoBiSpatialStructureFactorySpecs.cs
@@ -55,5 +55,11 @@ namespace MoBi.Core
       {
          _result.TopContainers.Single().Name.ShouldBeEqualTo(Constants.EVENTS);
       }
+
+      [Observation]
+      public void should_not_create_the_global_molecule_properties_container()
+      {
+         _result.GlobalMoleculeDependentProperties.ShouldBeNull();
+      }
    }
 }

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -25,9 +25,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.161" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/MoBi.Tests/Presentation/AddGlobalMoleculePropertiesUICommandSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/AddGlobalMoleculePropertiesUICommandSpecs.cs
@@ -1,0 +1,77 @@
+using FakeItEasy;
+using MoBi.Core.Domain.Builder;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.UICommand;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Diagram;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Services;
+
+namespace MoBi.Presentation
+{
+   public abstract class concern_for_AddGlobalMoleculePropertiesUICommand : ContextSpecification<AddGlobalMoleculePropertiesUICommand>
+   {
+      protected IMoBiContext _context;
+      protected IActiveSubjectRetriever _activeSubjectRetriever;
+      protected IMoBiSpatialStructureFactory _spatialStructureFactory;
+      protected MoBiSpatialStructure _spatialStructure;
+
+      protected override void Context()
+      {
+         _context = A.Fake<IMoBiContext>();
+         _activeSubjectRetriever = A.Fake<IActiveSubjectRetriever>();
+         _spatialStructureFactory = A.Fake<IMoBiSpatialStructureFactory>();
+         _spatialStructure = new MoBiSpatialStructure
+         {
+            DiagramManager = A.Fake<IDiagramManager<MoBiSpatialStructure>>()
+         };
+
+         A.CallTo(() => _activeSubjectRetriever.Active<MoBiSpatialStructure>()).Returns(_spatialStructure);
+         A.CallTo(() => _spatialStructureFactory.CreateGlobalMoleculeDependentProperties())
+            .Returns(new Container().WithName(Constants.MOLECULE_PROPERTIES).WithMode(ContainerMode.Logical));
+
+         sut = new AddGlobalMoleculePropertiesUICommand(_activeSubjectRetriever, _context, _spatialStructureFactory);
+      }
+   }
+
+   public class When_adding_the_global_molecule_properties_to_a_spatial_structure : concern_for_AddGlobalMoleculePropertiesUICommand
+   {
+      protected override void Because()
+      {
+         sut.Execute();
+      }
+
+      [Observation]
+      public void should_add_a_molecule_properties_container_to_the_spatial_structure()
+      {
+         _spatialStructure.GlobalMoleculeDependentProperties.Name.ShouldBeEqualTo(Constants.MOLECULE_PROPERTIES);
+      }
+
+      [Observation]
+      public void should_add_the_command_to_history()
+      {
+         A.CallTo(() => _context.AddToHistory(A<OSPSuite.Core.Commands.Core.ICommand>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_adding_the_global_molecule_properties_to_a_spatial_structure_that_already_has_them : concern_for_AddGlobalMoleculePropertiesUICommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _spatialStructure.GlobalMoleculeDependentProperties = new Container().WithName(Constants.MOLECULE_PROPERTIES);
+      }
+
+      protected override void Because()
+      {
+         sut.Execute();
+      }
+
+      [Observation]
+      public void should_not_add_another_molecule_properties_container()
+      {
+         A.CallTo(() => _context.AddToHistory(A<OSPSuite.Core.Commands.Core.ICommand>._)).MustNotHaveHappened();
+      }
+   }
+}

--- a/tests/MoBi.Tests/Presentation/ContextMenuForContainerSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/ContextMenuForContainerSpecs.cs
@@ -10,6 +10,7 @@ using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
+using OSPSuite.Core.Services;
 using OSPSuite.Infrastructure.Container.Castle;
 using OSPSuite.Presentation.Presenters;
 using OSPSuite.Presentation.Views.ContextMenus;
@@ -19,6 +20,7 @@ namespace MoBi.Presentation
    public abstract class concern_for_ContextMenuForContainer : ContextSpecification<ContextMenuForContainer>
    {
       protected IMoBiContext _context;
+      protected IActiveSubjectRetriever _activeSubjectRetriever;
       protected IContainer _moleculeProperties;
       protected ObjectBaseDTO _dto;
 
@@ -33,6 +35,7 @@ namespace MoBi.Presentation
       protected override void Context()
       {
          _context = A.Fake<IMoBiContext>();
+         _activeSubjectRetriever = A.Fake<IActiveSubjectRetriever>();
          var objectTypeResolver = A.Fake<IObjectTypeResolver>();
          A.CallTo(() => objectTypeResolver.TypeFor<IParameter>()).Returns(ObjectTypes.Parameter);
          A.CallTo(() => objectTypeResolver.TypeFor<IContainer>()).Returns(ObjectTypes.Container);
@@ -42,7 +45,7 @@ namespace MoBi.Presentation
          _dto = new ObjectBaseDTO(_moleculeProperties) {Name = Constants.MOLECULE_PROPERTIES};
          A.CallTo(() => _context.Get<IContainer>(A<string>._)).Returns(_moleculeProperties);
 
-         sut = new ContextMenuForContainer(_context, objectTypeResolver, A.Fake<OSPSuite.Utility.Container.IContainer>(), A.Fake<IEntityPathResolver>());
+         sut = new ContextMenuForContainer(_context, objectTypeResolver, A.Fake<OSPSuite.Utility.Container.IContainer>(), A.Fake<IEntityPathResolver>(), _activeSubjectRetriever);
       }
 
       protected override void Because()
@@ -69,6 +72,22 @@ namespace MoBi.Presentation
    }
 
    public class When_creating_the_context_menu_for_the_global_molecule_properties_of_a_spatial_structure : concern_for_ContextMenuForContainer
+   {
+      protected override void Context()
+      {
+         base.Context();
+         var spatialStructure = new MoBiSpatialStructure {GlobalMoleculeDependentProperties = _moleculeProperties};
+         A.CallTo(() => _activeSubjectRetriever.Active<MoBiSpatialStructure>()).Returns(spatialStructure);
+      }
+
+      [Observation]
+      public void should_allow_the_molecule_properties_to_be_deleted()
+      {
+         hasDeleteItem.ShouldBeTrue();
+      }
+   }
+
+   public class When_creating_the_context_menu_for_a_parentless_molecule_properties_container_outside_the_active_spatial_structure : concern_for_ContextMenuForContainer
    {
       [Observation]
       public void should_not_allow_the_molecule_properties_to_be_deleted()

--- a/tests/MoBi.Tests/Presentation/HierarchicalSpatialStructurePresenterSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/HierarchicalSpatialStructurePresenterSpecs.cs
@@ -39,6 +39,27 @@ namespace MoBi.Presentation
       }
    }
 
+   public class When_showing_a_spatial_structure_without_global_molecule_properties : concern_for_HierarchicalSpatialStructurePresenter
+   {
+      protected override void Context()
+      {
+         base.Context();
+         _spatialStructure.NeighborhoodsContainer = new Container().WithName(Constants.NEIGHBORHOODS);
+         Fake.ClearRecordedCalls(_objectBaseToObjectBaseDTOMapper);
+      }
+
+      protected override void Because()
+      {
+         sut.Edit(_spatialStructure);
+      }
+
+      [Observation]
+      public void should_not_create_a_root_node_for_the_missing_container()
+      {
+         A.CallTo(() => _objectBaseToObjectBaseDTOMapper.MapFrom(null)).MustNotHaveHappened();
+      }
+   }
+
    public class When_adding_a_non_root_node_to_the_spatial_structure : concern_for_HierarchicalSpatialStructurePresenter
    {
       private IContainer _addedObject;

--- a/tests/MoBi.Tests/Presentation/RemoveGlobalMoleculePropertiesUICommandSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/RemoveGlobalMoleculePropertiesUICommandSpecs.cs
@@ -1,0 +1,111 @@
+using FakeItEasy;
+using MoBi.Core.Domain.Model;
+using MoBi.Presentation.UICommand;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+using OSPSuite.Core.Diagram;
+using OSPSuite.Core.Domain;
+using OSPSuite.Core.Services;
+
+namespace MoBi.Presentation
+{
+   public abstract class concern_for_RemoveGlobalMoleculePropertiesUICommand : ContextSpecification<RemoveGlobalMoleculePropertiesUICommand>
+   {
+      protected IMoBiContext _context;
+      protected IActiveSubjectRetriever _activeSubjectRetriever;
+      protected IDialogCreator _dialogCreator;
+      protected MoBiSpatialStructure _spatialStructure;
+      protected IContainer _moleculeProperties;
+
+      protected override void Context()
+      {
+         _context = A.Fake<IMoBiContext>();
+         _activeSubjectRetriever = A.Fake<IActiveSubjectRetriever>();
+         _dialogCreator = A.Fake<IDialogCreator>();
+         _moleculeProperties = new Container().WithName(Constants.MOLECULE_PROPERTIES).WithMode(ContainerMode.Logical);
+         _spatialStructure = new MoBiSpatialStructure
+         {
+            DiagramManager = A.Fake<IDiagramManager<MoBiSpatialStructure>>(),
+            GlobalMoleculeDependentProperties = _moleculeProperties
+         };
+
+         A.CallTo(() => _activeSubjectRetriever.Active<MoBiSpatialStructure>()).Returns(_spatialStructure);
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).Returns(ViewResult.Yes);
+
+         sut = new RemoveGlobalMoleculePropertiesUICommand(_context, _activeSubjectRetriever, _dialogCreator);
+         sut.For(_moleculeProperties);
+      }
+   }
+
+   public class When_removing_the_global_molecule_properties_from_a_spatial_structure : concern_for_RemoveGlobalMoleculePropertiesUICommand
+   {
+      protected override void Because()
+      {
+         sut.Execute();
+      }
+
+      [Observation]
+      public void should_remove_the_molecule_properties_container_from_the_spatial_structure()
+      {
+         _spatialStructure.GlobalMoleculeDependentProperties.ShouldBeNull();
+      }
+
+      [Observation]
+      public void should_add_the_command_to_history()
+      {
+         A.CallTo(() => _context.AddToHistory(A<OSPSuite.Core.Commands.Core.ICommand>._)).MustHaveHappened();
+      }
+   }
+
+   public class When_the_user_cancels_the_removal_of_the_global_molecule_properties : concern_for_RemoveGlobalMoleculePropertiesUICommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         A.CallTo(() => _dialogCreator.MessageBoxYesNo(A<string>._, A<ViewResult>._)).Returns(ViewResult.No);
+      }
+
+      protected override void Because()
+      {
+         sut.Execute();
+      }
+
+      [Observation]
+      public void should_keep_the_molecule_properties_container()
+      {
+         _spatialStructure.GlobalMoleculeDependentProperties.ShouldBeEqualTo(_moleculeProperties);
+      }
+
+      [Observation]
+      public void should_not_add_a_command_to_history()
+      {
+         A.CallTo(() => _context.AddToHistory(A<OSPSuite.Core.Commands.Core.ICommand>._)).MustNotHaveHappened();
+      }
+   }
+
+   public class When_removing_a_molecule_properties_container_that_is_not_the_global_one : concern_for_RemoveGlobalMoleculePropertiesUICommand
+   {
+      protected override void Context()
+      {
+         base.Context();
+         sut.For(new Container().WithName(Constants.MOLECULE_PROPERTIES));
+      }
+
+      protected override void Because()
+      {
+         sut.Execute();
+      }
+
+      [Observation]
+      public void should_keep_the_global_molecule_properties_container()
+      {
+         _spatialStructure.GlobalMoleculeDependentProperties.ShouldBeEqualTo(_moleculeProperties);
+      }
+
+      [Observation]
+      public void should_not_add_a_command_to_history()
+      {
+         A.CallTo(() => _context.AddToHistory(A<OSPSuite.Core.Commands.Core.ICommand>._)).MustNotHaveHappened();
+      }
+   }
+}

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.160" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.160" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.161" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
A new spatial structure no longer carries an empty global `MoleculeProperties` container, so it stops overwriting the ones defined by previous modules when the module merge behavior is `Overwrite`. The container is no longer created by `SpatialStructureFactory` in Open-Systems-Pharmacology/OSPSuite.Core#2961, and `SpatialStructureMerger` already skips it when it is `null`.

In its place:
- **Add** — `AddMoleculeProperties` on the spatial structure root context menu, offered only while the container is absent.
- **Delete** — on the container's own node, wired to a dedicated command. It plugs into the `AddMenuItemsForSpecialName` hook from #2517, which deliberately left the global container out because the generic remove would have dropped the tree node without removing the data.

Both are undoable (`AddGlobalMoleculePropertiesCommand` / `RemoveGlobalMoleculePropertiesCommand`), and `HierarchicalSpatialStructurePresenter.entityIsInSpatialStructure` now recognises the global container so the tree refreshes on add and remove.

Also fixes two null paths that a spatial structure without the container would have hit: `ParameterResolver.resolveMoleculePropertiesInSpatialStructure` and `HierarchicalSpatialStructurePresenter.InitializeWith`.

Bumps OSPSuite.Core to 13.0.161, which this depends on.

Fixes #2512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to create and remove global molecule-dependent properties for spatial structures.
  * Added context-menu actions for managing these properties, including confirmation before removal.
  * Spatial structure views now display global molecule properties when available.

* **Bug Fixes**
  * Improved handling of spatial structures without global molecule properties, preventing empty or invalid tree entries.
  * Safely handles missing global molecule properties during parameter resolution.

* **Tests**
  * Added coverage for creation, removal, cancellation, duplicate prevention, and spatial structure display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->