### PR TITLE
Fixes #2531 Resolve initial conditions by path when inverting update commands

### DIFF
--- a/src/MoBi.Core/Commands/UpdateInitialConditionIsPresentCommand.cs
+++ b/src/MoBi.Core/Commands/UpdateInitialConditionIsPresentCommand.cs
@@ -2,20 +2,21 @@ using MoBi.Assets;
 using MoBi.Core.Domain.Model;
 using OSPSuite.Assets;
 using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 
 namespace MoBi.Core.Commands
 {
-   public class UpdateInitialConditionIsPresentCommand : BuildingBlockChangeCommandBase<IBuildingBlock<InitialCondition>>
+   public class UpdateInitialConditionIsPresentCommand : BuildingBlockChangeCommandBase<ILookupBuildingBlock<InitialCondition>>
    {
-      private readonly string _initialConditionId;
+      private readonly ObjectPath _initialConditionPath;
       private InitialCondition _initialCondition;
       private readonly bool _oldIsPresent;
       private readonly bool _newIsPresent;
 
-      public UpdateInitialConditionIsPresentCommand(IBuildingBlock<InitialCondition> initialConditionsBuildingBlock, InitialCondition initialCondition, bool isPresent) : base(initialConditionsBuildingBlock)
+      public UpdateInitialConditionIsPresentCommand(ILookupBuildingBlock<InitialCondition> initialConditionsBuildingBlock, InitialCondition initialCondition, bool isPresent) : base(initialConditionsBuildingBlock)
       {
-         _initialConditionId = initialCondition.Id;
+         _initialConditionPath = initialCondition.Path;
          _initialCondition = initialCondition;
          _oldIsPresent = initialCondition.IsPresent;
          _newIsPresent = isPresent;
@@ -40,7 +41,7 @@ namespace MoBi.Core.Commands
       public override void RestoreExecutionData(IMoBiContext context)
       {
          base.RestoreExecutionData(context);
-         _initialCondition = context.Get<InitialCondition>(_initialConditionId);
+         _initialCondition = _buildingBlock.ByPath(_initialConditionPath);
       }
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)

--- a/src/MoBi.Core/Commands/UpdateInitialConditionNegativeValuesAllowedCommand.cs
+++ b/src/MoBi.Core/Commands/UpdateInitialConditionNegativeValuesAllowedCommand.cs
@@ -2,21 +2,22 @@
 using MoBi.Core.Domain.Model;
 using OSPSuite.Assets;
 using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 
 namespace MoBi.Core.Commands
 {
-   public class UpdateInitialConditionNegativeValuesAllowedCommand : BuildingBlockChangeCommandBase<IBuildingBlock<InitialCondition>>
+   public class UpdateInitialConditionNegativeValuesAllowedCommand : BuildingBlockChangeCommandBase<ILookupBuildingBlock<InitialCondition>>
    {
-      private readonly string _initialConditionId;
+      private readonly ObjectPath _initialConditionPath;
       private InitialCondition _initialCondition;
       private readonly bool _oldNegativeValuesAllowed;
       private readonly bool _newNegativeValuesAllowed;
 
-      public UpdateInitialConditionNegativeValuesAllowedCommand(IBuildingBlock<InitialCondition> initialConditionsBuildingBlock, InitialCondition initialCondition, bool negativeValuesAllowed)
+      public UpdateInitialConditionNegativeValuesAllowedCommand(ILookupBuildingBlock<InitialCondition> initialConditionsBuildingBlock, InitialCondition initialCondition, bool negativeValuesAllowed)
          : base(initialConditionsBuildingBlock)
       {
-         _initialConditionId = initialCondition.Id;
+         _initialConditionPath = initialCondition.Path;
          _initialCondition = initialCondition;
          _oldNegativeValuesAllowed = initialCondition.NegativeValuesAllowed;
          _newNegativeValuesAllowed = negativeValuesAllowed;
@@ -41,7 +42,7 @@ namespace MoBi.Core.Commands
       public override void RestoreExecutionData(IMoBiContext context)
       {
          base.RestoreExecutionData(context);
-         _initialCondition = context.Get<InitialCondition>(_initialConditionId);
+         _initialCondition = _buildingBlock.ByPath(_initialConditionPath);
       }
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)

--- a/src/MoBi.Core/Commands/UpdateInitialConditionScaleDivisorCommand.cs
+++ b/src/MoBi.Core/Commands/UpdateInitialConditionScaleDivisorCommand.cs
@@ -2,24 +2,25 @@ using MoBi.Assets;
 using MoBi.Core.Domain.Model;
 using OSPSuite.Assets;
 using OSPSuite.Core.Commands.Core;
+using OSPSuite.Core.Domain;
 using OSPSuite.Core.Domain.Builder;
 
 namespace MoBi.Core.Commands
 {
-   public class UpdateInitialConditionScaleDivisorCommand : BuildingBlockChangeCommandBase<IBuildingBlock<InitialCondition>>
+   public class UpdateInitialConditionScaleDivisorCommand : BuildingBlockChangeCommandBase<ILookupBuildingBlock<InitialCondition>>
    {
       private readonly double _newScaleDivisor;
       private readonly double _oldScaleDivisor;
       private InitialCondition _initialCondition;
-      private readonly string _initialConditionId;
+      private readonly ObjectPath _initialConditionPath;
 
-      public UpdateInitialConditionScaleDivisorCommand(IBuildingBlock<InitialCondition> buildingBlock, InitialCondition initialCondition, double newScaleDivisor, double oldScaleDivisor)
+      public UpdateInitialConditionScaleDivisorCommand(ILookupBuildingBlock<InitialCondition> buildingBlock, InitialCondition initialCondition, double newScaleDivisor, double oldScaleDivisor)
          : base(buildingBlock)
       {
          _newScaleDivisor = newScaleDivisor;
          _oldScaleDivisor = oldScaleDivisor;
          _initialCondition = initialCondition;
-         _initialConditionId = initialCondition.Id;
+         _initialConditionPath = initialCondition.Path;
 
          Description = AppConstants.Commands.UpdateInitialConditionScaleDivisor(_initialCondition.Path.ToString(), oldScaleDivisor, newScaleDivisor);
          CommandType = AppConstants.Commands.EditCommand;
@@ -41,7 +42,7 @@ namespace MoBi.Core.Commands
       public override void RestoreExecutionData(IMoBiContext context)
       {
          base.RestoreExecutionData(context);
-         _initialCondition = context.Get<InitialCondition>(_initialConditionId);
+         _initialCondition = _buildingBlock.ByPath(_initialConditionPath);
       }
 
       protected override ICommand<IMoBiContext> GetInverseCommand(IMoBiContext context)

--- a/tests/MoBi.Tests/Core/Commands/UpdateInitialConditionScaleDivisorCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/UpdateInitialConditionScaleDivisorCommandSpecs.cs
@@ -14,8 +14,8 @@ namespace MoBi.Core.Commands
 
       protected override void Context()
       {
-         _startValueBuildingBlock = new InitialConditionsBuildingBlock();
-         _startValue = new InitialCondition { IsPresent = false };
+         _startValueBuildingBlock = new InitialConditionsBuildingBlock { Id = "buildingBlockId" };
+         _startValue = new InitialCondition { Name = "Drug", IsPresent = false };
          _startValueBuildingBlock.Add(_startValue);
          _context = A.Fake<IMoBiContext>();
 
@@ -42,7 +42,9 @@ namespace MoBi.Core.Commands
       protected override void Context()
       {
          base.Context();
-         A.CallTo(() => _context.Get<InitialCondition>(_startValue.Id)).Returns(_startValue);
+         // the initial condition is not registered in the object repository when it was added after its building block was registered
+         A.CallTo(() => _context.Get<InitialCondition>(_startValue.Id)).Returns((InitialCondition)null);
+         A.CallTo(() => _context.Get<ILookupBuildingBlock<InitialCondition>>(_startValueBuildingBlock.Id)).Returns(_startValueBuildingBlock);
       }
 
       protected override void Because()

--- a/tests/MoBi.Tests/Core/Commands/UpdateMoleculeStartValueScaleDivisorCommandSpecs.cs
+++ b/tests/MoBi.Tests/Core/Commands/UpdateMoleculeStartValueScaleDivisorCommandSpecs.cs
@@ -17,12 +17,15 @@ namespace MoBi.Core.Commands
       protected override void Context()
       {
          _oldScaleDivisor = 0;
-         _startValue = new InitialCondition { Id = "startValueId"};
+         _startValue = new InitialCondition { Id = "startValueId", Name = "Drug"};
          _buildingBlock = new InitialConditionsBuildingBlock { Id = "id"};
+         _buildingBlock.Add(_startValue);
          _context = A.Fake<IMoBiContext>();
          sut = new UpdateInitialConditionScaleDivisorCommand(_buildingBlock, _startValue, _newScaleDivisor, _oldScaleDivisor);
 
-         A.CallTo(() => _context.Get<InitialConditionsBuildingBlock>(_buildingBlock.Id)).Returns(_buildingBlock);
+         // the initial condition is not registered in the object repository when it was added after its building block was registered
+         A.CallTo(() => _context.Get<InitialCondition>(_startValue.Id)).Returns((InitialCondition)null);
+         A.CallTo(() => _context.Get<ILookupBuildingBlock<InitialCondition>>(_buildingBlock.Id)).Returns(_buildingBlock);
       }
    }
 
@@ -48,6 +51,12 @@ namespace MoBi.Core.Commands
 
    class When_reverting_command_to_modify_scale_factor : concern_for_UpdateInitialConditionScaleDivisorCommand
    {
+      protected override void Context()
+      {
+         _newScaleDivisor = 2;
+         base.Context();
+      }
+
       protected override void Because()
       {
          sut.ExecuteAndInvokeInverse(_context);


### PR DESCRIPTION
Fixes #2531

The three `UpdateInitialCondition*` commands re-resolved their entry from the global id repository. Entries added after their building block was registered — by Extend, by import, or as the inverse of a delete — are never registered there, so the lookup returned `null` and building the inverse command threw an NRE during rollback. This is why only entries added during the session reproduced it.

They now resolve the entry by path from its building block, as every other path-and-value-entity command already does. The type parameter widens to `ILookupBuildingBlock<InitialCondition>` to get `ByPath`; both implementing building blocks and all call sites already have that type.

The two revert specs now stub the id lookup to `null` — the production behaviour for an unregistered entry — and fail on the old code. The scale-divisor revert spec was vacuous (old and new value both `0`, empty building block) and was tightened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating initial-condition settings, including presence, negative-value handling, and scale divisors.
  * Undo and redo operations now continue to work when initial conditions are added after their building block is registered.

* **Tests**
  * Expanded coverage for restoring and reverting initial-condition changes in dynamically updated building blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->