### PR TITLE
Fixes #825 Apply the molecule's molecular weight to imported observed data

### DIFF
--- a/src/MoBi.Presentation/Tasks/ObservedDataTask.cs
+++ b/src/MoBi.Presentation/Tasks/ObservedDataTask.cs
@@ -360,7 +360,18 @@ namespace MoBi.Presentation.Tasks
             return;
 
          metaDataCategory.ShouldListOfValuesBeIncluded = true;
-         allMolecules().OrderBy(molecule => molecule.Name).Each(molecule => addInfoToCategory(metaDataCategory, molecule));
+         allMolecules().OrderBy(molecule => molecule.Name)
+            .Each(molecule => addInfoToCategory(metaDataCategory, molecule, molWeightInDefaultUnitFor(molecule)));
+      }
+
+      private static string molWeightInDefaultUnitFor(IContainer molecule)
+      {
+         var molWeightParameter = molecule.Parameter(Parameters.MOL_WEIGHT);
+         if (molWeightParameter == null || double.IsNaN(molWeightParameter.Value))
+            return string.Empty;
+
+         var dimension = molWeightParameter.Dimension;
+         return dimension.BaseUnitValueToUnitValue(dimension.DefaultUnit, molWeightParameter.Value).ToString();
       }
 
       private IEnumerable<IContainer> allMolecules()
@@ -451,9 +462,9 @@ namespace MoBi.Presentation.Tasks
          }
       }
 
-      private void addInfoToCategory(MetaDataCategory metaDataCategory, IContainer container)
+      private void addInfoToCategory(MetaDataCategory metaDataCategory, IContainer container, string displayValue = null)
       {
-         metaDataCategory.ListOfValues.Add(container.Name, container.Name);
+         metaDataCategory.ListOfValues.Add(container.Name, displayValue ?? container.Name);
 
          var icon = ApplicationIcons.IconByName(container.Icon);
          if (icon != ApplicationIcons.EmptyIcon)
@@ -478,7 +489,7 @@ namespace MoBi.Presentation.Tasks
       {
          var category = new MetaDataCategory();
          action(category);
-         return category.ListOfValues.Values;
+         return category.ListOfValues.Keys;
       }
 
       public IReadOnlyList<string> DefaultMetaDataCategories => new[]

--- a/tests/MoBi.Tests/Presentation/Tasks/ObservedDataTasksSpecs.cs
+++ b/tests/MoBi.Tests/Presentation/Tasks/ObservedDataTasksSpecs.cs
@@ -22,6 +22,8 @@ using OSPSuite.Infrastructure.Import.Core;
 using OSPSuite.Infrastructure.Import.Services;
 using OSPSuite.Utility.Extensions;
 using ImporterConfiguration = OSPSuite.Core.Import.ImporterConfiguration;
+using MoleculeBuilder = OSPSuite.Core.Domain.Builder.MoleculeBuilder;
+using MoleculeBuildingBlock = OSPSuite.Core.Domain.Builder.MoleculeBuildingBlock;
 
 namespace MoBi.Presentation.Tasks
 {
@@ -37,7 +39,7 @@ namespace MoBi.Presentation.Tasks
       private IDataRepositoryExportTask _dataRepositoryTask;
       protected IContainerTask _containerTask;
       private IObjectTypeResolver _objectTypeResolver;
-      private IBuildingBlockRepository _buildingBlockRepository;
+      protected IBuildingBlockRepository _buildingBlockRepository;
       protected IObjectBaseNamingTask _namingTask;
       private IConfirmationManager _confirmationManager;
       protected IParameterIdentificationTask _parameterIdentificationTask;
@@ -534,5 +536,75 @@ namespace MoBi.Presentation.Tasks
          A.CallTo(() => _context.AddToHistory(A<RemoveHistoricResultFromSimulationCommand>.Ignored))
             .MustNotHaveHappened();
       }
+   }
+
+   public class When_providing_the_molecule_meta_data_category_to_the_importer : concern_for_ObservedDataTask
+   {
+      private IReadOnlyList<MetaDataCategory> _metaDataCategories;
+      private IDimension _molWeightDimension;
+
+      protected override void Context()
+      {
+         base.Context();
+
+         _molWeightDimension = new Dimension(new BaseDimensionRepresentation(), Constants.Dimension.MOLECULAR_WEIGHT, "kg/µmol");
+         _molWeightDimension.AddUnit(new Unit("g/mol", 1e-9, 0));
+         _molWeightDimension.DefaultUnit = _molWeightDimension.Unit("g/mol");
+
+         var moleculeBuildingBlock = new MoleculeBuildingBlock();
+         moleculeBuildingBlock.Add(moleculeWithMolWeight("ADC", 0.000148));
+         moleculeBuildingBlock.Add(moleculeWithMolWeight("FcRn", double.NaN));
+
+         A.CallTo(() => _buildingBlockRepository.MoleculeBlockCollection).Returns(new List<MoleculeBuildingBlock> { moleculeBuildingBlock });
+         A.CallTo(() => _dataImporter.DefaultMetaDataCategoriesForObservedData()).Returns(new[]
+         {
+            new MetaDataCategory { Name = Constants.ObservedData.MOLECULE }
+         });
+
+         A.CallTo(() => _dataImporter.ImportDataSets(A<IReadOnlyList<MetaDataCategory>>._, A<IReadOnlyList<ColumnInfo>>._, A<DataImporterSettings>._, A<string>._))
+            .Invokes(call => _metaDataCategories = call.GetArgument<IReadOnlyList<MetaDataCategory>>(0))
+            .Returns((null, null));
+      }
+
+      private MoleculeBuilder moleculeWithMolWeight(string name, double molWeightInBaseUnit)
+      {
+         var molecule = new MoleculeBuilder().WithName(name).WithDimension(Constants.Dimension.NO_DIMENSION);
+         molecule.Add(DomainHelperForSpecs.ConstantParameterWithValue(molWeightInBaseUnit)
+            .WithName(Constants.Parameters.MOL_WEIGHT)
+            .WithDimension(_molWeightDimension)
+            .WithValue(molWeightInBaseUnit));
+         return molecule;
+      }
+
+      protected override void Because()
+      {
+         sut.AddObservedDataToProject();
+      }
+
+      [Observation]
+      public void should_list_the_molecule_names_as_keys()
+      {
+         moleculeCategory().ListOfValues.Keys.ShouldOnlyContainInOrder("ADC", "FcRn");
+      }
+
+      [Observation]
+      public void should_provide_the_molecular_weight_of_the_molecule_in_g_per_mol()
+      {
+         double.Parse(moleculeCategory().ListOfValues["ADC"]).ShouldBeEqualTo(148000, 1e-5);
+      }
+
+      [Observation]
+      public void should_not_provide_a_molecular_weight_for_a_molecule_without_one()
+      {
+         moleculeCategory().ListOfValues["FcRn"].ShouldBeEmpty();
+      }
+
+      [Observation]
+      public void should_offer_the_molecule_names_as_predefined_meta_data_values()
+      {
+         sut.PredefinedValuesFor(Constants.ObservedData.MOLECULE).ShouldOnlyContainInOrder("ADC", "FcRn");
+      }
+
+      private MetaDataCategory moleculeCategory() => _metaDataCategories.First(x => x.Name == Constants.ObservedData.MOLECULE);
    }
 }


