### PR TITLE
Fixes #2519 Add a --cores option to MoBi.CLI

### DIFF
--- a/src/MoBi.CLI/Commands/CLICommand.cs
+++ b/src/MoBi.CLI/Commands/CLICommand.cs
@@ -1,7 +1,9 @@
-﻿using System.Text;
+using System;
+using System.Text;
 using CommandLine;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
+using MoBi.Core;
 
 namespace MoBi.CLI.Commands
 {
@@ -17,9 +19,22 @@ namespace MoBi.CLI.Commands
       [Option("logLevel", Required = false, HelpText = "Optional. Log verbosity (Debug, Information, Warning, Error). Default is Information.")]
       public LogLevel LogLevel { get; set; } = LogLevel.Information;
 
+      [Option("cores", Required = false, HelpText = "Optional. Maximum number of cores (1 or more) to use for parallel work such as model construction and simulation runs. Default is the number of processors minus one.")]
+      public int? NumberOfCores { get; set; }
+
+      //parallelism gets exactly one owner per level: a caller managing process-level fan-out
+      //(e.g. the QualificationRunner) passes --cores 1 so this process does not multiply it
+      public void ApplyCoresTo(ICoreUserSettings userSettings)
+      {
+         if (NumberOfCores.HasValue)
+            userSettings.MaximumNumberOfCoresToUse = Math.Max(1, NumberOfCores.Value);
+      }
+
       protected virtual void LogDefaultOptions(StringBuilder sb)
       {
          sb.AppendLine($"Log level: {LogLevel}");
+         if (NumberOfCores.HasValue)
+            sb.AppendLine($"Number of cores: {NumberOfCores.Value}");
       }
    }
 

--- a/src/MoBi.CLI/Program.cs
+++ b/src/MoBi.CLI/Program.cs
@@ -43,6 +43,7 @@ namespace MoBi.CLI
       private static void startCommand<TRunOptions>(CLICommand<TRunOptions> command) where TRunOptions : IProvidePKSimPath
       {
          ApplicationStartup.Start();
+         command.ApplyCoresTo(IoC.Resolve<ICoreUserSettings>());
          var runOptions = command.ToRunOptions();
 
          if (!string.IsNullOrEmpty(runOptions.PKSimPath))

--- a/tests/MoBi.Tests/CLI/CLICommandSpecs.cs
+++ b/tests/MoBi.Tests/CLI/CLICommandSpecs.cs
@@ -1,0 +1,81 @@
+using CommandLine;
+using MoBi.CLI.Commands;
+using MoBi.CLI.Core.MinimalImplementations;
+using OSPSuite.BDDHelper;
+using OSPSuite.BDDHelper.Extensions;
+
+namespace MoBi.CLI
+{
+   public class TestCommand : CLICommand<object>
+   {
+      public override string Name => "Test";
+      public override object ToRunOptions() => new object();
+   }
+
+   public abstract class concern_for_CLICommand : ContextSpecification<TestCommand>
+   {
+      protected CoreUserSettings _userSettings;
+      protected int _defaultNumberOfCores;
+
+      protected override void Context()
+      {
+         _userSettings = new CoreUserSettings();
+         _defaultNumberOfCores = _userSettings.MaximumNumberOfCoresToUse;
+      }
+
+      protected static TestCommand Parse(params string[] args)
+      {
+         TestCommand command = null;
+         Parser.Default.ParseArguments<TestCommand>(args).WithParsed(x => command = x);
+         command.ShouldNotBeNull();
+         return command;
+      }
+   }
+
+   public class When_parsing_a_command_with_the_cores_option : concern_for_CLICommand
+   {
+      protected override void Because()
+      {
+         sut = Parse("--cores", "3");
+         sut.ApplyCoresTo(_userSettings);
+      }
+
+      [Observation]
+      public void should_use_the_given_number_of_cores()
+      {
+         _userSettings.MaximumNumberOfCoresToUse.ShouldBeEqualTo(3);
+      }
+   }
+
+   public class When_parsing_a_command_without_the_cores_option : concern_for_CLICommand
+   {
+      protected override void Because()
+      {
+         sut = Parse();
+         sut.ApplyCoresTo(_userSettings);
+      }
+
+      //a standalone CLI invocation owns the whole machine by default
+      [Observation]
+      public void should_keep_the_default_number_of_cores()
+      {
+         sut.NumberOfCores.HasValue.ShouldBeFalse();
+         _userSettings.MaximumNumberOfCoresToUse.ShouldBeEqualTo(_defaultNumberOfCores);
+      }
+   }
+
+   public class When_parsing_a_command_with_a_cores_option_below_one : concern_for_CLICommand
+   {
+      protected override void Because()
+      {
+         sut = Parse("--cores", "0");
+         sut.ApplyCoresTo(_userSettings);
+      }
+
+      [Observation]
+      public void should_use_at_least_one_core()
+      {
+         _userSettings.MaximumNumberOfCoresToUse.ShouldBeEqualTo(1);
+      }
+   }
+}

--- a/tests/MoBi.Tests/MoBi.Tests.csproj
+++ b/tests/MoBi.Tests/MoBi.Tests.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\MoBi.CLI\MoBi.CLI.csproj" />
     <ProjectReference Include="..\..\src\MoBi.CLI.Core\MoBi.CLI.Core.csproj" />
     <ProjectReference Include="..\..\src\MoBi.Core\MoBi.Core.csproj" />
     <ProjectReference Include="..\..\src\MoBi.Engine\MoBi.Engine.csproj" />


### PR DESCRIPTION
Fixes #2519

Adds a `--cores <n>` option to the shared `CLICommand` base so every MoBi.CLI verb accepts it. When provided, `ICoreUserSettings.MaximumNumberOfCoresToUse` is set right after container initialization and before the runner resolves (clamped to at least 1); when absent, the `ProcessorCount - 1` default is untouched, so standalone CLI use keeps full parallelism.

Per the agreed design, parallelism gets exactly one owner per level: the QualificationRunner will pass `--cores 1` to each spawned child (Open-Systems-Pharmacology/QualificationRunner#189) so process fan-out and in-process workers do not multiply.

Specs parse through the real `CommandLine.Parser`: `--cores 3` is applied, an absent option keeps the default, and `--cores 0` clamps to one core.

Companion: Open-Systems-Pharmacology/PK-Sim#3724 (PK-Sim side of the same option). The `MoBi.R` setter noted in the issue stays a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--cores` command-line option to control the maximum number of processor cores used.
  * Values below one are automatically adjusted to use at least one core.
  * The selected core count is displayed in startup option logging when provided.

* **Bug Fixes**
  * Ensured the configured core limit is applied when the application starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->