### PR TITLE
Fixes #2518 Create the dimension validation state per run

### DIFF
--- a/src/MoBi.Assets/MoBi.Assets.csproj
+++ b/src/MoBi.Assets/MoBi.Assets.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" /> 
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" /> 
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.BatchTool/MoBi.BatchTool.csproj
+++ b/src/MoBi.BatchTool/MoBi.BatchTool.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DevExpress.Win.Design" Version="25.2.7" Condition="'$(ExcludeDesigner)' != 'true'" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
+++ b/src/MoBi.CLI.Core/MoBi.CLI.Core.csproj
@@ -16,13 +16,13 @@
 
 
 	<ItemGroup>
-      <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
-      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.161" />
+      <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+      <PackageReference Include="OSPSuite.Infrastructure.Autofac" Version="13.0.164" />
       <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-      <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-      <PackageReference Include="OSPSuite.R" Version="13.0.161" />
-      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.161" />
-      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.161" />
+      <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+      <PackageReference Include="OSPSuite.R" Version="13.0.164" />
+      <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.164" />
+      <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.164" />
 	</ItemGroup>
 	<ItemGroup>
       <ProjectReference Include="..\MoBi.Assets\MoBi.Assets.csproj" />

--- a/src/MoBi.CLI/MoBi.CLI.csproj
+++ b/src/MoBi.CLI/MoBi.CLI.csproj
@@ -22,15 +22,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.164" />
   </ItemGroup>
   <ItemGroup>
      <Content Include="..\..\dimensions\OSPSuite.Dimensions.xml" Link="OSPSuite.Dimensions.xml">

--- a/src/MoBi.Core/Domain/Services/DimensionValidator.cs
+++ b/src/MoBi.Core/Domain/Services/DimensionValidator.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;

