### PR TITLE
Create multiple simulations in parallel from MoBi.R

### DIFF
--- a/src/MoBi.R/Domain/SimulationRequest.cs
+++ b/src/MoBi.R/Domain/SimulationRequest.cs
@@ -12,6 +12,7 @@ namespace MoBi.R.Domain
       private readonly List<ExpressionProfileBuildingBlock> _expressionProfiles = new();
       private readonly Cache<(string moleculeName, string category), string> _moleculeCalculationMethodOverrides = new();
 
+      public string SimulationName { get; set; }
       public SimulationSettings SimulationSettings { get; set; }
       public bool CreateAllProcessRateParameters { get; set; }
       public IndividualBuildingBlock Individual { get; private set; }

--- a/src/MoBi.R/Services/SimulationTask.cs
+++ b/src/MoBi.R/Services/SimulationTask.cs
@@ -17,7 +17,8 @@ namespace MoBi.R.Services
    {
       /// <summary>
       ///    Creates and validates one simulation per request, named after <see cref="SimulationRequest.SimulationName" />.
-      ///    The results are returned in the request order.
+      ///    The results are returned in the request order. A request that cannot be created reports its errors in its
+      ///    result.
       /// </summary>
       SimulationCreationResult[] CreateSimulationsAndValidateFrom(params SimulationRequest[] requests);
 
@@ -85,7 +86,7 @@ namespace MoBi.R.Services
 
          var results = new SimulationCreationResult[requests.Length];
 
-         SimulationCreationResult createAt(int index)
+         bool createAt(int index)
          {
             try
             {
@@ -96,7 +97,7 @@ namespace MoBi.R.Services
                results[index] = new SimulationCreationResult(null, Enumerable.Empty<string>(), new[] { e.Message });
             }
 
-            return results[index];
+            return results[index].Simulation != null;
          }
 
          //simulations are created sequentially until one succeeds, so that lazily initialized services are
@@ -104,9 +105,9 @@ namespace MoBi.R.Services
          var warmupCount = 0;
          while (warmupCount < requests.Length)
          {
-            var result = createAt(warmupCount);
+            var success = createAt(warmupCount);
             warmupCount++;
-            if (result.Simulation != null)
+            if (success)
                break;
          }
 

--- a/src/MoBi.R/Services/SimulationTask.cs
+++ b/src/MoBi.R/Services/SimulationTask.cs
@@ -17,7 +17,7 @@ namespace MoBi.R.Services
    {
       /// <summary>
       ///    Creates and validates one simulation per request, named after <see cref="SimulationRequest.SimulationName" />.
-      ///    The simulations are created in parallel and the results are returned in the request order.
+      ///    The results are returned in the request order.
       /// </summary>
       SimulationCreationResult[] CreateSimulationsAndValidateFrom(params SimulationRequest[] requests);
 

--- a/src/MoBi.R/Services/SimulationTask.cs
+++ b/src/MoBi.R/Services/SimulationTask.cs
@@ -16,13 +16,8 @@ namespace MoBi.R.Services
    public interface ISimulationTask
    {
       /// <summary>
-      ///    Creates and validates a simulation named after <see cref="SimulationRequest.SimulationName" />.
-      /// </summary>
-      SimulationCreationResult CreateSimulationAndValidateFrom(SimulationRequest request);
-
-      /// <summary>
-      ///    Creates and validates one simulation per request. The simulations are created in parallel and the results are
-      ///    returned in the request order.
+      ///    Creates and validates one simulation per request, named after <see cref="SimulationRequest.SimulationName" />.
+      ///    The simulations are created in parallel and the results are returned in the request order.
       /// </summary>
       SimulationCreationResult[] CreateSimulationsAndValidateFrom(params SimulationRequest[] requests);
 
@@ -66,7 +61,7 @@ namespace MoBi.R.Services
          return allNamedObjects.FindByName(namedObjectToSelect);
       }
 
-      public SimulationCreationResult CreateSimulationAndValidateFrom(SimulationRequest request)
+      private SimulationCreationResult createSimulationAndValidateFrom(SimulationRequest request)
       {
          if (request == null)
             throw new InvalidArgumentException(AppConstants.Exceptions.SimulationRequestCannotBeNull);
@@ -94,7 +89,7 @@ namespace MoBi.R.Services
          {
             try
             {
-               results[index] = CreateSimulationAndValidateFrom(requests[index]);
+               results[index] = createSimulationAndValidateFrom(requests[index]);
             }
             catch (Exception e) when (!e.IsOutOfMemory())
             {

--- a/src/MoBi.R/Services/SimulationTask.cs
+++ b/src/MoBi.R/Services/SimulationTask.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using MoBi.Assets;
 using MoBi.R.Domain;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 using OSPSuite.Core.Domain.Services;
 using OSPSuite.Core.Extensions;
+using ICoreUserSettings = MoBi.Core.ICoreUserSettings;
 using ModuleConfiguration = MoBi.R.Domain.ModuleConfiguration;
 
 namespace MoBi.R.Services
@@ -14,6 +16,12 @@ namespace MoBi.R.Services
    public interface ISimulationTask
    {
       SimulationCreationResult CreateSimulationAndValidateFrom(string simulationName, SimulationRequest request);
+
+      /// <summary>
+      ///    Creates and validates one simulation per request, named after <see cref="SimulationRequest.SimulationName" />.
+      ///    The simulations are created in parallel and the results are returned in the request order.
+      /// </summary>
+      SimulationCreationResult[] CreateSimulationsAndValidateFrom(params SimulationRequest[] requests);
 
       ModuleConfiguration CreateModuleConfiguration(Module module,
          string selectedParameterValues = null,
@@ -24,11 +32,13 @@ namespace MoBi.R.Services
    {
       private readonly ISimulationFactory _simulationFactory;
       private readonly IObjectTypeResolver _objectTypeResolver;
+      private readonly ICoreUserSettings _userSettings;
 
-      public SimulationTask(ISimulationFactory simulationFactory, IObjectTypeResolver objectTypeResolver)
+      public SimulationTask(ISimulationFactory simulationFactory, IObjectTypeResolver objectTypeResolver, ICoreUserSettings userSettings)
       {
          _simulationFactory = simulationFactory;
          _objectTypeResolver = objectTypeResolver;
+         _userSettings = userSettings;
       }
 
       public ModuleConfiguration CreateModuleConfiguration(Module module,
@@ -69,5 +79,48 @@ namespace MoBi.R.Services
             request.CreateAllProcessRateParameters,
             request.SimulationSettings);
       }
+
+      public SimulationCreationResult[] CreateSimulationsAndValidateFrom(params SimulationRequest[] requests)
+      {
+         if (requests == null)
+            throw new InvalidArgumentException(AppConstants.Exceptions.SimulationRequestCannotBeNull);
+
+         var results = new SimulationCreationResult[requests.Length];
+
+         SimulationCreationResult createAt(int index)
+         {
+            try
+            {
+               results[index] = CreateSimulationAndValidateFrom(requests[index]?.SimulationName, requests[index]);
+            }
+            catch (Exception e) when (!e.IsOutOfMemory())
+            {
+               results[index] = new SimulationCreationResult(null, Enumerable.Empty<string>(), new[] { e.Message });
+            }
+
+            return results[index];
+         }
+
+         //simulations are created sequentially until one succeeds, so that lazily initialized services are
+         //warmed up before the remaining simulations are created in parallel
+         var warmupCount = 0;
+         while (warmupCount < requests.Length)
+         {
+            var result = createAt(warmupCount);
+            warmupCount++;
+            if (result.Simulation != null)
+               break;
+         }
+
+         if (requests.Length > warmupCount)
+            Parallel.For(warmupCount, requests.Length, parallelOptions(), index => createAt(index));
+
+         return results;
+      }
+
+      private ParallelOptions parallelOptions() => new ParallelOptions
+      {
+         MaxDegreeOfParallelism = Math.Max(1, _userSettings.MaximumNumberOfCoresToUse)
+      };
    }
 }

--- a/src/MoBi.R/Services/SimulationTask.cs
+++ b/src/MoBi.R/Services/SimulationTask.cs
@@ -15,11 +15,14 @@ namespace MoBi.R.Services
 {
    public interface ISimulationTask
    {
-      SimulationCreationResult CreateSimulationAndValidateFrom(string simulationName, SimulationRequest request);
+      /// <summary>
+      ///    Creates and validates a simulation named after <see cref="SimulationRequest.SimulationName" />.
+      /// </summary>
+      SimulationCreationResult CreateSimulationAndValidateFrom(SimulationRequest request);
 
       /// <summary>
-      ///    Creates and validates one simulation per request, named after <see cref="SimulationRequest.SimulationName" />.
-      ///    The simulations are created in parallel and the results are returned in the request order.
+      ///    Creates and validates one simulation per request. The simulations are created in parallel and the results are
+      ///    returned in the request order.
       /// </summary>
       SimulationCreationResult[] CreateSimulationsAndValidateFrom(params SimulationRequest[] requests);
 
@@ -63,7 +66,7 @@ namespace MoBi.R.Services
          return allNamedObjects.FindByName(namedObjectToSelect);
       }
 
-      public SimulationCreationResult CreateSimulationAndValidateFrom(string simulationName, SimulationRequest request)
+      public SimulationCreationResult CreateSimulationAndValidateFrom(SimulationRequest request)
       {
          if (request == null)
             throw new InvalidArgumentException(AppConstants.Exceptions.SimulationRequestCannotBeNull);
@@ -71,7 +74,7 @@ namespace MoBi.R.Services
          var modulesArray = request?.ModuleConfigurations?.ToArray() ?? Array.Empty<ModuleConfiguration>();
          var expressionsArray = request?.ExpressionProfiles?.ToArray() ?? Array.Empty<ExpressionProfileBuildingBlock>();
 
-         return _simulationFactory.CreateSimulationFrom(simulationName,
+         return _simulationFactory.CreateSimulationFrom(request.SimulationName,
             modulesArray,
             expressionsArray,
             request.Individual,
@@ -91,7 +94,7 @@ namespace MoBi.R.Services
          {
             try
             {
-               results[index] = CreateSimulationAndValidateFrom(requests[index]?.SimulationName, requests[index]);
+               results[index] = CreateSimulationAndValidateFrom(requests[index]);
             }
             catch (Exception e) when (!e.IsOutOfMemory())
             {

--- a/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
+++ b/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
@@ -8,6 +8,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Utility.Extensions;
 using static MoBi.R.Tests.HelperForSpecs;
 using IProjectTask = MoBi.R.Services.IProjectTask;
 using ModuleConfiguration = MoBi.R.Domain.ModuleConfiguration;
@@ -82,6 +83,99 @@ internal class when_creating_simulation : when_creating_from_mobi_project
       var module = _creationResult.Simulation.Configuration.ModuleConfigurations
          .FirstOrDefault(x => x.Module.Name == "Module1")?.Module;
       module.ShouldNotBeNull();
+   }
+}
+
+internal abstract class when_creating_multiple_simulations_from_requests : when_creating_from_mobi_project
+{
+   protected SimulationCreationResult[] _results;
+   protected string[] _simulationNames;
+   protected SimulationRequest[] _requests;
+
+   protected override void Context()
+   {
+      base.Context();
+      _requests = _simulationNames.Select(createRequest).ToArray();
+   }
+
+   protected override void Because()
+   {
+      _results = sut.CreateSimulationsAndValidateFrom(_requests);
+   }
+
+   private SimulationRequest createRequest(string simulationName)
+   {
+      var request = new SimulationRequest { SimulationName = simulationName };
+      request.AddModuleConfiguration(_moduleConfiguration);
+      (_expressionProfilesForSimulation ?? Array.Empty<ExpressionProfileBuildingBlock>()).Each(request.AddExpressionProfile);
+      request.SetIndividual(_individualForSimulation);
+      return request;
+   }
+}
+
+internal class when_creating_multiple_simulations : when_creating_multiple_simulations_from_requests
+{
+   protected override void Context()
+   {
+      _simulationNames = new[] { "ParallelSim1", "ParallelSim2", "ParallelSim3", "ParallelSim4" };
+      base.Context();
+   }
+
+   [Observation]
+   public void should_return_one_result_per_request_in_the_request_order()
+   {
+      _results.Length.ShouldBeEqualTo(_simulationNames.Length);
+      _results.Select(x => x.Simulation.Name).ToArray().ShouldBeEqualTo(_simulationNames);
+   }
+
+   [Observation]
+   public void should_create_all_simulations_from_the_shared_module()
+   {
+      _results.Each(result =>
+      {
+         result.Simulation.ShouldNotBeNull();
+         result.Simulation.Configuration.ModuleConfigurations
+            .FirstOrDefault(x => x.Module.Name == "Module1")?.Module.ShouldNotBeNull();
+      });
+   }
+}
+
+internal class when_creating_multiple_simulations_and_one_cannot_be_created : when_creating_multiple_simulations_from_requests
+{
+   protected override void Context()
+   {
+      _simulationNames = new[] { "ParallelSim1", $"Invalid{Constants.ILLEGAL_CHARACTERS.First()}Name", "ParallelSim3" };
+      base.Context();
+   }
+
+   [Observation]
+   public void should_return_the_errors_for_the_failing_simulation()
+   {
+      _results[1].Simulation.ShouldBeNull();
+      _results[1].Errors.Any().ShouldBeTrue();
+   }
+
+   [Observation]
+   public void should_create_the_other_simulations_in_the_request_order()
+   {
+      _results[0].Simulation.Name.ShouldBeEqualTo(_simulationNames[0]);
+      _results[2].Simulation.Name.ShouldBeEqualTo(_simulationNames[2]);
+   }
+}
+
+internal class when_creating_multiple_simulations_without_requests : when_creating_from_mobi_project
+{
+   [Observation]
+   public void should_throw_expected_exception_when_the_requests_are_null()
+   {
+      The.Action(() => sut.CreateSimulationsAndValidateFrom(null))
+         .ShouldThrowAn<InvalidArgumentException>();
+   }
+
+   [Observation]
+   public void should_return_no_results_when_there_are_no_requests()
+   {
+      sut.CreateSimulationsAndValidateFrom().ShouldBeEmpty();
    }
 }
 

--- a/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
+++ b/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
@@ -66,7 +66,7 @@ internal class when_creating_simulation : when_creating_from_mobi_project
 {
    protected override void Because()
    {
-      _creationResult = sut.CreateSimulationAndValidateFrom(_request);
+      _creationResult = sut.CreateSimulationsAndValidateFrom(_request).Single();
    }
 
    [Observation]
@@ -179,16 +179,6 @@ internal class when_creating_multiple_simulations_without_requests : when_creati
    }
 }
 
-internal abstract class when_creating_an_invalid_configuration : when_creating_from_mobi_project
-{
-   [Observation]
-   public void should_throw_expected_exception()
-   {
-      The.Action(() => sut.CreateSimulationAndValidateFrom(_request))
-         .ShouldThrowAn<InvalidOperationException>();
-   }
-}
-
 internal class when_creating_simulation_from_pkml_module : concern_for_SimulationTask
 {
    private SimulationCreationResult _creationResult;
@@ -206,7 +196,7 @@ internal class when_creating_simulation_from_pkml_module : concern_for_Simulatio
 
    protected override void Because()
    {
-      _creationResult = sut.CreateSimulationAndValidateFrom(_request);
+      _creationResult = sut.CreateSimulationsAndValidateFrom(_request).Single();
    }
 
    [Observation]
@@ -238,7 +228,7 @@ internal class when_creating_simulation_with_warnings_only : concern_for_Simulat
 
    protected override void Because()
    {
-      _creationResult = sut.CreateSimulationAndValidateFrom(_request);
+      _creationResult = sut.CreateSimulationsAndValidateFrom(_request).Single();
    }
 
    [Observation]
@@ -270,10 +260,11 @@ internal class when_creating_simulation_with_errors : concern_for_SimulationTask
    }
 
    [Observation]
-   public void should_throw_expected_exception()
+   public void should_return_the_errors_instead_of_a_simulation()
    {
-      The.Action(() => sut.CreateSimulationAndValidateFrom(_request))
-         .ShouldThrowAn<InvalidOperationException>();
+      var result = sut.CreateSimulationsAndValidateFrom(_request).Single();
+      result.Simulation.ShouldBeNull();
+      result.Errors.Any().ShouldBeTrue();
    }
 }
 
@@ -298,7 +289,7 @@ internal class when_creating_simulation_with_create_all_process_rate_parameters_
 
    protected override void Because()
    {
-      _creationResult = sut.CreateSimulationAndValidateFrom(_request);
+      _creationResult = sut.CreateSimulationsAndValidateFrom(_request).Single();
    }
 
    [Observation]
@@ -334,7 +325,7 @@ internal class when_creating_simulation_with_custom_simulation_settings : concer
 
    protected override void Because()
    {
-      _creationResult = sut.CreateSimulationAndValidateFrom(_request);
+      _creationResult = sut.CreateSimulationsAndValidateFrom(_request).Single();
    }
 
    [Observation]
@@ -377,7 +368,7 @@ internal class when_creating_simulation_with_calculation_method_override : conce
 
    protected override void Because()
    {
-      _creationResult = sut.CreateSimulationAndValidateFrom(_request);
+      _creationResult = sut.CreateSimulationsAndValidateFrom(_request).Single();
    }
 
    [Observation]

--- a/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
+++ b/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using FakeItEasy;
+using MoBi.Assets;
+using MoBi.CLI.Core.MinimalImplementations;
 using MoBi.Core.Domain.Model;
 using MoBi.R.Domain;
 using MoBi.R.Services;
@@ -8,6 +11,7 @@ using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
+using OSPSuite.Core.Domain.Services;
 using OSPSuite.Utility.Extensions;
 using static MoBi.R.Tests.HelperForSpecs;
 using IProjectTask = MoBi.R.Services.IProjectTask;
@@ -134,8 +138,9 @@ internal class when_creating_multiple_simulations : when_creating_multiple_simul
       _results.Each(result =>
       {
          result.Simulation.ShouldNotBeNull();
-         result.Simulation.Configuration.ModuleConfigurations
-            .FirstOrDefault(x => x.Module.Name == "Module1")?.Module.ShouldNotBeNull();
+         var moduleConfiguration = result.Simulation.Configuration.ModuleConfigurations
+            .FirstOrDefault(x => x.Module.Name == "Module1");
+         moduleConfiguration.ShouldNotBeNull();
       });
    }
 }
@@ -160,6 +165,69 @@ internal class when_creating_multiple_simulations_and_one_cannot_be_created : wh
    {
       _results[0].Simulation.Name.ShouldBeEqualTo(_simulationNames[0]);
       _results[2].Simulation.Name.ShouldBeEqualTo(_simulationNames[2]);
+   }
+}
+
+internal class when_creating_a_simulation_without_a_name : when_creating_from_mobi_project
+{
+   private SimulationCreationResult _result;
+
+   protected override void Context()
+   {
+      base.Context();
+      _request.SimulationName = null;
+   }
+
+   protected override void Because()
+   {
+      _result = sut.CreateSimulationsAndValidateFrom(_request).Single();
+   }
+
+   [Observation]
+   public void should_return_the_errors_instead_of_a_simulation()
+   {
+      _result.Simulation.ShouldBeNull();
+      _result.Errors.ShouldContain(AppConstants.Exceptions.SimulationNameIsRequired);
+   }
+}
+
+internal class when_creating_multiple_simulations_with_a_null_request : when_creating_from_mobi_project
+{
+   private SimulationCreationResult[] _results;
+
+   protected override void Because()
+   {
+      _results = sut.CreateSimulationsAndValidateFrom(_request, null);
+   }
+
+   [Observation]
+   public void should_return_the_errors_for_the_null_request()
+   {
+      _results[1].Simulation.ShouldBeNull();
+      _results[1].Errors.ShouldContain(AppConstants.Exceptions.SimulationRequestCannotBeNull);
+   }
+
+   [Observation]
+   public void should_create_the_other_simulation()
+   {
+      _results[0].Simulation.ShouldNotBeNull();
+   }
+}
+
+internal class when_a_simulation_creation_runs_out_of_memory : ContextSpecification<ISimulationTask>
+{
+   protected override void Context()
+   {
+      var simulationFactory = A.Fake<ISimulationFactory>();
+      A.CallTo(simulationFactory).Throws(new OutOfMemoryException());
+      sut = new SimulationTask(simulationFactory, A.Fake<IObjectTypeResolver>(), new CoreUserSettings());
+   }
+
+   [Observation]
+   public void should_let_the_out_of_memory_escape()
+   {
+      The.Action(() => sut.CreateSimulationsAndValidateFrom(new SimulationRequest { SimulationName = "Sim" }))
+         .ShouldThrowAn<OutOfMemoryException>();
    }
 }
 

--- a/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
+++ b/tests/MoBi.R.Tests/Services/SimulationTaskSpecs.cs
@@ -52,7 +52,7 @@ internal class when_creating_from_mobi_project : concern_for_SimulationTask
 
       _moduleConfiguration = sut.CreateModuleConfiguration(_moduleForSimulation, "Parameter Values", "Initial Conditions");
 
-      _request = new SimulationRequest();
+      _request = new SimulationRequest { SimulationName = _simulationName };
       _request.AddModuleConfiguration(_moduleConfiguration);
       foreach (var ep in _expressionProfilesForSimulation ?? Array.Empty<ExpressionProfileBuildingBlock>())
          _request.AddExpressionProfile(ep);
@@ -66,7 +66,7 @@ internal class when_creating_simulation : when_creating_from_mobi_project
 {
    protected override void Because()
    {
-      _creationResult = sut.CreateSimulationAndValidateFrom(_simulationName, _request);
+      _creationResult = sut.CreateSimulationAndValidateFrom(_request);
    }
 
    [Observation]
@@ -184,7 +184,7 @@ internal abstract class when_creating_an_invalid_configuration : when_creating_f
    [Observation]
    public void should_throw_expected_exception()
    {
-      The.Action(() => sut.CreateSimulationAndValidateFrom(_simulationName, _request))
+      The.Action(() => sut.CreateSimulationAndValidateFrom(_request))
          .ShouldThrowAn<InvalidOperationException>();
    }
 }
@@ -200,13 +200,13 @@ internal class when_creating_simulation_from_pkml_module : concern_for_Simulatio
       _simulationName = "SimFromPKML";
       var moduleConfig = sut.CreateModuleConfiguration(module);
 
-      _request = new SimulationRequest();
+      _request = new SimulationRequest { SimulationName = _simulationName };
       _request.AddModuleConfiguration(moduleConfig);
    }
 
    protected override void Because()
    {
-      _creationResult = sut.CreateSimulationAndValidateFrom(_simulationName, _request);
+      _creationResult = sut.CreateSimulationAndValidateFrom(_request);
    }
 
    [Observation]
@@ -229,7 +229,7 @@ internal class when_creating_simulation_with_warnings_only : concern_for_Simulat
       _simulationName = "SimWithWarningsOnly";
       var moduleConfig = sut.CreateModuleConfiguration(_moduleForSimulation, "Parameter Values", "Initial Conditions");
 
-      _request = new SimulationRequest();
+      _request = new SimulationRequest { SimulationName = _simulationName };
       _request.AddModuleConfiguration(moduleConfig);
       _request.SetIndividual(_projectTask.IndividualBuildingBlockByName(_project, "European (P-gp modified, CYP3A4 36 h)"));
 
@@ -238,7 +238,7 @@ internal class when_creating_simulation_with_warnings_only : concern_for_Simulat
 
    protected override void Because()
    {
-      _creationResult = sut.CreateSimulationAndValidateFrom(_simulationName, _request);
+      _creationResult = sut.CreateSimulationAndValidateFrom(_request);
    }
 
    [Observation]
@@ -262,7 +262,7 @@ internal class when_creating_simulation_with_errors : concern_for_SimulationTask
       var module = _projectTask.ModuleByName(_project, "Module1");
       var moduleConfig = sut.CreateModuleConfiguration(module);
 
-      _request = new SimulationRequest();
+      _request = new SimulationRequest { SimulationName = _simulationName };
       _request.AddModuleConfiguration(moduleConfig);
       _request.SetIndividual(_projectTask.IndividualBuildingBlockByName(_project, "European (P-gp modified, CYP3A4 36 h)"));
 
@@ -272,7 +272,7 @@ internal class when_creating_simulation_with_errors : concern_for_SimulationTask
    [Observation]
    public void should_throw_expected_exception()
    {
-      The.Action(() => sut.CreateSimulationAndValidateFrom(_simulationName, _request))
+      The.Action(() => sut.CreateSimulationAndValidateFrom(_request))
          .ShouldThrowAn<InvalidOperationException>();
    }
 }
@@ -288,7 +288,7 @@ internal class when_creating_simulation_with_create_all_process_rate_parameters_
       _moduleForSimulation = _projectTask.ModuleByName(_project, "Module1");
       var moduleConfig = sut.CreateModuleConfiguration(_moduleForSimulation, "Parameter Values", "Initial Conditions");
 
-      _request = new SimulationRequest();
+      _request = new SimulationRequest { SimulationName = _simulationName };
       _request.AddModuleConfiguration(moduleConfig);
       _request.SetIndividual(_projectTask.IndividualBuildingBlockByName(_project, "European (P-gp modified, CYP3A4 36 h)"));
       _request.CreateAllProcessRateParameters = true;
@@ -298,7 +298,7 @@ internal class when_creating_simulation_with_create_all_process_rate_parameters_
 
    protected override void Because()
    {
-      _creationResult = sut.CreateSimulationAndValidateFrom(_simulationName, _request);
+      _creationResult = sut.CreateSimulationAndValidateFrom(_request);
    }
 
    [Observation]
@@ -324,7 +324,7 @@ internal class when_creating_simulation_with_custom_simulation_settings : concer
       var customSettings = new SimulationSettings();
       customSettings.Name = "CustomSettings";
 
-      _request = new SimulationRequest();
+      _request = new SimulationRequest { SimulationName = _simulationName };
       _request.AddModuleConfiguration(moduleConfig);
       _request.SetIndividual(_projectTask.IndividualBuildingBlockByName(_project, "European (P-gp modified, CYP3A4 36 h)"));
       _request.SimulationSettings = customSettings;
@@ -334,7 +334,7 @@ internal class when_creating_simulation_with_custom_simulation_settings : concer
 
    protected override void Because()
    {
-      _creationResult = sut.CreateSimulationAndValidateFrom(_simulationName, _request);
+      _creationResult = sut.CreateSimulationAndValidateFrom(_request);
    }
 
    [Observation]
@@ -367,7 +367,7 @@ internal class when_creating_simulation_with_calculation_method_override : conce
       
       var moduleConfiguration = sut.CreateModuleConfiguration(_moduleForSimulation, "Parameter Values", "Initial Conditions");
 
-      _request = new SimulationRequest();
+      _request = new SimulationRequest { SimulationName = _simulationName };
       _request.AddModuleConfiguration(moduleConfiguration);
       _request.SetIndividual(_projectTask.IndividualBuildingBlockByName(_project, "European (P-gp modified, CYP3A4 36 h)"));
       _request.AddMoleculeUsedCalculationMethod("Molecule name", _category, _overriddenCalculationMethod);
@@ -377,7 +377,7 @@ internal class when_creating_simulation_with_calculation_method_override : conce
 
    protected override void Because()
    {
-      _creationResult = sut.CreateSimulationAndValidateFrom(_simulationName, _request);
+      _creationResult = sut.CreateSimulationAndValidateFrom(_request);
    }
 
    [Observation]


### PR DESCRIPTION
Fixes #2516

`SimulationTask` now creates multiple simulations from `SimulationRequest`s in parallel, mirroring the parallel snapshot load from #2520/#2524.

### What changes

- `ISimulationTask` exposes a single `CreateSimulationsAndValidateFrom(params SimulationRequest[] requests)` returning one `SimulationCreationResult` per request in the request order. The former single-request method is folded into it as the private per-request step, following the plural-only shape of the other R-facing services (`RunSimulations`, `ImportResultsFromCSV`).
- Each request carries its name in the new `SimulationRequest.SimulationName` — the name only names the created simulation and the model root container, so it belongs on the request. The batch is then one trailing `params` array, the calling convention rSharp already binds for `SimulationRunner.RunSimulations`, working for any batch size including one. The R wrapper sets the property and splats the requests via `do.call`, as `runSimulations` does.
- The batch mirrors the hardened snapshot-load pattern: requests are created sequentially until the first success so lazily initialized services are warm, the rest are constructed in parallel bounded by `MaximumNumberOfCoresToUse`, and a request that cannot be created reports its errors in its result instead of failing the batch. Out-of-memory still propagates; a null requests array throws.

### Tests

- Four requests sharing one module are created in parallel with names and order preserved.
- A middle request with an illegal name fails into its result's `Errors` during the parallel phase while its neighbors succeed.
- A null requests array throws and an empty one returns no results; the single-request fixtures now run through the batch API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and validating multiple simulations in a single operation.
  * Simulation names can now be provided with each simulation request.
  * Results are returned in the same order as the submitted requests.
  * Individual simulation errors are reported in results, allowing other simulations to continue processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->