### PR DESCRIPTION
Fixes #825

Assigning a molecule in the observed data importer never transferred that molecule's molecular weight to the imported data set, so it had to be typed in by hand or carried as an extra column.

**Cause.** Core reads the MW from the *value* of the `Molecule` meta data category's `ListOfValues` and parses it as a number in g/mol. MoBi stored `name -> name` there, so the parse always failed and the MW was silently left unset. PK-Sim stores `name -> MolWeight` and works.

Not a recent regression: the lookup was added in 60e88cea0 and removed three days later in 3de65b346. `git tag --contains` returns the same tags for both commits, so no released version ever had it.

**Change.** Store the molecule's `Molecular weight` parameter converted into g/mol, which is the unit Core converts back from — the value reaches Core without a unit attached, so passing the display value through would send `148` for a 148 kDa antibody. Molecules with a `NaN` weight contribute an empty string and are skipped as before.

`predefinedValuesForCategory` now returns the list's keys rather than its values, otherwise the meta data editor's Molecule dropdown would start offering weights instead of molecule names.

Ambiguity when several modules define the same molecule name is out of scope here and tracked in #2530.

**Testing.** `MoBi.Tests` green (2735 passed, 0 failed). Four new observations cover the g/mol value, the `NaN` case, the dropdown keys and `PredefinedValuesFor`. Verified by hand in MoBi against an ADC project: `ADC` (148 kDa) yields 148000 g/mol, `nAb` yields 147220, and the small-molecule payload `Toxophore` yields 780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Observed-data import metadata now includes molecular weights for predefined molecules.
- Molecular weights are converted to each parameter’s default unit, including g/mol where applicable.
- Predefined molecule metadata is available for import selection and display.

## Bug Fixes

- Missing or invalid molecular-weight values now appear as blank instead of causing import issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->