--- a/src/MoBi.Core/Domain/Services/DimensionValidator.cs
+++ b/src/MoBi.Core/Domain/Services/DimensionValidator.cs
@@ -1,12 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
-using OSPSuite.Utility.Visitor;
 
 namespace MoBi.Core.Domain.Services
 {
-   public interface IDimensionValidator : IVisitor<IEntity>, IVisitor<IUsingFormula>
+   public interface IDimensionValidator
    {
       Task<ValidationResult> Validate(IContainer container, SimulationBuilder simulationBuilder);
       Task<ValidationResult> Validate(IModel model, SimulationBuilder simulationBuilder);

--- a/src/MoBi.Core/MoBi.Core.csproj
+++ b/src/MoBi.Core/MoBi.Core.csproj
@@ -31,12 +31,12 @@
     <PackageReference Include="NHibernate.Extensions.Sqlite" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets.Images" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure.Export" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure.Serialization" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure.Import" Version="13.0.164" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>

--- a/src/MoBi.Core/Services/DimensionValidator.cs
+++ b/src/MoBi.Core/Services/DimensionValidator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/MoBi.Core/Services/DimensionValidator.cs
+++ b/src/MoBi.Core/Services/DimensionValidator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,6 +11,7 @@ using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.FuncParser;
 using OSPSuite.Utility.Extensions;
+using OSPSuite.Utility.Visitor;
 using IMoBiCoreUserSettings = MoBi.Core.ICoreUserSettings;
 
 namespace MoBi.Core.Services
@@ -20,11 +21,7 @@ namespace MoBi.Core.Services
       private readonly DimensionParser _dimensionParser;
       private readonly IObjectPathFactory _objectPathFactory;
       private readonly IMoBiCoreUserSettings _userSettings;
-      private bool _checkDimensions;
-      private SimulationBuilder _simulationBuilder;
-      private ValidationResult _result;
       private readonly IDictionary<string, string> _hiddenNotifications;
-      private bool _checkRules;
 
       public DimensionValidator(DimensionParser dimensionParser, IObjectPathFactory objectPathFactory, IMoBiCoreUserSettings userSettings)
       {
@@ -64,164 +61,179 @@ namespace MoBi.Core.Services
       {
          return Task.Run(() =>
          {
-            try
-            {
-               _result = new ValidationResult();
-               _checkDimensions = _userSettings.CheckDimensions;
-               _checkRules = _userSettings.CheckRules;
-               _simulationBuilder = simulationBuilder;
-               containers.Each(c => c.AcceptVisitor(this));
-               return _result;
-            }
-            finally
-            {
-               _simulationBuilder = null;
-               _result = null;
-            }
+            //per-run state lives in a visitor created per call so that concurrent validations on this instance stay independent
+            var validationRun = new ValidationRun(_dimensionParser, _objectPathFactory, _userSettings, _hiddenNotifications, simulationBuilder);
+            containers.Each(c => c.AcceptVisitor(validationRun));
+            return validationRun.Result;
          });
       }
 
-      public void Visit(IEntity entity)
+      private class ValidationRun : IVisitor<IEntity>, IVisitor<IUsingFormula>
       {
-         if (!_checkRules) return;
+         private readonly DimensionParser _dimensionParser;
+         private readonly IObjectPathFactory _objectPathFactory;
+         private readonly IMoBiCoreUserSettings _userSettings;
+         private readonly IDictionary<string, string> _hiddenNotifications;
+         private readonly SimulationBuilder _simulationBuilder;
+         private readonly bool _checkDimensions;
+         private readonly bool _checkRules;
 
-         entity.Rules.BrokenBy(entity).Messages.Each(x => addNotification(NotificationType.Warning, entity, x));
-      }
+         public ValidationResult Result { get; } = new ValidationResult();
 
-      public void Visit(IUsingFormula entityUsingFormula)
-      {
-         try
+         public ValidationRun(DimensionParser dimensionParser, IObjectPathFactory objectPathFactory, IMoBiCoreUserSettings userSettings,
+            IDictionary<string, string> hiddenNotifications, SimulationBuilder simulationBuilder)
          {
-            Visit(entityUsingFormula as IEntity);
+            _dimensionParser = dimensionParser;
+            _objectPathFactory = objectPathFactory;
+            _userSettings = userSettings;
+            _hiddenNotifications = hiddenNotifications;
+            _simulationBuilder = simulationBuilder;
+            _checkDimensions = userSettings.CheckDimensions;
+            _checkRules = userSettings.CheckRules;
+         }
 
-            if (!_checkDimensions) return;
+         public void Visit(IEntity entity)
+         {
+            if (!_checkRules) return;
 
-            var formula = entityUsingFormula.Formula;
-            if (formula.IsConstant()) return; //do not need to check constants
+            entity.Rules.BrokenBy(entity).Messages.Each(x => addNotification(NotificationType.Warning, entity, x));
+         }
 
-            var displayPath = _objectPathFactory.CreateAbsoluteObjectPath(entityUsingFormula).PathAsString;
-            if (entityUsingFormula.Dimension == null)
+         public void Visit(IUsingFormula entityUsingFormula)
+         {
+            try
             {
-               addWarning(entityUsingFormula, AppConstants.Validation.NoDimensionSet(displayPath));
+               Visit(entityUsingFormula as IEntity);
+
+               if (!_checkDimensions) return;
+
+               var formula = entityUsingFormula.Formula;
+               if (formula.IsConstant()) return; //do not need to check constants
+
+               var displayPath = _objectPathFactory.CreateAbsoluteObjectPath(entityUsingFormula).PathAsString;
+               if (entityUsingFormula.Dimension == null)
+               {
+                  addWarning(entityUsingFormula, AppConstants.Validation.NoDimensionSet(displayPath));
+                  return;
+               }
+
+               checkFormula(entityUsingFormula, displayPath);
+               checkRHSFormula(entityUsingFormula as IParameter, displayPath);
+            }
+            catch (Exception exception)
+            {
+               addNotification(NotificationType.Error, entityUsingFormula, exception.Message);
+            }
+         }
+
+         private void checkRHSFormula(IParameter parameter, string displayPath)
+         {
+            var rhsFormula = parameter?.RHSFormula;
+            if (rhsFormula == null) return;
+
+            var rhsDimBaseRep = new BaseDimensionRepresentation(parameter.Dimension.BaseRepresentation);
+            rhsDimBaseRep.TimeExponent = rhsDimBaseRep.TimeExponent - 1;
+
+            if (!Equals(rhsDimBaseRep, rhsFormula.Dimension.BaseRepresentation))
+               addWarning(parameter, AppConstants.Validation.RHSDimensionMismatch(displayPath, rhsFormula.Name));
+
+            checkExplicitFormula(parameter, displayPath, rhsDimBaseRep, rhsFormula as ExplicitFormula);
+         }
+
+         private void addWarning(IEntity entityToValidate, string warning) => addNotification(NotificationType.Warning, entityToValidate, warning);
+
+         private void addNotification(NotificationType notificationType, IEntity entityToValidate, string notification)
+         {
+            var builder = _simulationBuilder.BuilderFor(entityToValidate);
+            if (!shouldShowNotification(entityToValidate, notification))
+               return;
+
+            Result.AddMessage(notificationType, builder, notification);
+         }
+
+         private bool shouldShowNotification(IObjectBase entityToValidate, string notification)
+         {
+            if (_userSettings.ShowPKSimDimensionProblemWarnings)
+               return true;
+
+            if (!_hiddenNotifications.Keys.Contains(entityToValidate.Name))
+               return true;
+
+            var messageEnd = _hiddenNotifications[entityToValidate.Name];
+            if (notification.EndsWith(messageEnd))
+               return false;
+
+            return true;
+         }
+
+         private void checkFormula(IUsingFormula entityUsingFormula, string displayPath)
+         {
+            if (!Equals(entityUsingFormula.Dimension, entityUsingFormula.Formula.Dimension))
+               addWarning(entityUsingFormula, AppConstants.Validation.DimensionMismatch(displayPath, entityUsingFormula.Formula.Name));
+
+            checkExplicitFormula(entityUsingFormula, displayPath, entityUsingFormula.Dimension.BaseRepresentation, entityUsingFormula.Formula as ExplicitFormula);
+         }
+
+         private void checkExplicitFormula(IUsingFormula entityUsingFormula, string displayPath, BaseDimensionRepresentation baseDimensionRepresentation, ExplicitFormula explicitFormula)
+         {
+            if (explicitFormula == null) return;
+
+            var dimensionInfos = new List<QuantityDimensionInformation>();
+            if (isDoubleString(explicitFormula.FormulaString))
+               return;
+
+            foreach (var objectReference in explicitFormula.ObjectReferences.Where(x => x.Object.Dimension != null))
+            {
+               var pathDim = explicitFormula.ObjectPaths.Where(path => path.Alias.Equals(objectReference.Alias)).Select(path => path.Dimension).FirstOrDefault();
+               if (!Equals(objectReference.Object.Dimension, pathDim))
+                  addWarning(entityUsingFormula, AppConstants.Validation.ReferenceDimensionMissmatch(displayPath, objectReference, pathDim));
+
+               dimensionInfos.Add(new QuantityDimensionInformation(objectReference.Alias, createDimensionInfoFromBaseRepresentation(objectReference.Object.Dimension.BaseRepresentation)));
+            }
+
+            var (dimInfo, parseSuccess, calculateDimensionSuccess, errorMessage) = _dimensionParser.GetDimensionInformationFor(explicitFormula.FormulaString, dimensionInfos);
+
+            if (!parseSuccess)
+            {
+               addNotification(NotificationType.Error, entityUsingFormula, errorMessage);
                return;
             }
 
-            checkFormula(entityUsingFormula, displayPath);
-            checkRHSFormula(entityUsingFormula as IParameter, displayPath);
-         }
-         catch (Exception exception)
-         {
-            addNotification(NotificationType.Error, entityUsingFormula, exception.Message);
-         }
-      }
 
-      private void checkRHSFormula(IParameter parameter, string displayPath)
-      {
-         var rhsFormula = parameter?.RHSFormula;
-         if (rhsFormula == null) return;
-
-         var rhsDimBaseRep = new BaseDimensionRepresentation(parameter.Dimension.BaseRepresentation);
-         rhsDimBaseRep.TimeExponent = rhsDimBaseRep.TimeExponent - 1;
-
-         if (!Equals(rhsDimBaseRep, rhsFormula.Dimension.BaseRepresentation))
-            addWarning(parameter, AppConstants.Validation.RHSDimensionMismatch(displayPath, rhsFormula.Name));
-
-         checkExplicitFormula(parameter, displayPath, rhsDimBaseRep, rhsFormula as ExplicitFormula);
-      }
-
-      private void addWarning(IEntity entityToValidate, string warning) => addNotification(NotificationType.Warning, entityToValidate, warning);
-
-      private void addNotification(NotificationType notificationType, IEntity entityToValidate, string notification)
-      {
-         var builder = _simulationBuilder.BuilderFor(entityToValidate);
-         if (!shouldShowNotification(entityToValidate, notification))
-            return;
-
-         _result.AddMessage(notificationType, builder, notification);
-      }
-
-      private bool shouldShowNotification(IObjectBase entityToValidate, string notification)
-      {
-         if (_userSettings.ShowPKSimDimensionProblemWarnings)
-            return true;
-
-         if (!_hiddenNotifications.Keys.Contains(entityToValidate.Name))
-            return true;
-
-         var messageEnd = _hiddenNotifications[entityToValidate.Name];
-         if (notification.EndsWith(messageEnd))
-            return false;
-
-         return true;
-      }
-
-      private void checkFormula(IUsingFormula entityUsingFormula, string displayPath)
-      {
-         if (!Equals(entityUsingFormula.Dimension, entityUsingFormula.Formula.Dimension))
-            addWarning(entityUsingFormula, AppConstants.Validation.DimensionMismatch(displayPath, entityUsingFormula.Formula.Name));
-
-         checkExplicitFormula(entityUsingFormula, displayPath, entityUsingFormula.Dimension.BaseRepresentation, entityUsingFormula.Formula as ExplicitFormula);
-      }
-
-      private void checkExplicitFormula(IUsingFormula entityUsingFormula, string displayPath, BaseDimensionRepresentation baseDimensionRepresentation, ExplicitFormula explicitFormula)
-      {
-         if (explicitFormula == null) return;
-
-         var dimensionInfos = new List<QuantityDimensionInformation>();
-         if (isDoubleString(explicitFormula.FormulaString))
-            return;
-
-         foreach (var objectReference in explicitFormula.ObjectReferences.Where(x => x.Object.Dimension != null))
-         {
-            var pathDim = explicitFormula.ObjectPaths.Where(path => path.Alias.Equals(objectReference.Alias)).Select(path => path.Dimension).FirstOrDefault();
-            if (!Equals(objectReference.Object.Dimension, pathDim))
-               addWarning(entityUsingFormula, AppConstants.Validation.ReferenceDimensionMissmatch(displayPath, objectReference, pathDim));
-
-            dimensionInfos.Add(new QuantityDimensionInformation(objectReference.Alias, createDimensionInfoFromBaseRepresentation(objectReference.Object.Dimension.BaseRepresentation)));
-         }
-
-         var (dimInfo, parseSuccess, calculateDimensionSuccess, errorMessage) = _dimensionParser.GetDimensionInformationFor(explicitFormula.FormulaString, dimensionInfos);
-
-         if (!parseSuccess)
-         {
-            addNotification(NotificationType.Error, entityUsingFormula, errorMessage);
-            return;
-         }
-
-
-         if (calculateDimensionSuccess)
-         {
-            if (!dimInfo.AreEquals(createDimensionInfoFromBaseRepresentation(baseDimensionRepresentation)))
+            if (calculateDimensionSuccess)
             {
-               addWarning(entityUsingFormula, AppConstants.Validation.FormulaDimensionMismatch(displayPath, explicitFormula.Dimension.Name));
+               if (!dimInfo.AreEquals(createDimensionInfoFromBaseRepresentation(baseDimensionRepresentation)))
+               {
+                  addWarning(entityUsingFormula, AppConstants.Validation.FormulaDimensionMismatch(displayPath, explicitFormula.Dimension.Name));
+               }
+
+               return;
             }
 
-            return;
+            //ignore some dimension check errors.
+            //Reason: some formulas are written so that dimension exponents cannot be calculated, e.g.
+            //x^y where y is not dimensionless.
+            if (_userSettings.ShowCannotCalcErrors)
+            {
+               addWarning(entityUsingFormula, errorMessage);
+            }
          }
 
-         //ignore some dimension check errors.
-         //Reason: some formulas are written so that dimension exponents cannot be calculated, e.g.
-         //x^y where y is not dimensionless. 
-         if (_userSettings.ShowCannotCalcErrors)
+         private bool isDoubleString(string stringToCheck)
          {
-            addWarning(entityUsingFormula, errorMessage);
+            return double.TryParse(stringToCheck, out _);
          }
-      }
 
-      private bool isDoubleString(string stringToCheck)
-      {
-         return double.TryParse(stringToCheck, out _);
-      }
-
-      private DimensionInformation createDimensionInfoFromBaseRepresentation(BaseDimensionRepresentation baseRepresentation)
-      {
-         return new DimensionInformation(baseRepresentation.LengthExponent,
-            baseRepresentation.MassExponent,
-            baseRepresentation.TimeExponent,
-            baseRepresentation.ElectricCurrentExponent,
-            baseRepresentation.TemperatureExponent,
-            baseRepresentation.AmountExponent,
-            baseRepresentation.LuminousIntensityExponent);
+         private DimensionInformation createDimensionInfoFromBaseRepresentation(BaseDimensionRepresentation baseRepresentation)
+         {
+            return new DimensionInformation(baseRepresentation.LengthExponent,
+               baseRepresentation.MassExponent,
+               baseRepresentation.TimeExponent,
+               baseRepresentation.ElectricCurrentExponent,
+               baseRepresentation.TemperatureExponent,
+               baseRepresentation.AmountExponent,
+               baseRepresentation.LuminousIntensityExponent);
+         }
       }
    }
 }

--- a/src/MoBi.Core/Services/DimensionValidator.cs
+++ b/src/MoBi.Core/Services/DimensionValidator.cs
@@ -61,7 +61,6 @@ namespace MoBi.Core.Services
       {
          return Task.Run(() =>
          {
-            //per-run state lives in a visitor created per call so that concurrent validations on this instance stay independent
             var validationRun = new ValidationRun(_dimensionParser, _objectPathFactory, _userSettings, _hiddenNotifications, simulationBuilder);
             containers.Each(c => c.AcceptVisitor(validationRun));
             return validationRun.Result;

--- a/src/MoBi.Core/Services/DimensionValidator.cs
+++ b/src/MoBi.Core/Services/DimensionValidator.cs
@@ -71,11 +71,12 @@ namespace MoBi.Core.Services
       {
          private readonly DimensionParser _dimensionParser;
          private readonly IObjectPathFactory _objectPathFactory;
-         private readonly IMoBiCoreUserSettings _userSettings;
          private readonly IDictionary<string, string> _hiddenNotifications;
          private readonly SimulationBuilder _simulationBuilder;
          private readonly bool _checkDimensions;
          private readonly bool _checkRules;
+         private readonly bool _showPKSimDimensionProblemWarnings;
+         private readonly bool _showCannotCalcErrors;
 
          public ValidationResult Result { get; } = new ValidationResult();
 
@@ -84,11 +85,12 @@ namespace MoBi.Core.Services
          {
             _dimensionParser = dimensionParser;
             _objectPathFactory = objectPathFactory;
-            _userSettings = userSettings;
             _hiddenNotifications = hiddenNotifications;
             _simulationBuilder = simulationBuilder;
             _checkDimensions = userSettings.CheckDimensions;
             _checkRules = userSettings.CheckRules;
+            _showPKSimDimensionProblemWarnings = userSettings.ShowPKSimDimensionProblemWarnings;
+            _showCannotCalcErrors = userSettings.ShowCannotCalcErrors;
          }
 
          public void Visit(IEntity entity)
@@ -152,7 +154,7 @@ namespace MoBi.Core.Services
 
          private bool shouldShowNotification(IObjectBase entityToValidate, string notification)
          {
-            if (_userSettings.ShowPKSimDimensionProblemWarnings)
+            if (_showPKSimDimensionProblemWarnings)
                return true;
 
             if (!_hiddenNotifications.Keys.Contains(entityToValidate.Name))
@@ -212,7 +214,7 @@ namespace MoBi.Core.Services
             //ignore some dimension check errors.
             //Reason: some formulas are written so that dimension exponents cannot be calculated, e.g.
             //x^y where y is not dimensionless.
-            if (_userSettings.ShowCannotCalcErrors)
+            if (_showCannotCalcErrors)
             {
                addWarning(entityUsingFormula, errorMessage);
             }

--- a/src/MoBi.Engine/MoBi.Engine.csproj
+++ b/src/MoBi.Engine/MoBi.Engine.csproj
@@ -28,8 +28,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Assets" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Assets" Version="13.0.164" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.Presentation/MoBi.Presentation.csproj
+++ b/src/MoBi.Presentation/MoBi.Presentation.csproj
@@ -20,9 +20,9 @@
 
   <ItemGroup>
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Presentation.Serialization" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi.R/MoBi.R.csproj
+++ b/src/MoBi.R/MoBi.R.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.R" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.R" Version="13.0.164" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MoBi.R/RRegister.cs
+++ b/src/MoBi.R/RRegister.cs
@@ -2,7 +2,6 @@ using MoBi.CLI.Core;
 using MoBi.CLI.Core.MinimalImplementations;
 using MoBi.Core;
 using MoBi.Core.Domain.Model.Diagram;
-using MoBi.Core.Domain.Services;
 using MoBi.Core.Serialization.Converter;
 using MoBi.Core.Serialization.ORM;
 using MoBi.Core.Serialization.Services;
@@ -61,7 +60,6 @@ namespace MoBi.R
          container.Register<IMoBiXmlSerializerRepository, MoBiCoreXmlSerializerRepository>(LifeStyle.Singleton);
          container.Register<IHistoryManagerFactory, HistoryManagerFactory>(LifeStyle.Singleton);
          container.Register<IDiagramManagerFactory, DiagramManagerFactory>(LifeStyle.Singleton);
-         container.Register<IDimensionValidator, DimensionValidator>(LifeStyle.Singleton);
          container.Register<ICoreUserSettings, OSPSuite.Core.ICoreUserSettings, CoreUserSettings>(LifeStyle.Singleton);
       }
    }

--- a/src/MoBi.UI/MoBi.UI.csproj
+++ b/src/MoBi.UI/MoBi.UI.csproj
@@ -25,11 +25,11 @@
     <PackageReference Include="OSPSuite.DataBinding" Version="4.0.0.5" />
     <PackageReference Include="OSPSuite.DataBinding.DevExpress" Version="7.0.0.6" />
     <PackageReference Include="OSPSuite.Utility" Version="5.0.0.11" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
    </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/src/MoBi/MoBi.csproj
+++ b/src/MoBi/MoBi.csproj
@@ -54,13 +54,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageReference Include="OSPSuite.Presentation" Version="13.0.161" GeneratePathProperty="true" />
+    <PackageReference Include="OSPSuite.Presentation" Version="13.0.164" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
+++ b/tests/MoBi.HelpersForTests/MoBi.HelpersForTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MoBi.Tests/Core/DimensionValidatorSpecs.cs
+++ b/tests/MoBi.Tests/Core/DimensionValidatorSpecs.cs
@@ -77,7 +77,7 @@ namespace MoBi.Core
             var visitor = call.GetArgument<IVisitor>(0);
             visit(visitor, _firstParameter);
             _firstVisitDone.Set();
-            _secondValidationDone.Wait(TimeSpan.FromSeconds(5));
+            _secondValidationDone.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
             visit(visitor, _secondParameter);
          });
 
@@ -98,7 +98,7 @@ namespace MoBi.Core
       protected override void Because()
       {
          var firstValidation = sut.Validate(new[] {_slowContainer}, _simulationBuilder);
-         _firstVisitDone.Wait(TimeSpan.FromSeconds(5));
+         _firstVisitDone.Wait(TimeSpan.FromSeconds(5)).ShouldBeTrue();
 
          _secondResult = sut.Validate(new[] {_fastContainer}, _simulationBuilder).Result;
          _secondValidationDone.Set();
@@ -131,7 +131,7 @@ namespace MoBi.Core
 
          var lengthDimension = new Dimension(new BaseDimensionRepresentation {LengthExponent = 1}, AppConstants.DimensionNames.LENGTH, "cm");
          var molWeightDimension = new Dimension(new BaseDimensionRepresentation { AmountExponent = 1, MassExponent = -1 }, "MW", "mol/g");
-         var areaDimension = new Dimension(new BaseDimensionRepresentation { LengthExponent = 2,}, AppConstants.DimensionNames.AREA, "cmï¿½");
+         var areaDimension = new Dimension(new BaseDimensionRepresentation { LengthExponent = 2,}, AppConstants.DimensionNames.AREA, "cm²");
 
          var radiusFormula = new ExplicitFormula()
             .WithFormulaString("0,0333 * (MW * 1E9) ^ 0,4226 * 1E-8")

--- a/tests/MoBi.Tests/Core/DimensionValidatorSpecs.cs
+++ b/tests/MoBi.Tests/Core/DimensionValidatorSpecs.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Linq;
+using System.Threading;
 using FakeItEasy;
 using MoBi.Assets;
 using MoBi.Core.Domain.Services;
@@ -13,6 +15,7 @@ using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Formulas;
 using OSPSuite.Core.Domain.UnitSystem;
 using OSPSuite.Utility.Extensions;
+using OSPSuite.Utility.Visitor;
 using OSPSuite.FuncParser;
 
 namespace MoBi.Core
@@ -34,6 +37,88 @@ namespace MoBi.Core
       }
    }
 
+   public class When_running_two_validations_concurrently_on_the_same_validator : concern_for_DimensionValidator
+   {
+      private IContainer _slowContainer;
+      private IContainer _fastContainer;
+      private IParameter _firstParameter;
+      private IParameter _secondParameter;
+      private IParameter _thirdParameter;
+      private SimulationBuilder _simulationBuilder;
+      private ManualResetEventSlim _firstVisitDone;
+      private ManualResetEventSlim _secondValidationDone;
+      private ValidationResult _firstResult;
+      private ValidationResult _secondResult;
+
+      protected override void Context()
+      {
+         base.Context();
+         _firstVisitDone = new ManualResetEventSlim();
+         _secondValidationDone = new ManualResetEventSlim();
+
+         //parameters whose formula has no dimension: each visit adds exactly one dimension mismatch warning
+         var topContainer = _buildConfiguration.All<SpatialStructure>().First().TopContainers.First();
+         addParameterWithDimensionlessFormula("NODIM_P1", topContainer);
+         addParameterWithDimensionlessFormula("NODIM_P2", topContainer);
+         addParameterWithDimensionlessFormula("NODIM_P3", topContainer);
+
+         var creationResult = DomainFactoryForSpecs.CreateModelFor(_buildConfiguration, "thename");
+         _simulationBuilder = creationResult.SimulationBuilder;
+
+         //visit the built model parameters: only entities tracked by the simulation builder can carry validation messages
+         _firstParameter = modelParameterNamed(creationResult, "NODIM_P1");
+         _secondParameter = modelParameterNamed(creationResult, "NODIM_P2");
+         _thirdParameter = modelParameterNamed(creationResult, "NODIM_P3");
+
+         //the slow container pauses its traversal until the second validation has completed on the same validator instance
+         _slowContainer = A.Fake<IContainer>();
+         A.CallTo(() => _slowContainer.AcceptVisitor(A<IVisitor>._)).Invokes(call =>
+         {
+            var visitor = call.GetArgument<IVisitor>(0);
+            visit(visitor, _firstParameter);
+            _firstVisitDone.Set();
+            _secondValidationDone.Wait(TimeSpan.FromSeconds(5));
+            visit(visitor, _secondParameter);
+         });
+
+         _fastContainer = A.Fake<IContainer>();
+         A.CallTo(() => _fastContainer.AcceptVisitor(A<IVisitor>._)).Invokes(call => visit(call.GetArgument<IVisitor>(0), _thirdParameter));
+      }
+
+      private static void addParameterWithDimensionlessFormula(string name, IContainer topContainer) =>
+         new Parameter().WithName(name).WithParentContainer(topContainer)
+            .WithFormula(new ExplicitFormula().WithFormulaString("111"))
+            .WithDimension(new Dimension(new BaseDimensionRepresentation(), "Dimensionless", ""));
+
+      private static IParameter modelParameterNamed(CreationResult creationResult, string name) =>
+         creationResult.Model.Root.GetAllChildren<IParameter>().First(x => x.Name.Equals(name));
+
+      private static void visit(IVisitor visitor, IParameter parameter) => visitor.DowncastTo<IVisitor<IUsingFormula>>().Visit(parameter);
+
+      protected override void Because()
+      {
+         var firstValidation = sut.Validate(new[] {_slowContainer}, _simulationBuilder);
+         _firstVisitDone.Wait(TimeSpan.FromSeconds(5));
+
+         _secondResult = sut.Validate(new[] {_fastContainer}, _simulationBuilder).Result;
+         _secondValidationDone.Set();
+
+         _firstResult = firstValidation.Result;
+      }
+
+      [Observation]
+      public void the_first_validation_should_report_the_messages_of_its_own_run()
+      {
+         _firstResult.Messages.Count().ShouldBeEqualTo(2);
+      }
+
+      [Observation]
+      public void the_second_validation_should_report_the_messages_of_its_own_run()
+      {
+         _secondResult.Messages.Count().ShouldBeEqualTo(1);
+      }
+   }
+
    internal class When_validating_a_parameter_from_pksim_that_should_not_be_shown_in_the_default_validation : concern_for_DimensionValidator
    {
       private IContainer _root;
@@ -46,7 +131,7 @@ namespace MoBi.Core
 
          var lengthDimension = new Dimension(new BaseDimensionRepresentation {LengthExponent = 1}, AppConstants.DimensionNames.LENGTH, "cm");
          var molWeightDimension = new Dimension(new BaseDimensionRepresentation { AmountExponent = 1, MassExponent = -1 }, "MW", "mol/g");
-         var areaDimension = new Dimension(new BaseDimensionRepresentation { LengthExponent = 2,}, AppConstants.DimensionNames.AREA, "cm²");
+         var areaDimension = new Dimension(new BaseDimensionRepresentation { LengthExponent = 2,}, AppConstants.DimensionNames.AREA, "cmï¿½");
 
          var radiusFormula = new ExplicitFormula()
             .WithFormulaString("0,0333 * (MW * 1E9) ^ 0,4226 * 1E-8")

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -25,9 +25,9 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.Infrastructure.Castle" Version="13.0.164" />
     <PackageReference Include="OSPSuite.FuncParser" Version="5.0.0.3" />
     <PackageReference Include="OSPSuite.SimModel" Version="5.0.0.80" />
     <PackageReference Include="OSPSuite.SimModelSolver_CVODES" Version="5.0.0.53" />

--- a/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
+++ b/tests/MoBi.UI.Tests/MoBi.UI.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="nunit" Version="3.14.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.1.1" />
-    <PackageReference Include="OSPSuite.Core" Version="13.0.161" />
-    <PackageReference Include="OSPSuite.UI" Version="13.0.161" />
+    <PackageReference Include="OSPSuite.Core" Version="13.0.164" />
+    <PackageReference Include="OSPSuite.UI" Version="13.0.164" />
    </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />


### PR DESCRIPTION
Fixes #2518

> Requires OSPSuite.Core **13.0.164** (contains Open-Systems-Pharmacology/OSPSuite.Core#2959) — already referenced by this branch.

### What changes

`DimensionValidator` no longer holds per-run state: the visiting state moves into a `ValidationRun` visitor created inside each `Validate` call, so concurrent validations on the same instance stay independent. The ineffective singleton registration of `IDimensionValidator` in `MoBi.R` is removed.

### Why

Dimension validation runs on `Task.Run` and is never awaited (`SimulationFactory.validateDimensions` only attaches continuations via `SecureContinueWith`), while the snapshot `SimulationMapper` holds a single `ISimulationFactory` — and therefore a single `IDimensionValidator` — for an entire project load. So even in today's sequential loop, simulation N+1's validation can begin on the same instance while simulation N's is still traversing: the second `_result = new ValidationResult()` clobbers the first, and the first call's `finally` nulls `_result`/`_simulationBuilder` mid-traversal of the second, producing a `NullReferenceException` in `addNotification` or warnings attributed to the wrong simulation.

The `MoBi.R` registration was silently ineffective anyway — the container resolves the first registration for a service, and `CoreRegister`'s scan (transient) runs earlier in the MoBi.R bootstrap — so it documented a lifestyle that was not in effect.

This is a prerequisite for #2424 (parallel model construction during snapshot load).

### Tests

A new spec runs two validations concurrently on the same validator with a deterministic interleaving and asserts each reports only its own messages. It fails against the previous implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dimension validation so simultaneous validation operations remain isolated and return the correct messages for each operation.
  - Removed an unnecessary validator registration from the R integration.

- **Chores**
  - Updated OSPSuite-related components across the application and test projects to version 13.0.164.

- **Tests**
  - Added coverage for concurrent dimension validation scenarios to help prevent cross-operation result mixing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->